### PR TITLE
update metapackage to 0.2.0; add git

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "compass" %}
-{% set version = "0.1.12" %}
+{% set version = "0.2.0" %}
 {% set build = 0 %}
 
 {% if mpi == "nompi" %}
@@ -49,6 +49,7 @@ requirements:
     - lxml
     - matplotlib
     - cmocean
+    - git
 
 test:
   imports:


### PR DESCRIPTION
Git is needed because the system git on some machines (at least Anvil) does not support the required `git describe` call.