### PR TITLE
Add support for the legacy branch to CI

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,10 +9,12 @@ to setup and configure a test case.
 
 ## Documentation
 
-The latest COMPASS documentation can be found here:
+The latest compass documentation can be found here:
 
 [http://mpas-dev.github.io/compass/stable/](http://mpas-dev.github.io/compass/stable/)
 
-The documentation is currently limited to the scripts for listing and setting
-up test cases, with extremely limited documentation of the testcases themselves.
-We plan to build out the documentation in the coming months.
+Documentation on the [legacy verion of COMPASS](https://github.com/MPAS-Dev/compass/tree/legacy)
+can be found here:
+
+[http://mpas-dev.github.io/compass/legacy/](http://mpas-dev.github.io/compass/legacy/)
+

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -2,6 +2,7 @@ trigger:
   branches:
     include:
     - master
+    - legacy
   tags:
     include:
     - '*'
@@ -9,6 +10,7 @@ pr:
   branches:
     include:
     - master
+    - legacy
 
 jobs:
 - job:
@@ -69,6 +71,9 @@ jobs:
         echo "This build is for branch $branch"
         if [[ ${branch} == "master" ]]; then
           export DOCS_VERSION="stable"
+          run=True
+        elif [[ ${branch} == "legacy" ]]; then
+          export DOCS_VERSION="legacy"
           run=True
         else
           echo "We don't build docs for $branch"


### PR DESCRIPTION
This merge also adds a link to the legacy documentation to the README. This PR is identical to #47 but for `master` instead of `legacy`.