### PR TITLE
Change three init mode namelist options

### DIFF
--- a/ocean/drying_slope/init_idealized_transect.xml
+++ b/ocean/drying_slope/init_idealized_transect.xml
@@ -14,7 +14,7 @@
 		<option name="config_tidal_boundary_left_value">0.0</option>
 		<option name="config_tidal_boundary_right_value">8.0e3</option>
 		<option name="config_tidal_forcing_monochromatic_baseline">3.0</option>
-		<option name="config_alter_ICs_for_pbcs">.true.</option>
+		<option name="config_alter_ICs_for_pcs">.true.</option>
 		<option name="config_thickness_flux_type">'centered'</option>
 	</namelist>
 </template>

--- a/ocean/global_ocean/template_init_with_land_ice.xml
+++ b/ocean/global_ocean/template_init_with_land_ice.xml
@@ -3,7 +3,7 @@
 	<namelist>
 		<option name="config_use_debugTracers">.true.</option>
 		<option name="config_land_ice_flux_mode">'standalone'</option>
-		<option name="config_use_rx1_constraint">.true.</option>
+		<option name="config_init_vertical_grid_type">'haney-number'</option>
 		<option name="config_rx1_max">5.0</option>
 		<option name="config_global_ocean_topography_file">'topography.nc'</option>
 		<option name="config_global_ocean_topography_nlat_dimname">'lat'</option>

--- a/ocean/global_ocean/template_initial_state.xml
+++ b/ocean/global_ocean/template_initial_state.xml
@@ -10,8 +10,8 @@
 		<option name="config_expand_sphere">.true.</option>
 		<option name="config_realistic_coriolis_parameter">.true.</option>
 
-		<option name="config_alter_ICs_for_pbcs">.true.</option>
-		<option name="config_pbc_alteration_type">'partial_cell'</option>
+		<option name="config_alter_ICs_for_pcs">.true.</option>
+		<option name="config_pc_alteration_type">'partial_cell'</option>
 
 		<option name="config_use_activeTracers_surface_restoring">.true.</option>
 		<option name="config_use_bulk_wind_stress">.true.</option>

--- a/ocean/isomip/template_init.xml
+++ b/ocean/isomip/template_init.xml
@@ -5,7 +5,7 @@
 		<option name="config_ocean_run_mode">'init'</option>
 		<option name="config_land_ice_flux_mode">'standalone'</option>
 		<option name="config_eos_type">'jm'</option>
-		<option name="config_use_rx1_constraint">.true.</option>
+		<option name="config_init_vertical_grid_type">'haney-number'</option>
 		<option name="config_rx1_max">5.0</option>
 	</namelist>
 

--- a/ocean/isomip_plus/template_init.xml
+++ b/ocean/isomip_plus/template_init.xml
@@ -11,7 +11,7 @@
 		<option name="config_eos_linear_Tref">-1.0</option>
 		<option name="config_eos_linear_Sref">34.2</option>
 		<option name="config_eos_linear_densityref">1027.51</option>
-		<option name="config_use_rx1_constraint">.true.</option>
+		<option name="config_init_vertical_grid_type">'haney-number'</option>
 		<option name="config_rx1_max">5.0</option>
 		<option name="config_isomip_plus_min_column_thickness">10.0</option>
 		<option name="config_isomip_plus_topography_file">'input_geometry_processed.nc'</option>

--- a/ocean/scripts/LIGHTparticles/user_nl_mpaso
+++ b/ocean/scripts/LIGHTparticles/user_nl_mpaso
@@ -5,7 +5,7 @@
 ! *** EXCEPT FOR ***
 ! 1. DO NOT CHANGE config_start_time, config_run_duration, config_stop_time,
 !    config_do_restart, config_Restart_timestamp_filename, config_calendar_type,
-!    config_set_restingThickness_to_IC, config_alter_ICs_for_pbcs
+!    config_set_restingThickness_to_IC, config_alter_ICs_for_pcs
 ! 2. To preview the namelists, invoke $CASEROOT preview-namelists and look at
 !    $CASEROOT/CaseDocs/mpaso_in
 !

--- a/ocean/sub_ice_shelf_2D/5km/Haney_number_init/config_init1.xml
+++ b/ocean/sub_ice_shelf_2D/5km/Haney_number_init/config_init1.xml
@@ -12,7 +12,7 @@
 	<namelist name="namelist.ocean" mode="init">
 		<template file="template_init.xml" path_base="script_resolution_dir"/>
 		<option name="config_write_cull_cell_mask">.true.</option>
-		<option name="config_use_rx1_constraint">.true.</option>
+		<option name="config_init_vertical_grid_type">'haney-number'</option>
 		<option name="config_rx1_max">5.0</option>
 	</namelist>
 

