### PR TITLE
Fix missing --ice_shelf_cavities flag

### DIFF
--- a/ocean/global_ocean/EC60to30wISC/files_for_e3sm/config_files_for_e3sm.xml
+++ b/ocean/global_ocean/EC60to30wISC/files_for_e3sm/config_files_for_e3sm.xml
@@ -11,6 +11,7 @@
 	<run_script name="run.py">
 		<step executable="./create_files_for_e3sm.py">
 			<argument flag="--config">config_files_for_e3sm.ini</argument>
+			<argument flag="--ice_shelf_cavities"/>
 		</step>
 	</run_script>
 </config>

--- a/ocean/global_ocean/SOwISC12to60/files_for_e3sm/config_files_for_e3sm.xml
+++ b/ocean/global_ocean/SOwISC12to60/files_for_e3sm/config_files_for_e3sm.xml
@@ -11,6 +11,7 @@
 	<run_script name="run.py">
 		<step executable="./create_files_for_e3sm.py">
 			<argument flag="--config">config_files_for_e3sm.ini</argument>
+			<argument flag="--ice_shelf_cavities"/>
 		</step>
 	</run_script>
 </config>


### PR DESCRIPTION
The ECwISC and SOwISC meshes are missing this flag as part of the files generated for E3SM