### PR TITLE
Remove config_iterative_init_variable from all tests

### DIFF
--- a/ocean/global_ocean/EC60to30wISC/spin_up_EN4_1900/config_initial_state.xml
+++ b/ocean/global_ocean/EC60to30wISC/spin_up_EN4_1900/config_initial_state.xml
@@ -40,7 +40,6 @@
 		<template file="template_initial_state.xml" path_base="script_configuration_dir"/>
 		<template file="template_critical_passages.xml" path_base="script_core_dir" path="global_ocean"/>
 		<template file="template_init_with_land_ice.xml" path_base="script_configuration_dir"/>
-		<option name="config_iterative_init_variable">'landIcePressure_from_top_density'</option>
 		<option name="config_global_ocean_depth_file">'layer_depth.nc'</option>
 		<option name="config_global_ocean_minimum_depth">10</option>
 		<option name="config_global_ocean_deepen_critical_passages">.false.</option>

--- a/ocean/global_ocean/EC60to30wISC/spin_up_EN4_1900/config_initial_state_64_levels.xml
+++ b/ocean/global_ocean/EC60to30wISC/spin_up_EN4_1900/config_initial_state_64_levels.xml
@@ -39,7 +39,6 @@
 		<template file="template_critical_passages.xml" path_base="script_core_dir" path="global_ocean"/>
 		<template file="template_init_with_land_ice.xml" path_base="script_configuration_dir"/>
 		<template file="template_initial_state.xml" path_base="script_resolution_dir"/>
-		<option name="config_iterative_init_variable">'landIcePressure_from_top_density'</option>
 		<option name="config_global_ocean_depth_file">'vertical_grid.nc'</option>
 		<option name="config_global_ocean_depth_dimname">'nVertLevels'</option>
 		<option name="config_global_ocean_depth_varname">'refMidDepth'</option>

--- a/ocean/global_ocean/EC60to30wISC/spin_up_phc/config_initial_state.xml
+++ b/ocean/global_ocean/EC60to30wISC/spin_up_phc/config_initial_state.xml
@@ -37,7 +37,6 @@
 		<template file="template_initial_state.xml" path_base="script_configuration_dir"/>
 		<template file="template_critical_passages.xml" path_base="script_core_dir" path="global_ocean"/>
 		<template file="template_init_with_land_ice.xml" path_base="script_configuration_dir"/>
-		<option name="config_iterative_init_variable">'landIcePressure_from_top_density'</option>
 		<option name="config_global_ocean_depth_file">'layer_depth.nc'</option>
 		<option name="config_global_ocean_minimum_depth">10</option>
 		<option name="config_global_ocean_deepen_critical_passages">.false.</option>

--- a/ocean/global_ocean/EC60to30wISC/spin_up_phc/config_initial_state_64_levels.xml
+++ b/ocean/global_ocean/EC60to30wISC/spin_up_phc/config_initial_state_64_levels.xml
@@ -39,7 +39,6 @@
 		<template file="template_critical_passages.xml" path_base="script_core_dir" path="global_ocean"/>
 		<template file="template_init_with_land_ice.xml" path_base="script_configuration_dir"/>
 		<template file="template_initial_state.xml" path_base="script_resolution_dir"/>
-		<option name="config_iterative_init_variable">'landIcePressure_from_top_density'</option>
 		<option name="config_global_ocean_depth_file">'vertical_grid.nc'</option>
 		<option name="config_global_ocean_depth_dimname">'nVertLevels'</option>
 		<option name="config_global_ocean_depth_varname">'refMidDepth'</option>

--- a/ocean/global_ocean/SOwISC12to60/init/config_initial_state.xml
+++ b/ocean/global_ocean/SOwISC12to60/init/config_initial_state.xml
@@ -41,7 +41,6 @@
 		<option name="config_global_ocean_tracer_depth_conversion_factor">0.01</option>
 		<option name="config_global_ocean_minimum_depth">10</option>
 		<option name="config_global_ocean_deepen_critical_passages">.false.</option>
-		<option name="config_iterative_init_variable">'landIcePressure_from_top_density'</option>
 	</namelist>
 
 	<streams name="streams.ocean" keep="immutable" mode="init">

