### PR TITLE
Landice/update to mpas tools mesh creation

### DIFF
--- a/README_landice.md
+++ b/README_landice.md
@@ -6,12 +6,24 @@ To set up and run landice test cases from COMPASS, you will need a conda
 environment.  First, install Miniconda3 (if miniconda is not already
 installed), then create a new conda environment as follows:
 ``` bash
-conda create -n compass_py3.7 -c conda-forge -c xylar python=3.7 geometric_features mpas_tools jigsaw jigsawpy metis pyflann scikit-image basemap pyamg ffmpeg pyqt
+conda create -n compass_0.1.12 -c conda-forge -c e3sm python=3.8 compass=0.1.12
 ```
 Each time you want to work with COMPASS, you will need to run:
 ```
-conda activate compass_py3.7
+conda activate compass_0.1.12
 ```
+
+An appropriate conda environment is already available on Los Alamos National
+Laboratory's Institutional Computing (LANL IC) machines as well as Anvil, Compy
+and Cori.  In each case, you will run:
+```
+source <base_path>/load_latest_compass.sh
+```
+Values of `<base_path>` are:
+* grizzly and badger - `/usr/projects/climate/SHARED_CLIMATE/anaconda_envs`
+* anvil (blues) - `/lcrc/soft/climate/e3sm-unified/`
+* compy - `/share/apps/E3SM/conda_envs`
+* cori - `/global/cfs/cdirs/acme/software/anaconda_envs`
 
 ## Setting config options
 

--- a/landice/Thwaites_variability/1km_varres_jigsaw/standard_configuration/config_setup_experiments.xml
+++ b/landice/Thwaites_variability/1km_varres_jigsaw/standard_configuration/config_setup_experiments.xml
@@ -2,7 +2,6 @@
 <config case="1km_varres_jigsaw">
 
         <!-- Set up needed files and executables -->
-        <add_executable source="jigsaw_converter" dest="triangle_to_netcdf.py"/>
         <add_executable source="model" dest="landice_model"/>
         <add_link source_path="script_configuration_dir" source="albany_input.yaml" dest="."/>
         <!--        <add_link source_path="script_configuration_dir" source="ais14to4km.20160713.nc" dest="ais_input_data.nc"/>-->
@@ -30,7 +29,7 @@
 
 
                 <!-- convert from jigsaw to basic netcdf format-->
-                <step executable="./triangle_to_netcdf.py" >
+                <step executable="jigsaw_to_netcdf" >
                         <argument flag="-m">thwaites_jigsaw_mesh.msh</argument>
                         <argument flag="-o">thwaites_jigsaw_netcdf.nc</argument>
                 </step>

--- a/landice/antarctica/200to40km_AIS_jigsaw/standard_configuration/config_setup_experiments.xml
+++ b/landice/antarctica/200to40km_AIS_jigsaw/standard_configuration/config_setup_experiments.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0"?>
 <config case="200km_varres_jigsaw">
 
-        <!-- Set up needed files and executables -->
-        <add_executable source="jigsaw_converter" dest="triangle_jigsaw_to_netcdf.py"/>
         <!--        <add_link source_path="script_configuration_dir" source="albany_input.yaml" dest="."/> -->
         <add_link source_path="script_test_dir" source="antarctica_8km_2018_04_20.nc" dest="ais_input_data.nc"/>
         <add_link source_path="script_test_dir" source="ais_temp_pattyn_cism_format.5km.filled.nc" dest="ais_temperature_input_data.nc"/>
@@ -24,7 +22,7 @@
         <run_script name="setup_test.py">
 
                 <!-- convert from jigsaw to basic netcdf format-->
-                <step executable="./triangle_jigsaw_to_netcdf.py"  pre_message="\n\n### Converting from JIGSAW \n\n" post_message="\n\n### Converting from JIGSAW complete\n\n">
+                <step executable="jigsaw_to_netcdf"  pre_message="\n\n### Converting from JIGSAW \n\n" post_message="\n\n### Converting from JIGSAW complete\n\n">
                         <argument flag="-m">ais200to40km-MESH.msh</argument>
                         <argument flag="-o">ais200to40km_jigsaw_netcdf.nc</argument>
                 </step>

--- a/landice/antarctica/2km_ABUMIP_jigsaw/standard_configuration/config_setup_experiments.xml
+++ b/landice/antarctica/2km_ABUMIP_jigsaw/standard_configuration/config_setup_experiments.xml
@@ -2,7 +2,6 @@
 <config case="2km_varres_jigsaw">
 
         <!-- Set up needed files and executables -->
-        <add_executable source="jigsaw_converter" dest="triangle_jigsaw_to_netcdf.py"/>
         <!--        <add_link source_path="script_configuration_dir" source="albany_input.yaml" dest="."/> -->
         <add_link source_path="script_test_dir" source="Antarctica-1km.BISICLES.CISM-style.nc" dest="ais_input_data.nc"/>
         <add_link source_path="script_test_dir" source="ais2km-MESH.msh" dest="."/>
@@ -23,7 +22,7 @@
         <run_script name="setup_test.py">
 
                 <!-- convert from jigsaw to basic netcdf format-->
-                <step executable="./triangle_jigsaw_to_netcdf.py"  pre_message="\n\n### Converting from JIGSAW \n\n" post_message="\n\n### Converting from JIGSAW complete\n\n">
+                <step executable="jigsaw_to_netcdf"  pre_message="\n\n### Converting from JIGSAW \n\n" post_message="\n\n### Converting from JIGSAW complete\n\n">
                         <argument flag="-m">ais2km-MESH.msh</argument>
                         <argument flag="-o">ais2km_jigsaw_netcdf.nc</argument>
                 </step>


### PR DESCRIPTION
This merge updates calls to jigsaw_to_netcdf to use the version from `mpas_tools` rather than from the outdated `compass/ocean/jigsaw_to_MPAS` location.

This merge also updates `README_landice.md` to describe the latest version of the `compass` environment and associated metapackage (v0.1.12).

Replaces https://github.com/MPAS-Dev/MPAS-Model/pull/689