### PR TITLE
Update legacy docs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -113,7 +113,7 @@ if not on_rtd:  # only import and set the theme if we're building docs locally
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['_static']
+# html_static_path = ['_static']
 
 
 # -- Options for HTMLHelp output ------------------------------------------

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,11 +1,16 @@
-COMPASS
-=======
+legacy COMPASS
+==============
 
 Configuration Of Model for Prediction Across Scales Setups (COMPASS) is an
 automated system to set up test cases that match the MPAS-Model repository. All
 namelists and streams files begin with the default generated from the
 Registry.xml file, and only the changes relevant to the particular test case are
 altered in those files.
+
+The following documentation is for the "legacy" version of COMPASS that can be
+found in the ``legacy`` branch on the COMPASS GitHub repo:
+
+https://github.com/MPAS-Dev/compass/tree/legacy
 
 .. toctree::
    :caption: User's guide
@@ -42,3 +47,9 @@ altered in those files.
    developers_guide/regression_suite
    developers_guide/run_config
    developers_guide/building_docs
+
+.. toctree::
+   :caption: Versions
+   :maxdepth: 2
+
+   versions

--- a/docs/ocean/test_cases/isomip_plus.rst
+++ b/docs/ocean/test_cases/isomip_plus.rst
@@ -125,16 +125,11 @@ has not yet been implemented in COMPASS.
 Setting up a run in COMPASS
 ---------------------------
 
-In a local check-out of the ``MPAS-Dev/MPAS-Model/ocean/develop`` branch:
-
-.. code-block:: bash
-
-   cd testing_and_setup/compass/
-
+Start with a local check-out of the ``MPAS-Dev/compass/legacy`` branch.
 To build test cases, you need to tell COMPASS where to find a few thing.
 Open a file ``config.ocean`` and put the following, where we have used the
 example path ``usr/projects/climate/username/mpas/model/ocean/develop`` as the
-location where MPAS-Ocena has been checked out and compiled:
+location where MPAS-Ocean has been checked out and compiled:
 
 .. code-block:: ini
 

--- a/docs/ocean/test_cases/isomip_plus_at_lanl.rst
+++ b/docs/ocean/test_cases/isomip_plus_at_lanl.rst
@@ -182,7 +182,7 @@ In this file, put:
    module use /usr/projects/climate/SHARED_CLIMATE/modulefiles/all/
    module load git
    if [ -f "load_compass_env.sh" ]; then
-       # this figures out from the testing_and_setup/compass directory or from
+       # this figures out from the local checkout of the compass repo or from
        # within a test case which version of the compass environment to load
        source load_compass_env.sh
    else
@@ -266,11 +266,16 @@ Take a coffee break, this will take some time.
 
 Okay you're back and refreshed?  Let's set up a test case.
 
+You also need to clone the compass repo and check out the ``legacy`` branch:
+
 .. code-block:: bash
 
-   cd testing_and_setup/compass/
+    git clone git@github.com:MPAS-Dev/compass.git
+    cd compass
+    git checkout legacy
+    git submodule update --init --recursive
 
-COMPASS (COnfiguration of Model for Prediction Across Scales Setups -- yes, a litle tortured) is a set of python
+COMPASS (COnfiguration of Model for Prediction Across Scales Setups -- yes, a little tortured) is a set of python
 scripts we use to set up and run our test cases.  To build test cases, you need to tell COMPASS where to find a few
 thing on Grizzly.  Open a file ``config.ocean`` and put the following in it:
 

--- a/docs/users_guide/overview.rst
+++ b/docs/users_guide/overview.rst
@@ -13,6 +13,7 @@ To begin, obtain the master branch of the
 
     git clone git@github.com:MPAS-Dev/compass.git
     cd compass
+    git checkout legacy
     git submodule update --init --recursive
 
 The MPAS repository is a submodule of COMPASS repository.  For example, to
@@ -157,7 +158,7 @@ testing. For the ocean core, they are here:
 
 .. code-block:: bash
 
-    ls testing_and_setup/compass/ocean/regression_suites/
+    ls ocean/regression_suites/
        land_ice_fluxes.xml  light.xml  nightly.xml  rpe_tests.xml
 
 You can set up a regression as follows:
@@ -196,8 +197,9 @@ branches at once. Begin where you keep your repositories:
 
     mkdir compass
     cd compass
-    git clone git@github.com:MPAS-Dev/compass.git master
+    git clone git@github.com:MPAS-Dev/compass.git legacy
     cd master
+    git checkout legacy
 
 The ``MPAS-Dev/compass`` repo is now ``origin``. You can add more remotes. For
 example
@@ -240,7 +242,6 @@ executable:
    compass.
 
    .. code-block:: bash
-
 
      git submodule update --init --recursive
      cd MPAS-Model/ocean/develop/

--- a/docs/versions.rst
+++ b/docs/versions.rst
@@ -1,0 +1,14 @@
+Code and Documentation Versions
+===============================
+
+================ ===============
+Documentation    On GitHub
+================ ===============
+`stable docs`_   `master`_
+`legacy docs`_   `legacy`_
+================ ===============
+
+.. _`stable docs`: ../stable/index.html
+.. _`legacy docs`: ../legacy/index.html
+.. _`master`: https://github.com/MPAS-Dev/compass/tree/master
+.. _`legacy`: https://github.com/MPAS-Dev/compass/tree/legacy


### PR DESCRIPTION
This merge:
* Adds a version page to the legacy documentation to point to the stable version
* Has the user check out the `legacy` branch when cloning the repo
* Fixes some old references to `testing_and_setup/compass` in the MPAS-Model repo
* Comments out usage of the `_static` directory in the docs, since this produces a warning when the docs are built.