### PR TITLE
Rename docs from master from "stable" to "latest"

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ to setup and configure a test case.
 
 The latest compass documentation can be found here:
 
-[http://mpas-dev.github.io/compass/stable/](http://mpas-dev.github.io/compass/stable/)
+[http://mpas-dev.github.io/compass/latest/](http://mpas-dev.github.io/compass/latest/)
 
 Documentation on the [legacy verion of COMPASS](https://github.com/MPAS-Dev/compass/tree/legacy)
 can be found here:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -100,7 +100,7 @@ jobs:
       if [ -n ${branch} ]; then
         echo "This build is for branch $branch"
         if [[ ${branch} == "master" ]]; then
-          export DOCS_VERSION="stable"
+          export DOCS_VERSION="latest"
           run=True
         elif [[ ${branch} == "legacy" ]]; then
           export DOCS_VERSION="legacy"

--- a/docs/versions.rst
+++ b/docs/versions.rst
@@ -4,12 +4,12 @@ Code and Documentation Versions
 ================ ===============
 Documentation    On GitHub
 ================ ===============
-`stable docs`_   `master`_
+`latest docs`_   `master`_
 `legacy docs`_   `legacy`_
 `1.0.0 docs`_    `1.0.0`_
 ================ ===============
 
-.. _`stable docs`: ../stable/index.html
+.. _`latest docs`: ../latest/index.html
 .. _`legacy docs`: ../legacy/index.html
 .. _`1.0.0 docs`: ../1.0.0/index.html
 .. _`master`: https://github.com/MPAS-Dev/compass/tree/master

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -96,7 +96,7 @@ about:
     All namelists and streams files begin with the default generated from the
     Registry.xml file, and only the changes relevant to the particular test
     case are altered in those files.
-  doc_url: https://mpas-dev.github.io/compass/stable/
+  doc_url: https://mpas-dev.github.io/compass/latest/
   dev_url: https://github.com/MPAS-Dev/compass
 
 extra:


### PR DESCRIPTION
The `master` branch here is not necessarily a stable branch, since we don't have a development branch, so the docs should be called `latest` like we do for development branches in most other repos.