### PR TITLE
Build compass metapackage in Azure

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -157,7 +157,7 @@ jobs:
       set -e
       eval "$(conda shell.bash hook)"
       conda create --yes --quiet --name compass --use-local python=$PYTHON_VERSION \
-          "compass=*=*$(mpi)*"
+          compass
     displayName: Create compass conda environment
 
   - bash: |
@@ -210,7 +210,7 @@ jobs:
       set -e
       eval "$(conda shell.bash hook)"
       conda create --yes --quiet --name compass --use-local python=$PYTHON_VERSION \
-          "compass=*=*$(mpi)*"
+          compass
     displayName: Create compass conda environment
 
   - bash: |

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -169,7 +169,6 @@ jobs:
       ./setup_testcase.py -h
       ./clean_testcase.py -h
       ./manage_regression_suite.py -h
-      cd ../..
     displayName: Test compass
 
 
@@ -223,6 +222,5 @@ jobs:
       ./setup_testcase.py -h
       ./clean_testcase.py -h
       ./manage_regression_suite.py -h
-      cd ../..
     displayName: Test compass
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -120,7 +120,7 @@ jobs:
     displayName: build and deploy docs
 
 - job:
-  displayName: compass-linux
+  displayName: linux
   pool:
     vmImage: 'ubuntu-16.04'
   strategy:
@@ -173,7 +173,7 @@ jobs:
 
 
 - job:
-  displayName: compass-osx
+  displayName: osx
   pool:
     vmImage: 'macOS-10.14'
   strategy:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -141,13 +141,20 @@ jobs:
       eval "$(conda shell.bash hook)"
       conda config --add channels conda-forge
       conda config --set channel_priority strict
-    displayName: Configure conda
+      conda create --yes --quiet --name build python=$PYTHON_VERSION conda conda-build
+    displayName: Create Anaconda build environment
+
+  - bash: |
+      eval "$(conda shell.bash hook)"
+      conda activate build
+      conda build recipe
+    displayName: Build COMPASS metapackage
 
   - bash: |
       set -e
       eval "$(conda shell.bash hook)"
-      conda create -y -n compass --override-channels -c conda-forge -c e3sm -c defaults \
-          python=$PYTHON_VERSION "compass=*=nompi*"
+      conda create --yes --quiet --name compass --use-local python=$PYTHON_VERSION \
+          "compass=*=nompi*"
     displayName: Create compass conda environment
 
   - bash: |
@@ -185,13 +192,20 @@ jobs:
       eval "$(conda shell.bash hook)"
       conda config --add channels conda-forge
       conda config --set channel_priority strict
-    displayName: Configure conda
+      conda create --yes --quiet --name build python=$PYTHON_VERSION conda conda-build
+    displayName: Create Anaconda build environment
+
+  - bash: |
+      eval "$(conda shell.bash hook)"
+      conda activate build
+      conda build recipe
+    displayName: Build COMPASS metapackage
 
   - bash: |
       set -e
       eval "$(conda shell.bash hook)"
-      conda create -y -n compass --override-channels -c conda-forge -c e3sm -c defaults \
-          python=$PYTHON_VERSION "compass=*=nompi*"
+      conda create --yes --quiet --name compass --use-local python=$PYTHON_VERSION \
+          "compass=*=nompi*"
     displayName: Create compass conda environment
 
   - bash: |

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -125,10 +125,15 @@ jobs:
     vmImage: 'ubuntu-16.04'
   strategy:
     matrix:
-      Python37:
-        python.version: '3.7'
-      Python38:
+      nompi:
         python.version: '3.8'
+        mpi: 'nompi'
+      openmpi:
+        python.version: '3.8'
+        mpi: 'openmpi'
+      mpich:
+        python.version: '3.8'
+        mpi: 'mpich'
 
   steps:
   - bash: echo "##vso[task.prependpath]$CONDA/bin"
@@ -145,14 +150,14 @@ jobs:
   - bash: |
       eval "$(conda shell.bash hook)"
       conda activate build
-      conda build recipe
+      conda build -m ci/mpi_$(mpi).yaml recipe
     displayName: Build COMPASS metapackage
 
   - bash: |
       set -e
       eval "$(conda shell.bash hook)"
       conda create --yes --quiet --name compass --use-local python=$PYTHON_VERSION \
-          "compass=*=nompi*"
+          "compass=*=*$(mpi)*"
     displayName: Create compass conda environment
 
   - bash: |
@@ -174,10 +179,15 @@ jobs:
     vmImage: 'macOS-10.14'
   strategy:
     matrix:
-      Python37:
-        python.version: '3.7'
-      Python38:
+      nompi:
         python.version: '3.8'
+        mpi: 'nompi'
+      openmpi:
+        python.version: '3.8'
+        mpi: 'openmpi'
+      mpich:
+        python.version: '3.8'
+        mpi: 'mpich'
 
   steps:
   - bash: echo "##vso[task.prependpath]$CONDA/bin"
@@ -194,14 +204,14 @@ jobs:
   - bash: |
       eval "$(conda shell.bash hook)"
       conda activate build
-      conda build recipe
+      conda build -m ci/mpi_$(mpi).yaml recipe
     displayName: Build COMPASS metapackage
 
   - bash: |
       set -e
       eval "$(conda shell.bash hook)"
       conda create --yes --quiet --name compass --use-local python=$PYTHON_VERSION \
-          "compass=*=nompi*"
+          "compass=*=*$(mpi)*"
     displayName: Create compass conda environment
 
   - bash: |

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -156,8 +156,9 @@ jobs:
   - bash: |
       set -e
       eval "$(conda shell.bash hook)"
-      conda create --yes --quiet --name compass --use-local python=$PYTHON_VERSION \
-          compass
+      conda activate build
+      conda create --yes --quiet --name compass -c ${CONDA_PREFIX}/conda-bld/ \
+          python=$PYTHON_VERSION compass
     displayName: Create compass conda environment
 
   - bash: |
@@ -209,8 +210,9 @@ jobs:
   - bash: |
       set -e
       eval "$(conda shell.bash hook)"
-      conda create --yes --quiet --name compass --use-local python=$PYTHON_VERSION \
-          compass
+      conda activate build
+      conda create --yes --quiet --name compass -c ${CONDA_PREFIX}/conda-bld/ \
+          python=$PYTHON_VERSION compass
     displayName: Create compass conda environment
 
   - bash: |

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -125,8 +125,6 @@ jobs:
     vmImage: 'ubuntu-16.04'
   strategy:
     matrix:
-      Python36:
-        python.version: '3.6'
       Python37:
         python.version: '3.7'
       Python38:
@@ -176,8 +174,6 @@ jobs:
     vmImage: 'macOS-10.14'
   strategy:
     matrix:
-      Python36:
-        python.version: '3.6'
       Python37:
         python.version: '3.7'
       Python38:

--- a/ci/mpi_mpich.yaml
+++ b/ci/mpi_mpich.yaml
@@ -1,0 +1,2 @@
+mpi:
+- mpich

--- a/ci/mpi_nompi.yaml
+++ b/ci/mpi_nompi.yaml
@@ -1,0 +1,2 @@
+mpi:
+- nompi

--- a/ci/mpi_openmpi.yaml
+++ b/ci/mpi_openmpi.yaml
@@ -1,0 +1,2 @@
+mpi:
+- openmpi


### PR DESCRIPTION
Before, it was being installed from the `e3sm` channel, which is not as helpful now that the recipe is local.