### PR TITLE
Fix a bug in the marsh_flooding/idealized_transect case

### DIFF
--- a/ocean/drying_slope/marsh_flooding/idealized_transect/config_analysis.xml
+++ b/ocean/drying_slope/marsh_flooding/idealized_transect/config_analysis.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <config case="analysis">
-	<add_link path_base="script_test_dir" source="comparison.py" dest="comparison.py"/>
+	<add_link source_path="script_test_dir" source="comparison.py" dest="comparison.py"/>
 	<add_link source="../forward1/output.nc" dest="NoVegetation.nc"/>
 	<add_link source="../forward2/output.nc" dest="ConstantVegManning.nc"/>
 	<add_link source="../forward3/output.nc" dest="VegManningEquation.nc"/>

--- a/ocean/drying_slope/marsh_flooding/idealized_transect/config_forward1.xml
+++ b/ocean/drying_slope/marsh_flooding/idealized_transect/config_forward1.xml
@@ -15,8 +15,8 @@
 
 	<run_script name="run.py">
 		<step executable="gpmetis">
-			<argument flag="graph.info">36</argument>
+			<argument flag="graph.info">2</argument>
 		</step>
-		<model_run procs="36" threads="1" namelist="namelist.ocean" streams="streams.ocean"/>
+		<model_run procs="2" threads="1" namelist="namelist.ocean" streams="streams.ocean"/>
 	</run_script>
 </config>

--- a/ocean/drying_slope/marsh_flooding/idealized_transect/config_forward2.xml
+++ b/ocean/drying_slope/marsh_flooding/idealized_transect/config_forward2.xml
@@ -15,8 +15,8 @@
 
 	<run_script name="run.py">
 		<step executable="gpmetis">
-			<argument flag="graph.info">36</argument>
+			<argument flag="graph.info">2</argument>
 		</step>
-		<model_run procs="36" threads="1" namelist="namelist.ocean" streams="streams.ocean"/>
+		<model_run procs="2" threads="1" namelist="namelist.ocean" streams="streams.ocean"/>
 	</run_script>
 </config>

--- a/ocean/drying_slope/marsh_flooding/idealized_transect/config_forward3.xml
+++ b/ocean/drying_slope/marsh_flooding/idealized_transect/config_forward3.xml
@@ -18,8 +18,8 @@
 
 	<run_script name="run.py">
 		<step executable="gpmetis">
-			<argument flag="graph.info">36</argument>
+			<argument flag="graph.info">2</argument>
 		</step>
-		<model_run procs="36" threads="1" namelist="namelist.ocean" streams="streams.ocean"/>
+		<model_run procs="2" threads="1" namelist="namelist.ocean" streams="streams.ocean"/>
 	</run_script>
 </config>


### PR DESCRIPTION
This bug appeared in linking the python script **`comparison.py`** to the **`script_test_dir`** directory. It intended to provide the path of the python script by using **`path_base`**, which generated to a invalid hyperlink of the script and failed to run the analysis. Changing it to **`source_path`** fixed this issue.