--- a/ocean/global_ocean/config_files_ISC/config_initial_state.xml
+++ b/ocean/global_ocean/config_files_ISC/config_initial_state.xml
@@ -39,7 +39,6 @@
 		<template file="template_critical_passages.xml" path_base="script_core_dir" path="global_ocean"/>
 		<template file="template_init_with_land_ice.xml" path_base="script_configuration_dir"/>
 		<template file="template_initial_state.xml" path_base="script_resolution_dir"/>
-		<option name="config_iterative_init_variable">'landIcePressure_from_top_density'</option>
 		<option name="config_global_ocean_depth_file">'vertical_grid.nc'</option>
 		<option name="config_global_ocean_depth_dimname">'nVertLevels'</option>
 		<option name="config_global_ocean_depth_varname">'refMidDepth'</option>

--- a/ocean/global_ocean/template_initial_state.xml
+++ b/ocean/global_ocean/template_initial_state.xml
@@ -115,7 +115,7 @@
 				<member name="landIcePressure" type="var"/>
 				<member name="landIceDraft" type="var"/>
 				<member name="ssh" type="var"/>
-				<member name="modifySSHMask" type="var"/>
+				<member name="modifyLandIcePressureMask" type="var"/>
 				<member name="rx1Cell" type="var"/>
 				<member name="rx1Edge" type="var"/>
 				<member name="rx1MaxCell" type="var"/>

--- a/ocean/isomip/10km/expt1.01/config_init1.xml
+++ b/ocean/isomip/10km/expt1.01/config_init1.xml
@@ -12,7 +12,6 @@
 	<namelist name="namelist.ocean" mode="init">
 		<template file="template_init.xml" path_base="script_configuration_dir"/>
 		<option name="config_write_cull_cell_mask">.true.</option>
-		<option name="config_iterative_init_variable">'landIcePressure_from_top_density'</option>
 	</namelist>
 
 	<streams name="streams.ocean" keep="immutable" mode="init">

--- a/ocean/isomip/10km/expt1.01/config_init2.xml
+++ b/ocean/isomip/10km/expt1.01/config_init2.xml
@@ -8,7 +8,6 @@
 	<namelist name="namelist.ocean" mode="init">
 		<template file="template_init.xml" path_base="script_configuration_dir"/>
 		<option name="config_write_cull_cell_mask">.false.</option>
-		<option name="config_iterative_init_variable">'landIcePressure_from_top_density'</option>
 	</namelist>
 
 	<streams name="streams.ocean" keep="immutable" mode="init">

--- a/ocean/isomip/10km/expt2.01/config_init1.xml
+++ b/ocean/isomip/10km/expt2.01/config_init1.xml
@@ -12,7 +12,6 @@
 	<namelist name="namelist.ocean" mode="init">
 		<template file="template_init.xml" path_base="script_configuration_dir"/>
 		<option name="config_write_cull_cell_mask">.true.</option>
-		<option name="config_iterative_init_variable">'landIcePressure_from_top_density'</option>
 		<option name="config_use_activeTracers_surface_restoring">.true.</option>
 		<option name="config_isomip_y2">390e3</option>
 		<option name="config_isomip_y3">410e3</option>

--- a/ocean/isomip/10km/expt2.01/config_init2.xml
+++ b/ocean/isomip/10km/expt2.01/config_init2.xml
@@ -8,7 +8,6 @@
 	<namelist name="namelist.ocean" mode="init">
 		<template file="template_init.xml" path_base="script_configuration_dir"/>
 		<option name="config_write_cull_cell_mask">.false.</option>
-		<option name="config_iterative_init_variable">'landIcePressure_from_top_density'</option>
 		<option name="config_use_activeTracers_surface_restoring">.true.</option>
 		<option name="config_isomip_y2">390e3</option>
 		<option name="config_isomip_y3">410e3</option>

--- a/ocean/isomip/template_init.xml
+++ b/ocean/isomip/template_init.xml
@@ -43,7 +43,7 @@
 				<member name="landIceMask" type="var"/>
 				<member name="landIcePressure" type="var"/>
 				<member name="landIceDraft" type="var"/>
