### PR TITLE
Update legacy docs

### DIFF
--- a/docs/machine_specific_instructions/anvil.rst
+++ b/docs/machine_specific_instructions/anvil.rst
@@ -9,7 +9,7 @@ First, you might want to build SCORPIO (see below), or use the one from
 
 .. code-block:: bash
 
-    source /lcrc/soft/climate/e3sm-unified/load_latest_compass.sh
+    source /lcrc/soft/climate/e3sm-unified/load_legacy_compass.sh
 
     module purge
     module load cmake/3.14.2-gvwazz3 intel/17.0.0-pwabdn2 \

--- a/docs/machine_specific_instructions/lanl.rst
+++ b/docs/machine_specific_instructions/lanl.rst
@@ -97,8 +97,25 @@ Hint: you can put the following line in your bashrc:
 
     alias mlgnu='module purge; module load git; module use /usr/projects/climate/SHARED_CLIMATE/modulefiles/all/; module load gcc/5.3.0 openmpi/1.10.5 netcdf/4.4.1 parallel-netcdf/1.5.0 pio/1.7.2; module unload python; source /usr/projects/climate/SHARED_CLIMATE/anaconda_envs/load_latest_compass.sh; echo "loading modules anaconda, gnu, openmpi, netcdf, pnetcdf, pio for grizzly"'
 
-grizzly, intel 17
------------------
+grizzly, intel 19 with scorpio
+------------------------------
+
+.. code-block:: bash
+
+    module purge
+    module load friendly-testing
+    module load intel/19.0.4 intel-mpi/2019.4 hdf5-parallel/1.8.16 pnetcdf/1.11.2 netcdf-h5parallel/4.7.3 mkl/2019.0.4
+    export NETCDF=/usr/projects/hpcsoft/toss3/grizzly/netcdf/4.7.3_intel-19.0.4_intel-mpi-2019.4_hdf5-1.8.16
+    export PNETCDF=/usr/projects/hpcsoft/toss3/grizzly/pnetcdf/1.11.2_intel-19.0.4_intel-mpi-2019.4_hdf5-1.8.16
+    export PIO=/usr/projects/climate/xylar/libraries/grizzly/scorpio-1.1.6-intel
+
+    make intel-mpi CORE=ocean USE_PIO2=true
+    # may also use: OPENMP=true DEBUG=true GEN_F90=true
+
+grizzly, intel 17 and pio 1
+---------------------------
+
+*Note: Intel 19 above is preferred*
 
 .. code-block:: bash
 
@@ -107,28 +124,6 @@ grizzly, intel 17
     module load intel/17.0.1
     module load openmpi/1.10.5 netcdf/4.4.1 parallel-netcdf/1.5.0 pio/1.7.2
     make ifort CORE=ocean
-
-grizzly, intel 19 with PIO2
----------------------------
-
-*Note: Intel 19 and PIO2 currently not functioning. Compile fails on PIO2 test. -Mark P, Jan 12 2021*
-
-.. code-block:: bash
-
-    module purge
-    module use /usr/projects/climate/SHARED_CLIMATE/modulefiles/all/scorpio
-    module load friendly-testing
-    module load intel/19.0.4 intel-mpi/2019.4 hdf5-parallel/1.8.16 pnetcdf/1.11.2 netcdf-h5parallel/4.7.3 mkl/2019.0.4 pio2/1.10.1
-    # note: if you already did this:
-    #  module use /usr/projects/climate/SHARED_CLIMATE/modulefiles/all/
-    # then it will show 'no such file' for hdf5-parallel/1.8.16.
-    # solution: log into a new node and try with only the commands above.
-    export I_MPI_CC=icc
-    export I_MPI_CXX=icpc
-    export I_MPI_F77=ifort
-    export I_MPI_F90=ifort
-
-    make ifort CORE=ocean USE_PIO2=true
 
 badger, gnu
 -----------

--- a/docs/machine_specific_instructions/lanl.rst
+++ b/docs/machine_specific_instructions/lanl.rst
@@ -69,7 +69,7 @@ git and compass environment, for all LANL IC machines:
     module load git
     module use /usr/projects/climate/SHARED_CLIMATE/modulefiles/all/
     module unload python
-    source /usr/projects/climate/SHARED_CLIMATE/anaconda_envs/load_latest_compass.sh
+    source /usr/projects/climate/SHARED_CLIMATE/anaconda_envs/load_legacy_compass.sh
 
 Example compass config file for LANL IC: ``general.config.ocean_turq``
 
@@ -95,7 +95,7 @@ Hint: you can put the following line in your bashrc:
 
 .. code-block:: bash
 
-    alias mlgnu='module purge; module load git; module use /usr/projects/climate/SHARED_CLIMATE/modulefiles/all/; module load gcc/5.3.0 openmpi/1.10.5 netcdf/4.4.1 parallel-netcdf/1.5.0 pio/1.7.2; module unload python; source /usr/projects/climate/SHARED_CLIMATE/anaconda_envs/load_latest_compass.sh; echo "loading modules anaconda, gnu, openmpi, netcdf, pnetcdf, pio for grizzly"'
+    alias mlgnu='module purge; module load git; module use /usr/projects/climate/SHARED_CLIMATE/modulefiles/all/; module load gcc/5.3.0 openmpi/1.10.5 netcdf/4.4.1 parallel-netcdf/1.5.0 pio/1.7.2; module unload python; source /usr/projects/climate/SHARED_CLIMATE/anaconda_envs/load_legacy_compass.sh; echo "loading modules anaconda, gnu, openmpi, netcdf, pnetcdf, pio for grizzly"'
 
 grizzly, intel 19 with scorpio
 ------------------------------

--- a/docs/machine_specific_instructions/nersc.rst
+++ b/docs/machine_specific_instructions/nersc.rst
@@ -7,7 +7,7 @@ compass environment:
 
 .. code-block:: bash
 
-    source /global/cfs/cdirs/e3sm/software/anaconda_envs/load_latest_compass.sh
+    source /global/cfs/cdirs/e3sm/software/anaconda_envs/load_legacy_compass.sh
 
 example compass config file:
 `general.config.ocean_cori <https://gist.github.com/mark-petersen/c61095d65216415ee0bb62a76da3c6cb>`_
@@ -56,7 +56,7 @@ cori, gnu
     module load cray-netcdf-hdf5parallel
     module load cray-parallel-netcdf
     module load cmake
-    source /global/project/projectdirs/e3sm/software/anaconda_envs/load_latest_e3sm_unified.sh
+    source /global/project/projectdirs/e3sm/software/anaconda_envs/load_legacy_compass.sh
     export PIO=/global/u2/h/hgkang/my_programs/Scorpio
     git submodule update --init --recursive
 


### PR DESCRIPTION
This merge updates Intel 19 compiler instructions on grizzly.

It also switches from `load_latest_compass.sh` to `load_legacy_compass.sh`.  A copy of the activation script with the new name has been added on Anvil/Chrysalis, Grizzly/Badger and Cori.