### PR TITLE
Fix SOMA and ZISO script links

### DIFF
--- a/ocean/soma/32km/default/config_analysis.xml
+++ b/ocean/soma/32km/default/config_analysis.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <config case="analysis">
-	<add_link source_path="mpas_model" source="testing_and_setup/compass/ocean/soma/32km/default/analysis/check_particle_sampling.py" dest="check_particle_sampling.py"/>
+	<add_link source_path="script_configuration_dir" source="analysis/check_particle_sampling.py" dest="check_particle_sampling.py"/>
 	<add_link source="../forward/output/output.0001-01-01_00.00.00.nc" dest="output.nc"/>
 	<add_link source="../forward/analysis_members/lagrPartTrack.0001-01-01_00.00.00.nc" dest="particleoutput.nc"/>
 

--- a/ocean/ziso/20km/default/config_forward.xml
+++ b/ocean/ziso/20km/default/config_forward.xml
@@ -5,7 +5,7 @@
 	<add_link source="../init_step2/mesh.nc" dest="mesh.nc"/>
 	<add_link source="../init_step2/graph.info" dest="graph.info"/>
 
-	<add_link source_path="mpas_model" source="testing_and_setup/compass/ocean/scripts/LIGHTparticles/make_particle_file.py" dest="make_particles.py"/>
+	<add_link source_path="script_core_dir" source="scripts/LIGHTparticles/make_particle_file.py" dest="make_particles.py"/>
 
 	<add_executable source="model" dest="ocean_model"/>
 


### PR DESCRIPTION
There are two testcases that use links to `testing_and_setup/compass` using `mpas_model` as the base.  This was never the intended way of finding contents of testcases, and no longer works now that COMPASS is in its own repo.  These two links have been fixed in this merge.

partially addresses #20 