### PR TITLE
Switch global ocean mesh culling and files for E3SM to use python masks

### DIFF
--- a/compass/ocean/tests/global_ocean/global_ocean.cfg
+++ b/compass/ocean/tests/global_ocean/global_ocean.cfg
@@ -5,7 +5,7 @@
 
 ## config options related to the mesh step
 # number of cores to use
-mesh_cores = 1
+mesh_cores = 18
 # minimum of cores, below which the step fails
 mesh_min_cores = 1
 # maximum memory usage allowed (in MB)

--- a/docs/developers_guide/quick_start.rst
+++ b/docs/developers_guide/quick_start.rst
@@ -62,9 +62,9 @@ follows:
 .. code-block:: bash
 
     conda create -n dev_compass python=3.8 affine cartopy cartopy_offlinedata \
-        cmocean "esmf=*=mpi_mpich*" ffmpeg "geometric_features=0.3.0" git \
+        cmocean "esmf=*=mpi_mpich*" ffmpeg "geometric_features=0.4.0" git \
         ipython "jigsaw=0.9.14" "jigsawpy=0.3.3" jupyter lxml matplotlib \
-        metis "mpas_tools=0.2.0" mpich nco "netcdf4=*=nompi_*" numpy \
+        metis "mpas_tools=0.5.1" mpich nco "netcdf4=*=nompi_*" numpy \
         progressbar2 pyamg "pyremap>=0.0.7,<0.1.0" rasterio requests scipy \
         xarray
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -46,7 +46,7 @@ requirements:
     - cmocean
     - esmf * {{ mpi_prefix }}_*
     - ffmpeg
-    - geometric_features 0.3.0
+    - geometric_features 0.4.0
     - git
     - ipython
     - jigsaw 0.9.14
@@ -55,7 +55,7 @@ requirements:
     - lxml
     - matplotlib-base
     - metis
-    - mpas_tools 0.2.0
+    - mpas_tools 0.5.1
     - {{ mpi }}  # [mpi != 'nompi']
     - nco
     - netcdf4 * nompi_*


### PR DESCRIPTION
This merge switches the `global_ocean` test group to using a set of threaded python tools for creating masks.  These same tools are being used in MPAS-Analyisis and have been shown to perform better on larger meshes than the C++ equivalents.

The python version of the transect mask creator also has the advantage that it follows the transect through polygons on the sphere rather than zig-zagging (which has been a problem with `MpasMaskCreator.x`). 

The results with the new tools are not expected to be bit-for-bit as compared with the previous mask creator.  So the test suites should pass but not bit-for-bit for global ocean test cases.

See https://github.com/MPAS-Dev/MPAS-Tools/pull/399