-				<member name="modifySSHMask" type="var"/>
+				<member name="modifyLandIcePressureMask" type="var"/>
 				<member name="rx1InitSmoothingMask" type="var"/>
 				<member name="verticalStretch" type="var"/>
 			</add_contents>

--- a/ocean/isomip_plus/2km/time_varying_Ocean0/config_adjust_ssh.xml
+++ b/ocean/isomip_plus/2km/time_varying_Ocean0/config_adjust_ssh.xml
@@ -15,7 +15,6 @@
 		<template file="template_adjust_ssh.xml" path_base="script_configuration_dir"/>
 		<option name="config_pio_num_iotasks">1</option>
 		<option name="config_pio_stride">4</option>
-		<option name="config_iterative_init_variable">'ssh'</option>
 		<option name="config_pressure_gradient_type">'Jacobian_from_TS'</option>
 		<option name="config_eos_type">'jm'</option>
 	</namelist>

--- a/ocean/isomip_plus/template_init.xml
+++ b/ocean/isomip_plus/template_init.xml
@@ -11,7 +11,6 @@
 		<option name="config_eos_linear_Tref">-1.0</option>
 		<option name="config_eos_linear_Sref">34.2</option>
 		<option name="config_eos_linear_densityref">1027.51</option>
-		<option name="config_iterative_init_variable">'landIcePressure_from_top_density'</option>
 		<option name="config_use_rx1_constraint">.true.</option>
 		<option name="config_rx1_max">5.0</option>
 		<option name="config_isomip_plus_min_column_thickness">10.0</option>

--- a/ocean/isomip_plus/template_init.xml
+++ b/ocean/isomip_plus/template_init.xml
@@ -55,7 +55,7 @@
 				<member name="landIceMask" type="var"/>
 				<member name="landIcePressure" type="var"/>
 				<member name="landIceDraft" type="var"/>
-				<member name="modifySSHMask" type="var"/>
+				<member name="modifyLandIcePressureMask" type="var"/>
 				<member name="rx1InitSmoothingMask" type="var"/>
 				<member name="verticalStretch" type="var"/>
 			</add_contents>

--- a/ocean/iterative_ssh_landIcePressure_scripts/iterate_init.py
+++ b/ocean/iterative_ssh_landIcePressure_scripts/iterate_init.py
@@ -97,7 +97,8 @@ for iterIndex in range(args.first_iteration, args.iteration_count):
     nVertLevels = len(initFile.dimensions['nVertLevels'])
     initSSH = initFile.variables['ssh'][0, :]
     bottomDepth = initFile.variables['bottomDepth'][:]
-    modifySSHMask = initFile.variables['modifySSHMask'][0, :]
+    modifyLandIcePressureMask = \
+        initFile.variables['modifyLandIcePressureMask'][0, :]
     landIcePressure = initFile.variables['landIcePressure'][0, :]
     lonCell = initFile.variables['lonCell'][:]
     latCell = initFile.variables['latCell'][:]
@@ -109,7 +110,7 @@ for iterIndex in range(args.first_iteration, args.iteration_count):
     topDensity = inSSHFile.variables['density'][nTime - 1, :, 0]
     inSSHFile.close()
 
-    mask = numpy.logical_and(maxLevelCell > 0, modifySSHMask == 1)
+    mask = numpy.logical_and(maxLevelCell > 0, modifyLandIcePressureMask == 1)
 
     deltaSSH = mask * (finalSSH - initSSH)
 

--- a/ocean/sub_ice_shelf_2D/5km/Haney_number_iterative_init/config_init1.xml
+++ b/ocean/sub_ice_shelf_2D/5km/Haney_number_iterative_init/config_init1.xml
@@ -12,7 +12,6 @@
 	<namelist name="namelist.ocean" mode="init">
 		<template file="template_init.xml" path_base="script_resolution_dir"/>
 		<option name="config_write_cull_cell_mask">.true.</option>
-		<option name="config_iterative_init_variable">'landIcePressure_from_top_density'</option>
 		<option name="config_use_rx1_constraint">.true.</option>
 		<option name="config_rx1_max">5.0</option>
 	</namelist>