--- a/ocean/sub_ice_shelf_2D/5km/Haney_number_init/config_init2.xml
+++ b/ocean/sub_ice_shelf_2D/5km/Haney_number_init/config_init2.xml
@@ -8,7 +8,7 @@
 	<namelist name="namelist.ocean" mode="init">
 		<template file="template_init.xml" path_base="script_resolution_dir"/>
 		<option name="config_write_cull_cell_mask">.false.</option>
-		<option name="config_use_rx1_constraint">.true.</option>
+		<option name="config_init_vertical_grid_type">'haney-number'</option>
 		<option name="config_rx1_max">5.0</option>
 	</namelist>
 

--- a/ocean/sub_ice_shelf_2D/5km/Haney_number_iterative_init/config_init1.xml
+++ b/ocean/sub_ice_shelf_2D/5km/Haney_number_iterative_init/config_init1.xml
@@ -12,7 +12,7 @@
 	<namelist name="namelist.ocean" mode="init">
 		<template file="template_init.xml" path_base="script_resolution_dir"/>
 		<option name="config_write_cull_cell_mask">.true.</option>
-		<option name="config_use_rx1_constraint">.true.</option>
+		<option name="config_init_vertical_grid_type">'haney-number'</option>
 		<option name="config_rx1_max">5.0</option>
 	</namelist>
 

--- a/ocean/sub_ice_shelf_2D/5km/Haney_number_iterative_init/config_init2.xml
+++ b/ocean/sub_ice_shelf_2D/5km/Haney_number_iterative_init/config_init2.xml
@@ -8,7 +8,7 @@
 	<namelist name="namelist.ocean" mode="init">
 		<template file="template_init.xml" path_base="script_resolution_dir"/>
 		<option name="config_write_cull_cell_mask">.false.</option>
-		<option name="config_use_rx1_constraint">.true.</option>
+		<option name="config_init_vertical_grid_type">'haney-number'</option>
 		<option name="config_rx1_max">5.0</option>
 	</namelist>
 

--- a/ocean/sub_ice_shelf_2D/5km/restart_test/config_init1.xml
+++ b/ocean/sub_ice_shelf_2D/5km/restart_test/config_init1.xml
@@ -12,7 +12,7 @@
 	<namelist name="namelist.ocean" mode="init">
 		<template file="template_init.xml" path_base="script_resolution_dir"/>
 		<option name="config_write_cull_cell_mask">.true.</option>
-		<option name="config_use_rx1_constraint">.true.</option>
+		<option name="config_init_vertical_grid_type">'haney-number'</option>
 		<option name="config_rx1_max">5.0</option>
 	</namelist>
 

--- a/ocean/sub_ice_shelf_2D/5km/restart_test/config_init2.xml
+++ b/ocean/sub_ice_shelf_2D/5km/restart_test/config_init2.xml
@@ -9,7 +9,7 @@
 		<template file="template_init.xml" path_base="script_resolution_dir"/>
                 <option name="config_sub_ice_shelf_2D_temperature">-3.0</option>
 		<option name="config_write_cull_cell_mask">.false.</option>
-		<option name="config_use_rx1_constraint">.true.</option>
+		<option name="config_init_vertical_grid_type">'haney-number'</option>
 		<option name="config_rx1_max">5.0</option>
 	</namelist>
 

--- a/ocean/sub_ice_shelf_2D/5km/with_frazil/config_init1.xml
+++ b/ocean/sub_ice_shelf_2D/5km/with_frazil/config_init1.xml
@@ -12,7 +12,7 @@
 	<namelist name="namelist.ocean" mode="init">
 		<template file="template_init.xml" path_base="script_resolution_dir"/>
 		<option name="config_write_cull_cell_mask">.true.</option>
-		<option name="config_use_rx1_constraint">.true.</option>
+		<option name="config_init_vertical_grid_type">'haney-number'</option>
 		<option name="config_rx1_max">5.0</option>
 	</namelist>
 

--- a/ocean/sub_ice_shelf_2D/5km/with_frazil/config_init2.xml
+++ b/ocean/sub_ice_shelf_2D/5km/with_frazil/config_init2.xml
@@ -10,7 +10,7 @@
 		<option name="config_sub_ice_shelf_2D_vert_levels">100</option>
 		<option name="config_sub_ice_shelf_2D_temperature">-3.0</option>
 		<option name="config_write_cull_cell_mask">.false.</option>
-		<option name="config_use_rx1_constraint">.true.</option>
+		<option name="config_init_vertical_grid_type">'haney-number'</option>
 		<option name="config_rx1_max">5.0</option>
 	</namelist>
 


### PR DESCRIPTION
In conjunction with https://github.com/MPAS-Dev/MPAS-Model/pull/825, The following namelist changes are needed:
* `config_alter_ICs_for_pbcs` --> `config_alter_ICs_for_pbs` (to support both top and bottom cells)
* `config_pbc_alteration_type` --> `config_pc_alteration_type`
* `config_use_rx1_constraint = .true.` --> `config_init_vertical_grid_type = 'haney-number'` (to support a new `z-level` vertical grid)
