### PR TITLE
Change how variable comparison is handled

### DIFF
--- a/compass/landice/tests/dome/decomposition_test/__init__.py
+++ b/compass/landice/tests/dome/decomposition_test/__init__.py
@@ -62,6 +62,6 @@ class DecompositionTest(TestCase):
         variables = ['thickness', 'normalVelocity']
         steps = self.steps_to_run
         if '1proc_run' in steps and '4proc_run' in steps:
-            compare_variables(variables, self.config, work_dir=self.work_dir,
+            compare_variables(test_case=self, variables=variables,
                               filename1='1proc_run/output.nc',
                               filename2='4proc_run/output.nc')

--- a/compass/landice/tests/dome/restart_test/__init__.py
+++ b/compass/landice/tests/dome/restart_test/__init__.py
@@ -95,6 +95,6 @@ class RestartTest(TestCase):
         variables = ['thickness', 'normalVelocity']
         steps = self.steps_to_run
         if 'full_run' in steps and 'restart_run' in steps:
-            compare_variables(variables, self.config, work_dir=self.work_dir,
+            compare_variables(test_case=self, variables=variables,
                               filename1='full_run/output.nc',
                               filename2='restart_run/output.nc')

--- a/compass/landice/tests/eismint2/decomposition_test/__init__.py
+++ b/compass/landice/tests/eismint2/decomposition_test/__init__.py
@@ -63,6 +63,6 @@ class DecompositionTest(TestCase):
                      'heatDissipation']
         steps = self.steps_to_run
         if '1proc_run' in steps and '4proc_run' in steps:
-            compare_variables(variables, self.config, work_dir=self.work_dir,
+            compare_variables(test_case=self, variables=variables,
                               filename1='1proc_run/output.nc',
                               filename2='4proc_run/output.nc')

--- a/compass/landice/tests/eismint2/restart_test/__init__.py
+++ b/compass/landice/tests/eismint2/restart_test/__init__.py
@@ -89,6 +89,6 @@ class RestartTest(TestCase):
                      'heatDissipation']
         steps = self.steps_to_run
         if 'full_run' in steps and 'restart_run' in steps:
-            compare_variables(variables, self.config, work_dir=self.work_dir,
+            compare_variables(test_case=self, variables=variables,
                               filename1='full_run/output.nc',
                               filename2='restart_run/output.nc')

--- a/compass/landice/tests/enthalpy_benchmark/A/__init__.py
+++ b/compass/landice/tests/enthalpy_benchmark/A/__init__.py
@@ -67,5 +67,5 @@ class A(TestCase):
         super().run()
         variables = ['temperature', 'basalWaterThickness',
                      'groundedBasalMassBal']
-        compare_variables(variables, self.config, work_dir=self.work_dir,
+        compare_variables(test_case=self, variables=variables,
                           filename1='phase3/output.nc')

--- a/compass/landice/tests/greenland/decomposition_test/__init__.py
+++ b/compass/landice/tests/greenland/decomposition_test/__init__.py
@@ -40,6 +40,6 @@ class DecompositionTest(TestCase):
         variables = ['thickness', 'normalVelocity']
         steps = self.steps_to_run
         if '1proc_run' in steps and '8proc_run' in steps:
-            compare_variables(variables, self.config, work_dir=self.work_dir,
+            compare_variables(test_case=self, variables=variables,
                               filename1='1proc_run/output.nc',
                               filename2='8proc_run/output.nc')

--- a/compass/landice/tests/greenland/restart_test/__init__.py
+++ b/compass/landice/tests/greenland/restart_test/__init__.py
@@ -66,6 +66,6 @@ class RestartTest(TestCase):
         variables = ['thickness', 'normalVelocity']
         steps = self.steps_to_run
         if 'full_run' in steps and 'restart_run' in steps:
-            compare_variables(variables, self.config, work_dir=self.work_dir,
+            compare_variables(test_case=self, variables=variables,
                               filename1='full_run/output.nc',
                               filename2='restart_run/output.nc')

--- a/compass/landice/tests/hydro_radial/decomposition_test/__init__.py
+++ b/compass/landice/tests/hydro_radial/decomposition_test/__init__.py
@@ -50,6 +50,6 @@ class DecompositionTest(TestCase):
         variables = ['waterThickness', 'waterPressure']
         steps = self.steps_to_run
         if '1proc_run' in steps and '3proc_run' in steps:
-            compare_variables(variables, self.config, work_dir=self.work_dir,
+            compare_variables(test_case=self, variables=variables,
                               filename1='1proc_run/output.nc',
                               filename2='3proc_run/output.nc')

--- a/compass/landice/tests/hydro_radial/restart_test/__init__.py
+++ b/compass/landice/tests/hydro_radial/restart_test/__init__.py
@@ -84,6 +84,6 @@ class RestartTest(TestCase):
         variables = ['waterThickness', 'waterPressure']
         steps = self.steps_to_run
         if 'full_run' in steps and 'restart_run' in steps:
-            compare_variables(variables, self.config, work_dir=self.work_dir,
+            compare_variables(test_case=self, variables=variables,
                               filename1='full_run/output.nc',
                               filename2='restart_run/output.nc')

--- a/compass/ocean/tests/baroclinic_channel/decomp_test/__init__.py
+++ b/compass/ocean/tests/baroclinic_channel/decomp_test/__init__.py
@@ -61,6 +61,6 @@ class DecompTest(TestCase):
                      'normalVelocity']
         steps = self.steps_to_run
         if '4proc' in steps and '8proc' in steps:
-            compare_variables(variables, self.config, work_dir=self.work_dir,
+            compare_variables(test_case=self, variables=variables,
                               filename1='4proc/output.nc',
                               filename2='8proc/output.nc')

--- a/compass/ocean/tests/baroclinic_channel/restart_test/__init__.py
+++ b/compass/ocean/tests/baroclinic_channel/restart_test/__init__.py
@@ -69,6 +69,6 @@ class RestartTest(TestCase):
                      'normalVelocity']
         steps = self.steps_to_run
         if 'full_run' in steps and 'restart_run' in steps:
-            compare_variables(variables, self.config, work_dir=self.work_dir,
+            compare_variables(test_case=self, variables=variables,
                               filename1='full_run/output.nc',
                               filename2='restart_run/output.nc')

--- a/compass/ocean/tests/baroclinic_channel/threads_test/__init__.py
+++ b/compass/ocean/tests/baroclinic_channel/threads_test/__init__.py
@@ -61,6 +61,6 @@ class ThreadsTest(TestCase):
                      'normalVelocity']
         steps = self.steps_to_run
         if '1thread' in steps and '2thread' in steps:
-            compare_variables(variables, self.config, work_dir=self.work_dir,
+            compare_variables(test_case=self, variables=variables,
                               filename1='1thread/output.nc',
                               filename2='2thread/output.nc')

--- a/compass/ocean/tests/global_ocean/analysis_test/__init__.py
+++ b/compass/ocean/tests/global_ocean/analysis_test/__init__.py
@@ -97,7 +97,7 @@ class AnalysisTest(ForwardTestCase):
         failed = list()
         for filename, variables in variables.items():
             try:
-                compare_variables(variables, config, work_dir=work_dir,
+                compare_variables(test_case=self, variables=variables,
                                   filename1=filename)
             except ValueError:
                 traceback.print_exc()
@@ -136,7 +136,7 @@ class AnalysisTest(ForwardTestCase):
                  'diatFe', 'diatSi', 'diazChl', 'diazC', 'diazFe', 'phaeoChl',
                  'phaeoC', 'phaeoFe'])
 
-        compare_variables(variables, self.config, work_dir=self.work_dir,
+        compare_variables(test_case=self, variables=variables,
                           filename1='forward/output.nc')
 
         timers = ['time integration']

--- a/compass/ocean/tests/global_ocean/daily_output_test/__init__.py
+++ b/compass/ocean/tests/global_ocean/daily_output_test/__init__.py
@@ -58,6 +58,6 @@ class DailyOutputTest(ForwardTestCase):
             'timeDaily_avg_ssh']
 
         compare_variables(
-            variables, config, work_dir=work_dir,
+            test_case=self, variables=variables,
             filename1='forward/analysis_members/'
                       'mpaso.hist.am.timeSeriesStatsDaily.0001-01-01.nc')

--- a/compass/ocean/tests/global_ocean/decomp_test/__init__.py
+++ b/compass/ocean/tests/global_ocean/decomp_test/__init__.py
@@ -48,6 +48,6 @@ class DecompTest(ForwardTestCase):
                      'normalVelocity']
         steps = self.steps_to_run
         if '4proc' in steps and '8proc' in steps:
-            compare_variables(variables, self.config, work_dir=self.work_dir,
+            compare_variables(test_case=self, variables=variables,
                               filename1='4proc/output.nc',
                               filename2='8proc/output.nc')

--- a/compass/ocean/tests/global_ocean/dynamic_adjustment.py
+++ b/compass/ocean/tests/global_ocean/dynamic_adjustment.py
@@ -55,5 +55,5 @@ class DynamicAdjustment(ForwardTestCase):
         variables = ['temperature', 'salinity', 'layerThickness',
                      'normalVelocity']
 
-        compare_variables(variables, self.config, work_dir=self.work_dir,
+        compare_variables(test_case=self, variables=variables,
                           filename1='simulation/output.nc')

--- a/compass/ocean/tests/global_ocean/init/__init__.py
+++ b/compass/ocean/tests/global_ocean/init/__init__.py
@@ -99,7 +99,7 @@ class Init(TestCase):
 
         if 'initial_state' in steps:
             variables = ['temperature', 'salinity', 'layerThickness']
-            compare_variables(variables, config, work_dir,
+            compare_variables(test_case=self, variables=variables,
                               filename1='initial_state/initial_state.nc')
 
             if self.with_bgc:
@@ -111,10 +111,10 @@ class Init(TestCase):
                     'diatFe', 'diatSi', 'diazChl', 'diazC', 'diazFe',
                     'phaeoChl', 'phaeoC', 'phaeoFe', 'DMS', 'DMSP', 'PROT',
                     'POLY', 'LIP']
-                compare_variables(variables, config, work_dir,
+                compare_variables(test_case=self, variables=variables,
                                   filename1='initial_state/initial_state.nc')
 
         if 'ssh_adjustment' in steps:
             variables = ['ssh', 'landIcePressure']
-            compare_variables(variables, config, work_dir,
+            compare_variables(test_case=self, variables=variables,
                               filename1='ssh_adjustment/adjusted_init.nc')

--- a/compass/ocean/tests/global_ocean/mesh/__init__.py
+++ b/compass/ocean/tests/global_ocean/mesh/__init__.py
@@ -76,5 +76,5 @@ class Mesh(TestCase):
         super().run()
 
         variables = ['xCell', 'yCell', 'zCell']
-        compare_variables(variables, config, self.work_dir,
+        compare_variables(test_case=self, variables=variables,
                           filename1='mesh/culled_mesh.nc')

--- a/compass/ocean/tests/global_ocean/performance_test/__init__.py
+++ b/compass/ocean/tests/global_ocean/performance_test/__init__.py
@@ -58,7 +58,7 @@ class PerformanceTest(ForwardTestCase):
                  'diatFe', 'diatSi', 'diazChl', 'diazC', 'diazFe', 'phaeoChl',
                  'phaeoC', 'phaeoFe'])
 
-        compare_variables(variables, self.config, work_dir=self.work_dir,
+        compare_variables(test_case=self, variables=variables,
                           filename1='forward/output.nc')
 
         if self.mesh.with_ice_shelf_cavities:
@@ -72,7 +72,7 @@ class PerformanceTest(ForwardTestCase):
                 'landIceInterfaceSalinity', 'accumulatedLandIceMass',
                 'accumulatedLandIceHeat']
 
-            compare_variables(variables, self.config, work_dir=self.work_dir,
+            compare_variables(test_case=self, variables=variables,
                               filename1='forward/land_ice_fluxes.nc')
 
         timers = ['time integration']

--- a/compass/ocean/tests/global_ocean/restart_test/__init__.py
+++ b/compass/ocean/tests/global_ocean/restart_test/__init__.py
@@ -64,6 +64,6 @@ class RestartTest(ForwardTestCase):
                      'normalVelocity']
         steps = self.steps_to_run
         if 'full_run' in steps and 'restart_run' in steps:
-            compare_variables(variables, self.config, work_dir=self.work_dir,
+            compare_variables(test_case=self, variables=variables,
                               filename1='full_run/output.nc',
                               filename2='restart_run/output.nc')

--- a/compass/ocean/tests/global_ocean/threads_test/__init__.py
+++ b/compass/ocean/tests/global_ocean/threads_test/__init__.py
@@ -48,6 +48,6 @@ class ThreadsTest(ForwardTestCase):
                      'normalVelocity']
         steps = self.steps_to_run
         if '1thread' in steps and '2thread' in steps:
-            compare_variables(variables, self.config, work_dir=self.work_dir,
+            compare_variables(test_case=self, variables=variables,
                               filename1='1thread/output.nc',
                               filename2='2thread/output.nc')

--- a/compass/ocean/tests/ice_shelf_2d/default/__init__.py
+++ b/compass/ocean/tests/ice_shelf_2d/default/__init__.py
@@ -60,7 +60,7 @@ class Default(TestCase):
         # perform validation
         variables = ['temperature', 'salinity', 'layerThickness',
                      'normalVelocity']
-        compare_variables(variables, self.config, work_dir=self.work_dir,
+        compare_variables(test_case=self, variables=variables,
                           filename1='forward/output.nc')
 
         variables = \
@@ -72,5 +72,5 @@ class Default(TestCase):
              'landIceHeatTransferVelocity', 'landIceSaltTransferVelocity',
              'landIceInterfaceTemperature', 'landIceInterfaceSalinity',
              'accumulatedLandIceMass', 'accumulatedLandIceHeat']
-        compare_variables(variables, self.config, work_dir=self.work_dir,
+        compare_variables(test_case=self, variables=variables,
                           filename1='forward/land_ice_fluxes.nc')

--- a/compass/ocean/tests/ice_shelf_2d/restart_test/__init__.py
+++ b/compass/ocean/tests/ice_shelf_2d/restart_test/__init__.py
@@ -72,7 +72,7 @@ class RestartTest(TestCase):
         if 'full_run' in steps and 'restart_run' in steps:
             variables = ['temperature', 'salinity', 'layerThickness',
                          'normalVelocity']
-            compare_variables(variables, self.config, work_dir=self.work_dir,
+            compare_variables(test_case=self, variables=variables,
                               filename1='full_run/output.nc',
                               filename2='restart_run/output.nc')
 
@@ -88,7 +88,7 @@ class RestartTest(TestCase):
                          'landIceInterfaceTemperature',
                          'landIceInterfaceSalinity', 'accumulatedLandIceMass',
                          'accumulatedLandIceHeat']
-            compare_variables(variables, self.config, work_dir=self.work_dir,
+            compare_variables(test_case=self, variables=variables,
                               filename1='full_run/land_ice_fluxes.nc',
                               filename2='restart_run/land_ice_fluxes.nc')
 
@@ -98,6 +98,6 @@ class RestartTest(TestCase):
                          'frazilTemperatureTendency', 'frazilSalinityTendency',
                          'frazilSurfacePressure',
                          'accumulatedLandIceFrazilMass']
-            compare_variables(variables, self.config, work_dir=self.work_dir,
+            compare_variables(test_case=self, variables=variables,
                               filename1='full_run/frazil.nc',
                               filename2='restart_run/frazil.nc')

--- a/compass/ocean/tests/ziso/default/__init__.py
+++ b/compass/ocean/tests/ziso/default/__init__.py
@@ -79,14 +79,14 @@ class Default(TestCase):
         if 'forward' in steps:
             variables = ['temperature', 'layerThickness']
             compare_variables(
-                variables, config, work_dir,
+                test_case=self, variables=variables,
                 filename1='forward/output/output.0001-01-01_00.00.00.nc')
 
             variables = [
                 'xParticle', 'yParticle', 'zParticle', 'zLevelParticle',
                 'buoyancyParticle', 'indexToParticleID', 'currentCell',
                 'transfered', 'numTimesReset']
-            compare_variables(variables, config, work_dir,
+            compare_variables(test_case=self, variables=variables,
                               filename1='forward/analysis_members/'
                                         'lagrPartTrack.0001-01-01_00.00.00.nc')
 

--- a/compass/ocean/tests/ziso/with_frazil/__init__.py
+++ b/compass/ocean/tests/ziso/with_frazil/__init__.py
@@ -74,7 +74,7 @@ class WithFrazil(TestCase):
         if 'forward' in steps:
             variables = ['temperature', 'layerThickness']
             compare_variables(
-                variables, config, work_dir,
+                test_case=self, variables=variables,
                 filename1='forward/output/output.0001-01-01_00.00.00.nc')
 
             variables = ['accumulatedFrazilIceMass',
@@ -83,5 +83,5 @@ class WithFrazil(TestCase):
                          'frazilTemperatureTendency', 'frazilSalinityTendency',
                          'frazilSurfacePressure',
                          'accumulatedLandIceFrazilMass']
-            compare_variables(variables, config, work_dir,
+            compare_variables(test_case=self, variables=variables,
                               filename1='forward/frazil.nc')

--- a/compass/run.py
+++ b/compass/run.py
@@ -91,8 +91,8 @@ def run_suite(suite_name):
                 if baseline_status is None:
                     status = '  {}'.format(internal_status)
                 else:
-                    status = '  {}  compare: {}'.format(internal_status,
-                                                        baseline_status)
+                    status = '  test: {}  baseline comparison: {}'.format(
+                        internal_status, baseline_status)
 
                 if test_pass:
                     logger.info(status)

--- a/compass/setup.py
+++ b/compass/setup.py
@@ -165,8 +165,7 @@ def setup_case(path, test_case, config_file, machine, work_dir, baseline_dir,
 
     # add the baseline directory for this test case
     if baseline_dir is not None:
-        baseline_root = os.path.join(baseline_dir, path)
-        config.set('paths', 'baseline_dir', baseline_root)
+        test_case.baseline_dir = os.path.join(baseline_dir, path)
 
     # set the mpas_model path from the command line if provided
     if mpas_model_path is not None:


### PR DESCRIPTION
Perform all variable comparisons before either raising an exception (in an individual test case) or printing a failure message that separates the "internal" test status from the comparison with the baseline.

closes #59 