--- a/ocean/sub_ice_shelf_2D/5km/Haney_number_iterative_init/config_init2.xml
+++ b/ocean/sub_ice_shelf_2D/5km/Haney_number_iterative_init/config_init2.xml
@@ -8,7 +8,6 @@
 	<namelist name="namelist.ocean" mode="init">
 		<template file="template_init.xml" path_base="script_resolution_dir"/>
 		<option name="config_write_cull_cell_mask">.false.</option>
-		<option name="config_iterative_init_variable">'landIcePressure_from_top_density'</option>
 		<option name="config_use_rx1_constraint">.true.</option>
 		<option name="config_rx1_max">5.0</option>
 	</namelist>

--- a/ocean/sub_ice_shelf_2D/5km/iterative_init/config_init1.xml
+++ b/ocean/sub_ice_shelf_2D/5km/iterative_init/config_init1.xml
@@ -12,7 +12,6 @@
 	<namelist name="namelist.ocean" mode="init">
 		<template file="template_init.xml" path_base="script_resolution_dir"/>
 		<option name="config_write_cull_cell_mask">.true.</option>
-		<option name="config_iterative_init_variable">'landIcePressure_from_top_density'</option>
 	</namelist>
 
 	<streams name="streams.ocean" keep="immutable" mode="init">

--- a/ocean/sub_ice_shelf_2D/5km/iterative_init/config_init2.xml
+++ b/ocean/sub_ice_shelf_2D/5km/iterative_init/config_init2.xml
@@ -8,7 +8,6 @@
 	<namelist name="namelist.ocean" mode="init">
 		<template file="template_init.xml" path_base="script_resolution_dir"/>
 		<option name="config_write_cull_cell_mask">.false.</option>
-		<option name="config_iterative_init_variable">'landIcePressure_from_top_density'</option>
 	</namelist>
 
 	<streams name="streams.ocean" keep="immutable" mode="init">

--- a/ocean/sub_ice_shelf_2D/5km/restart_test/config_init1.xml
+++ b/ocean/sub_ice_shelf_2D/5km/restart_test/config_init1.xml
@@ -12,6 +12,8 @@
 	<namelist name="namelist.ocean" mode="init">
 		<template file="template_init.xml" path_base="script_resolution_dir"/>
 		<option name="config_write_cull_cell_mask">.true.</option>
+		<option name="config_use_rx1_constraint">.true.</option>
+		<option name="config_rx1_max">5.0</option>
 	</namelist>
 
 	<streams name="streams.ocean" keep="immutable" mode="init">

--- a/ocean/sub_ice_shelf_2D/5km/restart_test/config_init2.xml
+++ b/ocean/sub_ice_shelf_2D/5km/restart_test/config_init2.xml
@@ -9,7 +9,6 @@
 		<template file="template_init.xml" path_base="script_resolution_dir"/>
                 <option name="config_sub_ice_shelf_2D_temperature">-3.0</option>
 		<option name="config_write_cull_cell_mask">.false.</option>
-		<option name="config_iterative_init_variable">'landIcePressure_from_top_density'</option>
 		<option name="config_use_rx1_constraint">.true.</option>
 		<option name="config_rx1_max">5.0</option>
 	</namelist>

--- a/ocean/sub_ice_shelf_2D/5km/template_init.xml
+++ b/ocean/sub_ice_shelf_2D/5km/template_init.xml
@@ -44,6 +44,8 @@
 				<member name="landIceDraft" type="var"/>
 				<member name="modifyLandIcePressureMask" type="var"/>
 				<member name="rx1InitSmoothingMask" type="var"/>
+				<member name="density" type="var"/>
+				<member name="zMid" type="var"/>
 			</add_contents>
 		</stream>
 	</streams>

--- a/ocean/sub_ice_shelf_2D/5km/template_init.xml
+++ b/ocean/sub_ice_shelf_2D/5km/template_init.xml
@@ -42,7 +42,7 @@
 				<member name="landIceMask" type="var"/>
 				<member name="landIcePressure" type="var"/>
 				<member name="landIceDraft" type="var"/>
-				<member name="modifySSHMask" type="var"/>
+				<member name="modifyLandIcePressureMask" type="var"/>
 				<member name="rx1InitSmoothingMask" type="var"/>
 			</add_contents>
 		</stream>

