### PR TITLE
Fix metadata for `global_ocean` test group

### DIFF
--- a/compass/ocean/tests/global_ocean/metadata.py
+++ b/compass/ocean/tests/global_ocean/metadata.py
@@ -174,8 +174,7 @@ def _get_conda_package_version(package):
     lines = conda.split('\n')
     for line in lines:
         parts = line.split()
-        if parts[0] == package:
+        if len(parts) > 0 and parts[0] == package:
             return parts[1]
 
-    raise ValueError('Package {} not found in the conda environment'.format(
-        package))
+    return 'not found'


### PR DESCRIPTION
Put `"not found"` in metadata for missing packages, rather than raising an exception.  We should not require that the `compass` package be present.  I took it out of the test environment and discovered these errors.