--- a/ocean/sub_ice_shelf_2D/5km/with_frazil/config_init1.xml
+++ b/ocean/sub_ice_shelf_2D/5km/with_frazil/config_init1.xml
@@ -12,6 +12,8 @@
 	<namelist name="namelist.ocean" mode="init">
 		<template file="template_init.xml" path_base="script_resolution_dir"/>
 		<option name="config_write_cull_cell_mask">.true.</option>
+		<option name="config_use_rx1_constraint">.true.</option>
+		<option name="config_rx1_max">5.0</option>
 	</namelist>
 
 	<streams name="streams.ocean" keep="immutable" mode="init">

--- a/ocean/sub_ice_shelf_2D/5km/with_frazil/config_init2.xml
+++ b/ocean/sub_ice_shelf_2D/5km/with_frazil/config_init2.xml
@@ -10,7 +10,6 @@
 		<option name="config_sub_ice_shelf_2D_vert_levels">100</option>
 		<option name="config_sub_ice_shelf_2D_temperature">-3.0</option>
 		<option name="config_write_cull_cell_mask">.false.</option>
-		<option name="config_iterative_init_variable">'landIcePressure_from_top_density'</option>
 		<option name="config_use_rx1_constraint">.true.</option>
 		<option name="config_rx1_max">5.0</option>
 	</namelist>

--- a/ocean/sub_ice_shelf_2D/check_bit_for_bit.py
+++ b/ocean/sub_ice_shelf_2D/check_bit_for_bit.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python
+
+import xarray
+import sys
+import numpy
+
+
+filename1 = sys.argv[1]
+filename2 = sys.argv[2]
+
+ds1 = xarray.open_dataset(filename1)
+ds2 = xarray.open_dataset(filename2)
+
+var_list = list()
+for var in ds1:
+    if var in ds2:
+        var_list.append(var)
+    else:
+        print('Warning: {} found in first but not second file'.format(var))
+
+for var in ds2:
+    if var not in ds1:
+        print('Warning: {} found in second but not first file'.format(var))
+
+all_pass = True
+for var in var_list:
+    var1 = ds1[var]
+    var2 = ds2[var]
+
+    if not numpy.issubdtype(var1.dtype, numpy.number) or \
+            not numpy.issubdtype(var2.dtype, numpy.number):
+        # not a numerical field
+        continue
+
+    if var1.sizes != var2.sizes:
+        print('ERROR: {} not the same size: {} {}'.format(var, var1.sizes,
+                                                          var2.sizes))
+        all_pass = False
+        continue
+
+    diff = numpy.abs(var1 - var2)
+    if numpy.any(diff > 0.):
+        print('ERROR: {} not bit-for-bit:\n    {}'.format(var,
+                                                          diff.max().values))
+        all_pass = False
+
+if all_pass:
+    print('PASS')
+else:
+    print('FAIL')
+    sys.exit(1)

--- a/ocean/sub_ice_shelf_2D/plot_sub_ice_shelf_2D.py
+++ b/ocean/sub_ice_shelf_2D/plot_sub_ice_shelf_2D.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python
+
+import xarray
+import sys
+import numpy
+import matplotlib.pyplot as plt
+
+
+filename = sys.argv[1]
+
+ds = xarray.open_dataset(filename)
+
+if 'Time' in ds.dims:
+    ds = ds.isel(Time=0)
+
+ds = ds.groupby('yCell').mean(dim='nCells')
+
+nCells = ds.sizes['yCell']
+nVertLevels = ds.sizes['nVertLevels']
+zInterface = numpy.zeros((nCells, nVertLevels+1))
+zInterface[:, 0] = ds.ssh.values
+for zIndex in range(nVertLevels):
+    zInterface[:, zIndex+1] = zInterface[:, zIndex] - \
+                              ds.layerThickness.isel(nVertLevels=zIndex).values
+
+plt.figure()
+plt.plot(ds.yCell, zInterface, 'k')
+plt.plot(ds.yCell, ds.zMid, 'b')
+plt.show()


### PR DESCRIPTION
This merge removes references to the `config_iterative_init_variable` namelist option, which was removed in https://github.com/MPAS-Dev/MPAS-Model/pull/812.

It also renames the field `modifySSHMask` to `modifyLandIcePressureMask`, to be consistent with changes in that PR.