### PR TITLE
Make activation scripts (test envs and releases) on supported machines

### DIFF
--- a/compass/default.cfg
+++ b/compass/default.cfg
@@ -21,3 +21,26 @@ verify = True
 
 # the program to use for graph partitioning
 partition_executable = gpmetis
+
+
+# Options related to deploying a compass conda environment on supported
+# machines
+[deploy]
+
+# is this a test environment?
+test = True
+
+# should we build the local package?  If not, it must already exist.
+build = False
+
+# Recreate the environment if it already exists?
+recreate = False
+
+# a suffix on the environment name
+suffix =
+
+# the python version
+python = 3.8
+
+# the MPI version (nompi, mpich or openmpi)
+mpi = nompi

--- a/compass/default.cfg
+++ b/compass/default.cfg
@@ -44,3 +44,9 @@ python = 3.8
 
 # the MPI version (nompi, mpich or openmpi)
 mpi = nompi
+
+# the version of ESMF to build if using system compilers and MPI
+esmf = 8.1.1
+
+# the SCORPIO version to build
+scorpio = 1.1.6

--- a/compass/machines/anvil.cfg
+++ b/compass/machines/anvil.cfg
@@ -13,7 +13,7 @@ landice_database_root = /lcrc/group/e3sm/public_html/mpas_standalonedata/mpas-al
 
 # the path to the base conda environment where compass environments have
 # been created
-compass_envs = /lcrc/soft/climate/e3sm-unified/base
+compass_envs = /lcrc/soft/climate/compass/anvil/base
 
 
 # The parallel section describes options related to running tests in parallel
@@ -30,3 +30,11 @@ cores_per_node = 36
 
 # the number of multiprocessing or dask threads to use
 threads = 18
+
+
+# Options related to deploying a compass conda environment on supported
+# machines
+[deploy]
+
+# the unix group for permissions for the compass conda environment
+group = climate

--- a/compass/machines/anvil.cfg
+++ b/compass/machines/anvil.cfg
@@ -42,8 +42,14 @@ group = climate
 # the compiler set to use for system libraries and MPAS builds
 compiler = intel18
 
-# the system MPI library to use
-mpi = mvapich
+# the system MPI library to use for intel18 compiler
+mpi_intel18 = mvapich
+
+# the system MPI library to use for intel (17) compiler
+mpi_intel = mvapich
+
+# the system MPI library to use for gnu compiler
+mpi_gnu = mvapich
 
 # the base path to system libraries to be added as part of setting up compass
 system_libs = /lcrc/soft/climate/compass/anvil/system

--- a/compass/machines/anvil.cfg
+++ b/compass/machines/anvil.cfg
@@ -44,3 +44,6 @@ compiler = intel18
 
 # the system MPI library to use
 mpi = mvapich
+
+# the base path to system libraries to be added as part of setting up compass
+system_libs = /lcrc/soft/climate/compass/anvil/system

--- a/compass/machines/anvil.cfg
+++ b/compass/machines/anvil.cfg
@@ -38,3 +38,9 @@ threads = 18
 
 # the unix group for permissions for the compass conda environment
 group = climate
+
+# the compiler set to use for system libraries and MPAS builds
+compiler = intel18
+
+# the system MPI library to use
+mpi = mvapich

--- a/compass/machines/badger.cfg
+++ b/compass/machines/badger.cfg
@@ -13,7 +13,7 @@ landice_database_root = /usr/projects/regionalclimate/COMMON_MPAS/mpas_standalon
 
 # the path to the base conda environment where compass environments have
 # been created
-compass_envs = /usr/projects/climate/SHARED_CLIMATE/anaconda_envs/base
+compass_envs = /usr/projects/climate/SHARED_CLIMATE/compass/badger/base
 
 
 # The parallel section describes options related to running tests in parallel
@@ -33,3 +33,11 @@ account = e3sm
 
 # the number of multiprocessing or dask threads to use
 threads = 18
+
+
+# Options related to deploying a compass conda environment on supported
+# machines
+[deploy]
+
+# the unix group for permissions for the compass conda environment
+group = climate

--- a/compass/machines/badger.cfg
+++ b/compass/machines/badger.cfg
@@ -45,8 +45,11 @@ group = climate
 # the compiler set to use for system libraries and MPAS builds
 compiler = intel
 
-# the system MPI library to use
-mpi = impi
+# the system MPI library to use for intel compiler
+mpi_intel = impi
+
+# the system MPI library to use for gnu compiler
+mpi_gnu = mvapich
 
 # the base path to system libraries to be added as part of setting up compass
 system_libs = /usr/projects/climate/SHARED_CLIMATE/compass/badger/system

--- a/compass/machines/badger.cfg
+++ b/compass/machines/badger.cfg
@@ -47,3 +47,6 @@ compiler = intel
 
 # the system MPI library to use
 mpi = impi
+
+# the base path to system libraries to be added as part of setting up compass
+system_libs = /usr/projects/climate/SHARED_CLIMATE/compass/badger/system

--- a/compass/machines/badger.cfg
+++ b/compass/machines/badger.cfg
@@ -41,3 +41,9 @@ threads = 18
 
 # the unix group for permissions for the compass conda environment
 group = climate
+
+# the compiler set to use for system libraries and MPAS builds
+compiler = intel
+
+# the system MPI library to use
+mpi = impi

--- a/compass/machines/chrysalis.cfg
+++ b/compass/machines/chrysalis.cfg
@@ -42,8 +42,11 @@ group = climate
 # the compiler set to use for system libraries and MPAS builds
 compiler = intel
 
-# the system MPI library to use
-mpi = impi
+# the system MPI library to use for intel (17) compiler
+mpi_intel = impi
+
+# the system MPI library to use for gnu compiler
+mpi_gnu = openmpi
 
 # the base path to system libraries to be added as part of setting up compass
 system_libs = /lcrc/soft/climate/compass/chrysalis/system

--- a/compass/machines/chrysalis.cfg
+++ b/compass/machines/chrysalis.cfg
@@ -13,7 +13,7 @@ landice_database_root = /lcrc/group/e3sm/public_html/mpas_standalonedata/mpas-al
 
 # the path to the base conda environment where compass environments have
 # been created
-compass_envs = /lcrc/soft/climate/e3sm-unified/base
+compass_envs = /lcrc/soft/climate/compass/chrysalis/base
 
 
 # The parallel section describes options related to running tests in parallel
@@ -30,3 +30,11 @@ cores_per_node = 64
 
 # the number of multiprocessing or dask threads to use
 threads = 18
+
+
+# Options related to deploying a compass conda environment on supported
+# machines
+[deploy]
+
+# the unix group for permissions for the compass conda environment
+group = climate

--- a/compass/machines/chrysalis.cfg
+++ b/compass/machines/chrysalis.cfg
@@ -38,3 +38,9 @@ threads = 18
 
 # the unix group for permissions for the compass conda environment
 group = climate
+
+# the compiler set to use for system libraries and MPAS builds
+compiler = intel
+
+# the system MPI library to use
+mpi = impi

--- a/compass/machines/chrysalis.cfg
+++ b/compass/machines/chrysalis.cfg
@@ -44,3 +44,6 @@ compiler = intel
 
 # the system MPI library to use
 mpi = impi
+
+# the base path to system libraries to be added as part of setting up compass
+system_libs = /lcrc/soft/climate/compass/chrysalis/system

--- a/compass/machines/compy.cfg
+++ b/compass/machines/compy.cfg
@@ -38,3 +38,9 @@ threads = 18
 
 # the unix group for permissions for the compass conda environment
 group = users
+
+# the compiler set to use for system libraries and MPAS builds
+compiler = intel
+
+# the system MPI library to use
+mpi = impi

--- a/compass/machines/compy.cfg
+++ b/compass/machines/compy.cfg
@@ -13,7 +13,7 @@ landice_database_root = /compyfs/mpas_standalonedata/mpas-albany-landice
 
 # the path to the base conda environment where compass environments have
 # been created
-compass_envs = /share/apps/E3SM/conda_envs/base
+compass_envs = /share/apps/E3SM/conda_envs/compass/base
 
 
 # The parallel section describes options related to running tests in parallel
@@ -30,3 +30,11 @@ cores_per_node = 36
 
 # the number of multiprocessing or dask threads to use
 threads = 18
+
+
+# Options related to deploying a compass conda environment on supported
+# machines
+[deploy]
+
+# the unix group for permissions for the compass conda environment
+group = users

--- a/compass/machines/compy.cfg
+++ b/compass/machines/compy.cfg
@@ -44,3 +44,6 @@ compiler = intel
 
 # the system MPI library to use
 mpi = impi
+
+# the base path to system libraries to be added as part of setting up compass
+system_libs =  /share/apps/E3SM/conda_envs/compass/system

--- a/compass/machines/compy.cfg
+++ b/compass/machines/compy.cfg
@@ -42,8 +42,11 @@ group = users
 # the compiler set to use for system libraries and MPAS builds
 compiler = intel
 
-# the system MPI library to use
-mpi = impi
+# the system MPI library to use for intel compiler
+mpi_intel = impi
+
+# the system MPI library to use for gnu compiler
+mpi_pgi = mvapich2
 
 # the base path to system libraries to be added as part of setting up compass
 system_libs =  /share/apps/E3SM/conda_envs/compass/system

--- a/compass/machines/cori-haswell.cfg
+++ b/compass/machines/cori-haswell.cfg
@@ -50,3 +50,6 @@ mpi_gnu = mpt
 
 # the base path to system libraries to be added as part of setting up compass
 system_libs = /global/cfs/cdirs/e3sm/software/compass/cori-haswell/system
+
+# the version of ESMF to build if using system compilers and MPI (don't build)
+esmf = None

--- a/compass/machines/cori-haswell.cfg
+++ b/compass/machines/cori-haswell.cfg
@@ -42,8 +42,11 @@ group = e3sm
 # the compiler set to use for system libraries and MPAS builds
 compiler = intel
 
-# the system MPI library to use
-mpi = mpt
+# the system MPI library to use for intel compiler
+mpi_intel = mpt
+
+# the system MPI library to use for gnu compiler
+mpi_gnu = mpt
 
 # the base path to system libraries to be added as part of setting up compass
 system_libs = /global/cfs/cdirs/e3sm/software/compass/cori-haswell/system

--- a/compass/machines/cori-haswell.cfg
+++ b/compass/machines/cori-haswell.cfg
@@ -13,7 +13,7 @@ landice_database_root = /global/cfs/cdirs/e3sm/mpas_standalonedata/mpas-albany-l
 
 # the path to the base conda environment where compass environments have
 # been created
-compass_envs = /global/cfs/cdirs/e3sm/software/anaconda_envs/base
+compass_envs = /global/cfs/cdirs/e3sm/software/compass/cori-haswell/base
 
 
 # The parallel section describes options related to running tests in parallel
@@ -30,3 +30,11 @@ cores_per_node = 32
 
 # the number of multiprocessing or dask threads to use
 threads = 16
+
+
+# Options related to deploying a compass conda environment on supported
+# machines
+[deploy]
+
+# the unix group for permissions for the compass conda environment
+group = e3sm

--- a/compass/machines/cori-haswell.cfg
+++ b/compass/machines/cori-haswell.cfg
@@ -44,3 +44,6 @@ compiler = intel
 
 # the system MPI library to use
 mpi = mpt
+
+# the base path to system libraries to be added as part of setting up compass
+system_libs = /global/cfs/cdirs/e3sm/software/compass/cori-haswell/system

--- a/compass/machines/cori-haswell.cfg
+++ b/compass/machines/cori-haswell.cfg
@@ -38,3 +38,9 @@ threads = 16
 
 # the unix group for permissions for the compass conda environment
 group = e3sm
+
+# the compiler set to use for system libraries and MPAS builds
+compiler = intel
+
+# the system MPI library to use
+mpi = mpt

--- a/compass/machines/cori-knl.cfg
+++ b/compass/machines/cori-knl.cfg
@@ -38,3 +38,9 @@ threads = 18
 
 # the unix group for permissions for the compass conda environment
 group = e3sm
+
+# the compiler set to use for system libraries and MPAS builds
+compiler = intel
+
+# the system MPI library to use
+mpi = impi

--- a/compass/machines/cori-knl.cfg
+++ b/compass/machines/cori-knl.cfg
@@ -13,7 +13,7 @@ landice_database_root = /global/cfs/cdirs/e3sm/mpas_standalonedata/mpas-albany-l
 
 # the path to the base conda environment where compass environments have
 # been created
-compass_envs = /global/cfs/cdirs/e3sm/software/anaconda_envs/base
+compass_envs = /global/cfs/cdirs/e3sm/software/compass/cori-knl/base
 
 
 # The parallel section describes options related to running tests in parallel
@@ -30,3 +30,11 @@ cores_per_node = 68
 
 # the number of multiprocessing or dask threads to use
 threads = 18
+
+
+# Options related to deploying a compass conda environment on supported
+# machines
+[deploy]
+
+# the unix group for permissions for the compass conda environment
+group = e3sm

--- a/compass/machines/cori-knl.cfg
+++ b/compass/machines/cori-knl.cfg
@@ -44,3 +44,6 @@ compiler = intel
 
 # the system MPI library to use
 mpi = impi
+
+# the base path to system libraries to be added as part of setting up compass
+system_libs = /global/cfs/cdirs/e3sm/software/compass/cori-knl/system

--- a/compass/machines/cori-knl.cfg
+++ b/compass/machines/cori-knl.cfg
@@ -50,3 +50,6 @@ mpi_gnu = mpt
 
 # the base path to system libraries to be added as part of setting up compass
 system_libs = /global/cfs/cdirs/e3sm/software/compass/cori-knl/system
+
+# the version of ESMF to build if using system compilers and MPI (don't build)
+esmf = None

--- a/compass/machines/cori-knl.cfg
+++ b/compass/machines/cori-knl.cfg
@@ -42,8 +42,11 @@ group = e3sm
 # the compiler set to use for system libraries and MPAS builds
 compiler = intel
 
-# the system MPI library to use
-mpi = impi
+# the system MPI library to use for intel compiler
+mpi_intel = impi
+
+# the system MPI library to use for gnu compiler
+mpi_gnu = mpt
 
 # the base path to system libraries to be added as part of setting up compass
 system_libs = /global/cfs/cdirs/e3sm/software/compass/cori-knl/system

--- a/compass/machines/grizzly.cfg
+++ b/compass/machines/grizzly.cfg
@@ -45,8 +45,11 @@ group = climate
 # the compiler set to use for system libraries and MPAS builds
 compiler = intel
 
-# the system MPI library to use
-mpi = impi
+# the system MPI library to use for intel compiler
+mpi_intel = impi
+
+# the system MPI library to use for gnu compiler
+mpi_gnu = mvapich
 
 # the base path to system libraries to be added as part of setting up compass
 system_libs = /usr/projects/climate/SHARED_CLIMATE/compass/grizzly/system

--- a/compass/machines/grizzly.cfg
+++ b/compass/machines/grizzly.cfg
@@ -47,3 +47,6 @@ compiler = intel
 
 # the system MPI library to use
 mpi = impi
+
+# the base path to system libraries to be added as part of setting up compass
+system_libs = /usr/projects/climate/SHARED_CLIMATE/compass/grizzly/system

--- a/compass/machines/grizzly.cfg
+++ b/compass/machines/grizzly.cfg
@@ -41,3 +41,9 @@ threads = 18
 
 # the unix group for permissions for the compass conda environment
 group = climate
+
+# the compiler set to use for system libraries and MPAS builds
+compiler = intel
+
+# the system MPI library to use
+mpi = impi

--- a/compass/machines/grizzly.cfg
+++ b/compass/machines/grizzly.cfg
@@ -13,7 +13,7 @@ landice_database_root = /usr/projects/regionalclimate/COMMON_MPAS/mpas_standalon
 
 # the path to the base conda environment where compass environments have
 # been created
-compass_envs = /usr/projects/climate/SHARED_CLIMATE/anaconda_envs/base
+compass_envs = /usr/projects/climate/SHARED_CLIMATE/compass/grizzly/base
 
 
 # The parallel section describes options related to running tests in parallel
@@ -33,3 +33,11 @@ account = e3sm
 
 # the number of multiprocessing or dask threads to use
 threads = 18
+
+
+# Options related to deploying a compass conda environment on supported
+# machines
+[deploy]
+
+# the unix group for permissions for the compass conda environment
+group = climate

--- a/compass/setup.py
+++ b/compass/setup.py
@@ -222,6 +222,11 @@ def setup_case(path, test_case, config_file, machine, work_dir, baseline_dir,
     with open(pickle_filename, 'wb') as handle:
         pickle.dump(test_case, handle, protocol=pickle.HIGHEST_PROTOCOL)
 
+    if 'LOAD_COMPASS_ENV' in os.environ:
+        script_filename = os.environ['LOAD_COMPASS_ENV']
+        # make a symlink to the script for loading the compass conda env.
+        symlink(script_filename, os.path.join(work_dir, 'load_compass_env.sh'))
+
 
 def main():
     parser = argparse.ArgumentParser(

--- a/compass/setup.py
+++ b/compass/setup.py
@@ -47,6 +47,8 @@ def setup_cases(tests=None, numbers=None, config_file=None, machine=None,
         A dictionary of test cases, with the relative path in the work
         directory as keys
     """
+    if machine is None and 'COMPASS_MACHINE' in os.environ:
+        machine = os.environ['COMPASS_MACHINE']
 
     if config_file is None and machine is None:
         raise ValueError('At least one of config_file and machine is needed.')

--- a/compass/suite.py
+++ b/compass/suite.py
@@ -79,6 +79,11 @@ def setup_suite(mpas_core, suite_name, config_file=None, machine=None,
     with open(pickle_file, 'wb') as handle:
         pickle.dump(test_suite, handle, protocol=pickle.HIGHEST_PROTOCOL)
 
+    if 'LOAD_COMPASS_ENV' in os.environ:
+        script_filename = os.environ['LOAD_COMPASS_ENV']
+        # make a symlink to the script for loading the compass conda env.
+        symlink(script_filename, os.path.join(work_dir, 'load_compass_env.sh'))
+
     max_cores, max_of_min_cores = _get_required_cores(test_cases)
 
     print('target cores: {}'.format(max_cores))

--- a/compass/suite.py
+++ b/compass/suite.py
@@ -43,6 +43,8 @@ def setup_suite(mpas_core, suite_name, config_file=None, machine=None,
         The relative or absolute path to the root of a branch where the MPAS
         model has been built
     """
+    if machine is None and 'COMPASS_MACHINE' in os.environ:
+        machine = os.environ['COMPASS_MACHINE']
 
     if config_file is None and machine is None:
         raise ValueError('At least one of config_file and machine is needed.')

--- a/deploy/build.template
+++ b/deploy/build.template
@@ -1,0 +1,62 @@
+#!/bin/bash
+
+build_dir=$(pwd)
+
+export SCORPIO_VERSION={{ scorpio }}
+
+{{ modules }}
+
+set -e
+
+{{ sys_info.netcdf_paths }}
+
+export SCORPIO_PATH={{ scorpio_path }}
+export ESMF_PATH={{ esmf_path }}
+
+if [ ! -d "${SCORPIO_PATH}" ]; then
+    rm -rf scorpio*
+
+    git clone git@github.com:E3SM-Project/scorpio.git
+    cd scorpio
+    git checkout scorpio-v$SCORPIO_VERSION
+
+    mkdir build
+    cd build
+    FC={{ sys_info.mpifc }} CC={{ sys_info.mpicc }} CXX={{ sys_info.mpicxx }} cmake \
+        -DCMAKE_INSTALL_PREFIX=$SCORPIO_PATH -DPIO_ENABLE_TIMING=OFF \
+        -DNetCDF_C_PATH=$NETCDF_C_PATH \
+        -DNetCDF_Fortran_PATH=$NETCDF_FORTRAN_PATH \
+        -DPnetCDF_PATH=$PNETCDF_PATH ..
+
+    make
+    make install
+
+    cd $build_dir
+fi
+
+if [ ! -d "${ESMF_PATH}" ]; then
+    rm -rf esmf*
+    git clone git@github.com:esmf-org/esmf.git
+    cd esmf
+    git checkout {{ esmf_branch }}
+
+    export ESMF_DIR=$(pwd)
+
+    export ESMF_INSTALL_PREFIX=${ESMF_PATH}
+    export ESMF_INSTALL_BINDIR=${ESMF_PATH}/bin
+    export ESMF_INSTALL_DOCDIR=${ESMF_PATH}/doc
+    export ESMF_INSTALL_HEADERDIR=${ESMF_PATH}/include
+    export ESMF_INSTALL_LIBDIR=${ESMF_PATH}/lib
+    export ESMF_INSTALL_MODDIR=${ESMF_PATH}/mod
+
+    {{ sys_info.esmf_netcdf }}
+    export ESMF_PNETCDF="pnetcdf-config"
+
+    {{ sys_info.esmf_compilers }}
+    export ESMF_COMM={{ sys_info.esmf_comm }}
+
+    make -j 8
+    make install
+
+    cd $build_dir
+fi

--- a/deploy/build.template
+++ b/deploy/build.template
@@ -2,18 +2,16 @@
 
 build_dir=$(pwd)
 
-export SCORPIO_VERSION={{ scorpio }}
-
 {{ modules }}
 
 set -e
 
 {{ sys_info.netcdf_paths }}
 
-export SCORPIO_PATH={{ scorpio_path }}
-export ESMF_PATH={{ esmf_path }}
+export SCORPIO_VERSION="{{ scorpio }}"
+export SCORPIO_PATH="{{ scorpio_path }}"
 
-if [ ! -d "${SCORPIO_PATH}" ]; then
+if [ "${SCORPIO_VERSION}" != "None" ] && [ ! -d "${SCORPIO_PATH}" ]; then
     rm -rf scorpio*
 
     git clone git@github.com:E3SM-Project/scorpio.git
@@ -34,11 +32,14 @@ if [ ! -d "${SCORPIO_PATH}" ]; then
     cd $build_dir
 fi
 
-if [ ! -d "${ESMF_PATH}" ]; then
+export ESMF_PATH="{{ esmf_path }}"
+export ESMF_BRANCH="{{ esmf_branch }}"
+
+if [ "${ESMF_BRANCH}" != "None" ] && [ ! -d "${ESMF_PATH}" ]; then
     rm -rf esmf*
     git clone git@github.com:esmf-org/esmf.git
     cd esmf
-    git checkout {{ esmf_branch }}
+    git checkout "${ESMF_BRANCH}"
 
     export ESMF_DIR=$(pwd)
 

--- a/deploy/create_compass_env.py
+++ b/deploy/create_compass_env.py
@@ -11,25 +11,249 @@ import argparse
 import sys
 import re
 import configparser
+from lxml import etree
+from jinja2 import Template
+import shutil
 
 
-def check_env(base_path, env_name):
+def get_e3sm_compiler_and_mpi(machine, compiler, mpilib):
+
+    for filename in ['config_machines.xml', 'config_compilers.xml']:
+        url = 'https://raw.githubusercontent.com/E3SM-Project/E3SM/master/' \
+              'cime_config/machines/{}'.format(filename)
+        r = requests.get(url)
+        with open(filename, 'wb') as outfile:
+            outfile.write(r.content)
+
+    root = etree.parse('config_machines.xml')
+
+    machines = next(root.iter('config_machines'))
+
+    mach = None
+    for mach in machines:
+        if mach.tag == 'machine' and mach.attrib['MACH'] == machine:
+            break
+
+    if mach is None:
+        raise ValueError('{} does not appear to be an E3SM supported machine. '
+                         'compass cannot be deployed with system compilers.')
+
+    compilers = None
+    for child in mach:
+        if child.tag == 'COMPILERS':
+            compilers = child.text.split(',')
+            break
+
+    if compiler not in compilers:
+        raise ValueError('Compiler {} not found on {}. Try: {}'.format(
+            compiler, machine, compilers))
+
+    mpilibs = None
+    for child in mach:
+        if child.tag == 'MPILIBS':
+            mpilibs = child.text.split(',')
+            break
+
+    if mpilib not in mpilibs:
+        raise ValueError('MPI library {} not found on {}. Try: {}'.format(
+            mpilib, machine, mpilibs))
+
+    machine_os = None
+    for child in mach:
+        if child.tag == 'OS':
+            machine_os = child.text
+            break
+
+    commands = []
+    modules = next(mach.iter('module_system'))
+    for module in modules:
+        if module.tag == 'modules':
+            include = True
+            if 'compiler' in module.attrib and \
+                    module.attrib['compiler'] != compiler:
+                include = False
+            if 'mpilib' in module.attrib and \
+                    module.attrib['mpilib'] != mpilib and \
+                    module.attrib['mpilib'] != '!mpi-serial':
+                include = False
+            if include:
+                for command in module:
+                    if command.tag == 'command':
+                        text = 'module {}'.format(command.attrib['name'])
+                        if command.text is not None:
+                            text = '{} {}'.format(text, command.text)
+                        commands.append(text)
+
+    root = etree.parse('config_compilers.xml')
+
+    compilers = next(root.iter('config_compilers'))
+
+    mpicc = None
+    mpifc = None
+    mpicxx = None
+    for comp in compilers:
+        if comp.tag != 'compiler':
+            continue
+        if 'COMPILER' in comp.attrib and comp.attrib['COMPILER'] != compiler:
+            continue
+        if 'OS' in comp.attrib and comp.attrib['OS'] != machine_os:
+            continue
+        if 'MACH' in comp.attrib and comp.attrib['MACH'] != machine:
+            continue
+
+        # okay, this is either a "generic" compiler section or one for this
+        # machine
+
+        for child in comp:
+            if 'MPILIB' in child.attrib:
+                mpi = child.attrib['MPILIB']
+                if mpi[0] == '!':
+                    mpi_match = mpi[1:] != mpilib
+                else:
+                    mpi_match = mpi == mpilib
+            else:
+                mpi_match = True
+
+            if not mpi_match:
+                continue
+
+            if child.tag == 'MPICC':
+                mpicc = child.text.strip()
+            elif child.tag == 'MPICXX':
+                mpicxx = child.text.strip()
+            elif child.tag == 'MPIFC':
+                mpifc = child.text.strip()
+
+    env_vars = []
+
+    if 'intel' in compiler:
+        esmf_compilers = '    export ESMF_COMPILER=intel'
+    elif compiler == 'pgi':
+        esmf_compilers = '    export ESMF_COMPILER=pgi\n' \
+                         '    export ESMF_F90={}\n' \
+                         '    export ESMF_CXX={}'.format(mpifc, mpicxx)
+    else:
+        esmf_compilers = '    export ESMF_F90={}\n' \
+                         '    export ESMF_CXX={}'.format(mpifc, mpicxx)
+
+    if 'intel' in compiler and machine == 'anvil':
+        env_vars.extend(['export I_MPI_CC=icc',
+                         'export I_MPI_CXX=icpc',
+                         'export I_MPI_F77=ifort',
+                         'export I_MPI_F90=ifort'])
+
+    if mpilib == 'mvapich':
+        esmf_comm = 'mvapich2'
+        env_vars.extend(['export MV2_ENABLE_AFFINITY=0',
+                         'export MV2_SHOW_CPU_BINDING=1'])
+    elif mpilib == 'mpich':
+        esmf_comm = 'mpich3'
+    elif mpilib == 'impi':
+        esmf_comm = 'intelmpi'
+    else:
+        esmf_comm = mpilib
+
+    if machine == 'grizzly':
+        esmf_netcdf = \
+            '    export ESMF_NETCDF="split"\n' \
+            '    export ESMF_NETCDF_INCLUDE=$NETCDF_C_PATH/include\n' \
+            '    export ESMF_NETCDF_LIBPATH=$NETCDF_C_PATH/lib64'
+    elif machine == 'badger':
+        esmf_netcdf = \
+            '    export ESMF_NETCDF="split"\n' \
+            '    export ESMF_NETCDF_INCLUDE=$NETCDF_C_PATH/include\n' \
+            '    export ESMF_NETCDF_LIBPATH=$NETCDF_C_PATH/lib64'
+    else:
+        esmf_netcdf = '    export ESMF_NETCDF="nc-config"'
+
+    if 'cori' in machine:
+        netcdf_paths = 'export NETCDF_C_PATH=$NETCDF_DIR\n' \
+                       'export NETCDF_FORTRAN_PATH=$NETCDF_DIR\n' \
+                       'export PNETCDF_PATH=$PNETCDF_DIR'
+        mpas_netcdf_paths = 'export NETCDF=$NETCDF_DIR\n' \
+                            'export NETCDFF=$NETCDF_DIR\n' \
+                            'export PNETCDF=$PNETCDF_DIR'
+    else:
+        netcdf_paths = \
+            'export NETCDF_C_PATH=$(dirname $(dirname $(which nc-config)))\n' \
+            'export NETCDF_FORTRAN_PATH=$(dirname $(dirname $(which nf-config)))\n' \
+            'export PNETCDF_PATH=$(dirname $(dirname $(which pnetcdf-config)))'
+        mpas_netcdf_paths = \
+            'export NETCDF=$(dirname $(dirname $(which nc-config)))\n' \
+            'export NETCDFF=$(dirname $(dirname $(which nf-config)))\n' \
+            'export PNETCDF=$(dirname $(dirname $(which pnetcdf-config)))'
+
+    sys_info = dict(modules=commands, mpicc=mpicc, mpicxx=mpicxx, mpifc=mpifc,
+                    esmf_comm=esmf_comm, esmf_netcdf=esmf_netcdf,
+                    esmf_compilers=esmf_compilers, netcdf_paths=netcdf_paths,
+                    mpas_netcdf_paths=mpas_netcdf_paths, env_vars=env_vars)
+
+    return sys_info
+
+
+def build_system_libraries(source_path, scorpio, esmf, scorpio_path, esmf_path,
+                           sys_info):
+
+    esmf_branch = 'ESMF_{}'.format(esmf.replace('.', '_'))
+
+    script_filename = 'build.bash'
+
+    with open('{}/deploy/build.template'.format(source_path), 'r') as f:
+        template = Template(f.read())
+
+    script = template.render(
+        sys_info=sys_info, modules='\n'.join(sys_info['modules']),
+        scorpio=scorpio, scorpio_path=scorpio_path,  esmf_path=esmf_path,
+        esmf_branch=esmf_branch)
+    print('Writing {}'.format(script_filename))
+    with open(script_filename, 'w') as handle:
+        handle.write(script)
+
+    command = '/bin/bash build.bash'
+    check_call(command)
+
+
+def write_load_compass(source_path, conda_base, script_filename, compass_env,
+                       sys_info):
+
+    with open('{}/deploy/load_compass.template'.format(source_path), 'r') as f:
+        template = Template(f.read())
+
+    script = template.render(conda_base=conda_base, compass_env=compass_env,
+                             modules='\n'.join(sys_info['modules']),
+                             env_vars='\n'.join(sys_info['env_vars']),
+                             netcdf_paths=sys_info['mpas_netcdf_paths'],
+                             script_filename=script_filename)
+
+    print('Writing {}'.format(script_filename))
+    with open(script_filename, 'w') as handle:
+        handle.write(script)
+
+
+def check_env(script_filename, env_name, is_test):
     print("Checking the environment {}".format(env_name))
 
-    activate = 'source {}/etc/profile.d/conda.sh; conda activate {}'.format(
-        base_path, env_name)
+    activate = 'source {}'.format(script_filename)
 
     imports = ['geometric_features', 'mpas_tools', 'jigsawpy', 'compass']
+    commands = [['gpmetis', '--help'],
+                ['ffmpeg', '--help']]
+    if not is_test:
+        commands.extend(
+            [['compass', 'list'],
+             ['compass', 'setup', '--help'],
+             ['compass', 'suite', '--help'],
+             ['compass', 'clean', '--help']])
+    else:
+        commands.extend(
+            [['python', '-m', 'compass', 'list'],
+             ['python', '-m', 'compass', 'setup', '--help'],
+             ['python', '-m', 'compass', 'suite', '--help'],
+             ['python', '-m', 'compass', 'clean', '--help']])
+
     for import_name in imports:
         command = '{}; python -c "import {}"'.format(activate, import_name)
         test_command(command, os.environ, import_name)
-
-    commands = [['gpmetis', '--help'],
-                ['ffmpeg', '--help'],
-                ['compass', 'list'],
-                ['compass', 'setup', '--help'],
-                ['compass', 'suite', '--help'],
-                ['compass', 'clean', '--help']]
 
     for command in commands:
         package = command[0]
@@ -39,37 +263,47 @@ def check_env(base_path, env_name):
 
 def test_command(command, env, package):
     try:
-        subprocess.check_call(command, env=env, executable='/bin/bash',
-                              shell=True)
+        check_call(command, env=env)
     except subprocess.CalledProcessError as e:
         print('  {} failed'.format(package))
         raise e
     print('  {} passes'.format(package))
 
 
+def check_call(commands, env=None):
+    print('runnning: {}'.format(commands))
+    subprocess.run(commands, env=env, executable='/bin/bash', shell=True,
+                   check=True)
+
+
 def main():
     parser = argparse.ArgumentParser(
-        description='Deploy a compass conda environment', prog='compass-deploy')
+        description='Deploy a compass conda environment')
     parser.add_argument("-m", "--machine", dest="machine",
                         help="The name of the machine for loading machine-"
-                             "related config options", metavar="MACH")
+                             "related config options")
     parser.add_argument("-f", "--config_file", dest="config_file",
                         help="Config file to override deployment config "
                              "options")
-    parser.add_argument("-t", "--test", dest="test", type=bool,
-                        help="Whether to deploy a test environment")
-    parser.add_argument("-b", "--build", dest="build", type=bool,
-                        help="Whether to build the test package")
-    parser.add_argument("-r", "--recreate", dest="recreate", type=bool,
-                        help="Whether to recreate the environment if it "
-                             "exists")
-    parser.add_argument("-s", "--suffix", dest="suffix", type=str,
-                        help="A suffix to append to the environment name")
+    parser.add_argument("--test", dest="test", action='store_true',
+                        help="Deploy a test environment")
+    parser.add_argument("--no-test", dest="test", action='store_false',
+                        help="Deploy a production environment")
+    parser.add_argument("--build", dest="build", action='store_true',
+                        help="Build the test package")
+    parser.add_argument("--no-build", dest="build", action='store_false',
+                        help="Don't build the test package")
+    parser.add_argument("--recreate", dest="recreate", action='store_true',
+                        help="Recreate the environment if it exists")
+    parser.add_argument("--no-recreate", dest="recreate", action='store_false',
+                        help="Don't recreate the environment if it exists")
     parser.add_argument("-p", "--python", dest="python", type=str,
                         help="The python version to deploy")
     parser.add_argument("-i", "--mpi", dest="mpi", type=str,
-                        help="The MPI flavor (nompi, mpich, openmpi) to "
-                             "deploy")
+                        help="The MPI library (nompi, mpich, openmpi or a "
+                             "system flavor) to deploy")
+    parser.add_argument("-c", "--compiler", dest="compiler", type=str,
+                        help="The name of the compiler")
     parser.add_argument("-g", "--group", dest="group", type=str,
                         help="The unix group that should own the environment")
 
@@ -89,9 +323,10 @@ def main():
     config = configparser.ConfigParser(
         interpolation=configparser.ExtendedInterpolation())
     config.read(default_config)
-    if args.machine is not None:
+    machine = args.machine
+    if machine is not None:
         machine_config = os.path.join(here, '..', 'compass', 'machines',
-                                      '{}.cfg'.format(args.machine))
+                                      '{}.cfg'.format(machine))
         config.read(machine_config)
 
     if args.config_file is not None:
@@ -102,20 +337,10 @@ def main():
     else:
         group = config.get('deploy', 'group')
 
-    if args.suffix is not None:
-        suffix = args.suffix
-    else:
-        suffix = config.get('deploy', 'suffix')
-
     if args.python is not None:
         python = args.python
     else:
         python = config.get('deploy', 'python')
-
-    if args.mpi is not None:
-        mpi = args.mpi
-    else:
-        mpi = config.get('deploy', 'mpi')
 
     if args.test is not None:
         is_test = args.test
@@ -132,6 +357,59 @@ def main():
     else:
         force_recreate = config.getboolean('deploy', 'recreate')
 
+    if args.compiler is not None:
+        compiler = args.compiler
+    elif config.has_option('deploy', 'compiler'):
+        compiler = config.get('deploy', 'compiler')
+    else:
+        compiler = None
+
+    if args.mpi is not None:
+        mpi = args.mpi
+    else:
+        mpi = config.get('deploy', 'mpi_{}'.format(compiler))
+
+    esmf = config.get('deploy', 'esmf')
+    scorpio = config.get('deploy', 'scorpio')
+
+    if compiler is not None:
+        suffix = '_{}_{}'.format(compiler, mpi)
+    else:
+        suffix = ''
+
+    source_path = os.getcwd()
+    if machine is not None:
+        build_dir = 'deploy/build_{}{}'.format(machine, suffix)
+        try:
+            shutil.rmtree(build_dir)
+        except OSError:
+            pass
+        try:
+            os.makedirs(build_dir)
+        except FileExistsError:
+            pass
+
+        os.chdir(build_dir)
+
+    if compiler is not None:
+        sys_info = get_e3sm_compiler_and_mpi(machine, compiler, mpi)
+        conda_mpi = 'nompi'
+        system_libs = config.get('deploy', 'system_libs')
+        scorpio_path = os.path.join(system_libs, 'compass_{}', compiler,
+                                    mpi, 'scorpio_{}'.format(scorpio))
+        esmf_path = os.path.join(system_libs, 'compass_{}', compiler,
+                                 mpi, 'esmf_{}'.format(esmf))
+        sys_info['env_vars'].append('export PATH="{}:$PATH"'.format(
+            os.path.join(esmf_path, 'bin')))
+
+        sys_info['env_vars'].append('export PIO={}'.format(scorpio_path))
+    else:
+        sys_info = dict(modules=[], env_vars=[], mpas_netcdf_paths='')
+        conda_mpi = mpi
+        system_libs = None
+        scorpio_path = None
+        esmf_path = None
+
     base_path = config.get('paths', 'compass_envs')
     activ_path = os.path.abspath(os.path.join(base_path, '..'))
 
@@ -143,7 +421,7 @@ def main():
             outfile.write(r.content)
 
         command = '/bin/bash {} -b -p {}'.format(miniconda, base_path)
-        subprocess.check_call(command, executable='/bin/bash', shell=True)
+        check_call(command)
         os.remove(miniconda)
 
     activate = 'source {}/etc/profile.d/conda.sh; conda activate'.format(
@@ -156,17 +434,18 @@ def main():
                'conda install -y conda-build; ' \
                'conda update -y --all'.format(activate, base_path)
 
-    subprocess.check_call(commands, executable='/bin/bash', shell=True)
+    check_call(commands)
     print('done')
 
     if is_test and build:
         print('Building the conda package')
         commands = '{}; ' \
-                   'conda build -m ci/mpi_{}.yaml recipe'.format(activate, mpi)
+                   'conda build -m {}/ci/mpi_{}.yaml {}/recipe'.format(
+                       activate, source_path, conda_mpi, source_path)
 
-        subprocess.check_call(commands, executable='/bin/bash', shell=True)
+        check_call(commands)
 
-    if mpi == 'nompi':
+    if conda_mpi == 'nompi':
         mpi_prefix = 'nompi'
     else:
         mpi_prefix = 'mpi_{}'.format(mpi)
@@ -180,51 +459,58 @@ def main():
         python, version, mpi_prefix)
 
     if is_test:
-        env_name = 'test_compass_{}{}'.format(version, suffix)
+        env_name = 'test_compass_{}'.format(version)
     else:
-        env_name = 'compass_{}{}'.format(version, suffix)
-    if not os.path.exists('{}/envs/{}'.format(base_path, env_name)) \
-            or force_recreate:
+        env_name = 'compass_{}'.format(version)
+    env_path = os.path.join(base_path, 'envs', env_name)
+    if not os.path.exists(env_path) or force_recreate:
         print('creating {}'.format(env_name))
         commands = '{}; conda create -y -n {} {} {}'.format(
             activate, env_name, channels, packages)
-        subprocess.check_call(commands, executable='/bin/bash', shell=True)
+        check_call(commands)
+
+        if compiler is not None:
+            # remove conda-forge esmf because we will use the system build
+            commands = '{}; conda remove -y --force -n {} esmf'.format(
+                activate, env_name)
+            check_call(commands)
+
+        if is_test:
+            # remove compass itself because this is a development environment
+            commands = '{}; conda remove -y --force -n {} compass'.format(
+                activate, env_name)
+            check_call(commands)
+
     else:
         print('{} already exists'.format(env_name))
 
-    check_env(base_path, env_name)
+    if compiler is not None:
+        build_system_libraries(source_path, scorpio, esmf, scorpio_path,
+                               esmf_path, sys_info)
 
     try:
         os.makedirs(activ_path)
     except FileExistsError:
         pass
 
-    for ext in ['sh', 'csh']:
-        script = []
-        if ext == 'sh':
-            script.extend(['if [ -x "$(command -v module)" ] ; then\n',
-                           '  module unload python\n',
-                           'fi\n'])
-        script.append('source {}/etc/profile.d/conda.{}\n'.format(
-            base_path, ext))
-        script.append('conda activate {}\n'.format(env_name))
+    if is_test:
+        prefix = 'test'
+    else:
+        prefix = 'load'
 
-        if is_test:
-            file_name = '{}/load_test_compass{}.{}'.format(
-                activ_path, suffix, ext)
-        else:
-            file_name = '{}/load_latest_compass{}.{}'.format(
-                activ_path, suffix, ext)
-        if os.path.exists(file_name):
-            os.remove(file_name)
-        with open(file_name, 'w') as f:
-            f.writelines(script)
+    script_filename = '{}/{}_compass{}{}.sh'.format(
+        activ_path, prefix, version, suffix)
+    write_load_compass(source_path, base_path, script_filename, env_name,
+                       sys_info)
+
+    os.chdir(source_path)
+    check_env(script_filename, env_name, is_test)
 
     commands = '{}; conda clean -y -p -t'.format(activate)
-    subprocess.check_call(commands, executable='/bin/bash', shell=True)
+    check_call(commands)
 
     print('changing permissions on activation scripts')
-    activation_files = glob.glob('{}/load_*_compass*'.format(
+    activation_files = glob.glob('{}/*_compass*.sh'.format(
         activ_path))
 
     read_perm = stat.S_IRUSR | stat.S_IWUSR | stat.S_IRGRP | stat.S_IROTH
@@ -243,65 +529,67 @@ def main():
     new_gid = grp.getgrnam(group).gr_gid
 
     files_and_dirs = []
-    for root, dirs, files in os.walk(base_path):
-        files_and_dirs.extend(dirs)
-        files_and_dirs.extend(files)
+    for base in [base_path, system_libs]:
+        for root, dirs, files in os.walk(base):
+            files_and_dirs.extend(dirs)
+            files_and_dirs.extend(files)
 
     widgets = [progressbar.Percentage(), ' ', progressbar.Bar(),
                ' ', progressbar.ETA()]
     bar = progressbar.ProgressBar(widgets=widgets,
                                   maxval=len(files_and_dirs)).start()
     progress = 0
-    for root, dirs, files in os.walk(base_path):
-        for directory in dirs:
-            progress += 1
-            bar.update(progress)
+    for base in [base_path, system_libs]:
+        for root, dirs, files in os.walk(base):
+            for directory in dirs:
+                progress += 1
+                bar.update(progress)
 
-            directory = os.path.join(root, directory)
+                directory = os.path.join(root, directory)
 
-            try:
-                dir_stat = os.stat(directory)
-            except OSError:
-                continue
+                try:
+                    dir_stat = os.stat(directory)
+                except OSError:
+                    continue
 
-            perm = dir_stat.st_mode & mask
+                perm = dir_stat.st_mode & mask
 
-            if perm == exec_perm and dir_stat.st_uid == new_uid and \
-                    dir_stat.st_gid == new_gid:
-                continue
+                if perm == exec_perm and dir_stat.st_uid == new_uid and \
+                        dir_stat.st_gid == new_gid:
+                    continue
 
-            try:
-                os.chown(directory, new_uid, new_gid)
-                os.chmod(directory, exec_perm)
-            except OSError:
-                continue
+                try:
+                    os.chown(directory, new_uid, new_gid)
+                    os.chmod(directory, exec_perm)
+                except OSError:
+                    continue
 
-        for file_name in files:
-            progress += 1
-            bar.update(progress)
-            file_name = os.path.join(root, file_name)
-            try:
-                file_stat = os.stat(file_name)
-            except OSError:
-                continue
+            for file_name in files:
+                progress += 1
+                bar.update(progress)
+                file_name = os.path.join(root, file_name)
+                try:
+                    file_stat = os.stat(file_name)
+                except OSError:
+                    continue
 
-            perm = file_stat.st_mode & mask
+                perm = file_stat.st_mode & mask
 
-            if perm & stat.S_IXUSR:
-                # executable, so make sure others can execute it
-                new_perm = exec_perm
-            else:
-                new_perm = read_perm
+                if perm & stat.S_IXUSR:
+                    # executable, so make sure others can execute it
+                    new_perm = exec_perm
+                else:
+                    new_perm = read_perm
 
-            if perm == new_perm and file_stat.st_uid == new_uid and \
-                    file_stat.st_gid == new_gid:
-                continue
+                if perm == new_perm and file_stat.st_uid == new_uid and \
+                        file_stat.st_gid == new_gid:
+                    continue
 
-            try:
-                os.chown(file_name, new_uid, new_gid)
-                os.chmod(file_name, perm)
-            except OSError:
-                continue
+                try:
+                    os.chown(file_name, new_uid, new_gid)
+                    os.chmod(file_name, perm)
+                except OSError:
+                    continue
 
     bar.finish()
     print('  done.')

--- a/deploy/create_compass_env.py
+++ b/deploy/create_compass_env.py
@@ -214,7 +214,7 @@ def build_system_libraries(source_path, scorpio, esmf, scorpio_path, esmf_path,
 
 
 def write_load_compass(source_path, conda_base, script_filename, compass_env,
-                       sys_info):
+                       machine, sys_info):
 
     with open('{}/deploy/load_compass.template'.format(source_path), 'r') as f:
         template = Template(f.read())
@@ -223,7 +223,7 @@ def write_load_compass(source_path, conda_base, script_filename, compass_env,
                              modules='\n'.join(sys_info['modules']),
                              env_vars='\n'.join(sys_info['env_vars']),
                              netcdf_paths=sys_info['mpas_netcdf_paths'],
-                             script_filename=script_filename)
+                             script_filename=script_filename, machine=machine)
 
     print('Writing {}'.format(script_filename))
     with open(script_filename, 'w') as handle:
@@ -501,7 +501,7 @@ def main():
     script_filename = '{}/{}_compass{}{}.sh'.format(
         activ_path, prefix, version, suffix)
     write_load_compass(source_path, base_path, script_filename, env_name,
-                       sys_info)
+                       machine, sys_info)
 
     os.chdir(source_path)
     check_env(script_filename, env_name, is_test)

--- a/deploy/load_compass.template
+++ b/deploy/load_compass.template
@@ -11,3 +11,5 @@ export USE_PIO2=true
 export HDF5_USE_FILE_LOCKING=FALSE
 
 export LOAD_COMPASS_ENV={{ script_filename }}
+
+export COMPASS_MACHINE={{ machine }}

--- a/deploy/load_compass.template
+++ b/deploy/load_compass.template
@@ -1,0 +1,13 @@
+source {{ conda_base }}/etc/profile.d/conda.sh
+conda activate {{ compass_env }}
+
+{{ modules }}
+
+{{ netcdf_paths }}
+
+{{ env_vars }}
+
+export USE_PIO2=true
+export HDF5_USE_FILE_LOCKING=FALSE
+
+export LOAD_COMPASS_ENV={{ script_filename }}

--- a/docs/developers_guide/machines/anvil.rst
+++ b/docs/developers_guide/machines/anvil.rst
@@ -6,12 +6,13 @@ Anvil
 intel18
 -------
 
-To load the compass environment and modules, and set appropriate environment
-variables run this in the ``compass`` repo root:
+This is the default ``compass`` compiler on Anvil.  To activate the compass
+environment, load modules, and set appropriate environment variables, run this
+in the ``compass`` repo root:
 
 .. code-block:: bash
 
-    source ./load/load_compass_env.sh -m anvil -c intel18
+    source ./load/load_compass_env.sh
 
 To build the MPAS model with
 
@@ -28,12 +29,12 @@ or
 gnu
 ---
 
-To load the compass environment and modules, and set appropriate environment
-variables run this in the ``compass`` repo root:
+To activate the compass environment, load modules, and set appropriate
+environment variables, run this in the ``compass`` repo root:
 
 .. code-block:: bash
 
-    source ./load/load_compass_env.sh -m anvil -c gnu
+    source ./load/load_compass_env.sh -c gnu
 
 To build the MPAS model with
 

--- a/docs/developers_guide/machines/anvil.rst
+++ b/docs/developers_guide/machines/anvil.rst
@@ -1,0 +1,48 @@
+.. _dev_machine_anvil:
+
+Anvil
+=====
+
+intel18
+-------
+
+To load the compass environment and modules, and set appropriate environment
+variables run this in the ``compass`` repo root:
+
+.. code-block:: bash
+
+    source ./load/load_compass_env.sh -m anvil -c intel18
+
+To build the MPAS model with
+
+.. code-block:: bash
+
+    make CORE=landice ifort
+
+or
+
+.. code-block:: bash
+
+    make CORE=ocean ifort
+
+gnu
+---
+
+To load the compass environment and modules, and set appropriate environment
+variables run this in the ``compass`` repo root:
+
+.. code-block:: bash
+
+    source ./load/load_compass_env.sh -m anvil -c gnu
+
+To build the MPAS model with
+
+.. code-block:: bash
+
+    make CORE=landice gfortran
+
+or
+
+.. code-block:: bash
+
+    make CORE=ocean gfortran

--- a/docs/developers_guide/machines/badger.rst
+++ b/docs/developers_guide/machines/badger.rst
@@ -3,6 +3,22 @@
 Badger
 ======
 
+.. note::
+
+  It is important that you not point to custom module files for the compiler,
+  MPI, and netcdf modules on Grizzly to work properly.  If you have:
+
+  .. code-block:: bash
+
+    module use /usr/projects/climate/SHARED_CLIMATE/modulefiles/all
+
+  or similar commands in your ``.bashrc``, please either comment them out or
+  make sure to run
+
+  .. code-block:: bash
+
+    module unuse /usr/projects/climate/SHARED_CLIMATE/modulefiles/all
+
 intel
 -----
 

--- a/docs/developers_guide/machines/badger.rst
+++ b/docs/developers_guide/machines/badger.rst
@@ -6,12 +6,13 @@ Badger
 intel
 -----
 
-To load the compass environment and modules, and set appropriate environment
-variables run this in the ``compass`` repo root:
+This is the default ``compass`` compiler on Badger.  To activate the compass
+environment, load modules, and set appropriate environment variables, run this
+in the ``compass`` repo root:
 
 .. code-block:: bash
 
-    source ./load/load_compass_env.sh -m badger -c intel
+    source ./load/load_compass_env.sh
 
 To build the MPAS model with
 
@@ -28,12 +29,12 @@ or
 gnu
 ---
 
-To load the compass environment and modules, and set appropriate environment
-variables run this in the ``compass`` repo root:
+To activate the compass environment, load modules, and set appropriate
+environment variables, run this in the ``compass`` repo root:
 
 .. code-block:: bash
 
-    source ./load/load_compass_env.sh -m badger -c gnu
+    source ./load/load_compass_env.sh -c gnu
 
 To build the MPAS model with
 

--- a/docs/developers_guide/machines/badger.rst
+++ b/docs/developers_guide/machines/badger.rst
@@ -1,0 +1,48 @@
+.. _dev_machine_badger:
+
+Badger
+======
+
+intel
+-----
+
+To load the compass environment and modules, and set appropriate environment
+variables run this in the ``compass`` repo root:
+
+.. code-block:: bash
+
+    source ./load/load_compass_env.sh -m badger -c intel
+
+To build the MPAS model with
+
+.. code-block:: bash
+
+    make CORE=landice intel-mpi
+
+or
+
+.. code-block:: bash
+
+    make CORE=ocean intel-mpi
+
+gnu
+---
+
+To load the compass environment and modules, and set appropriate environment
+variables run this in the ``compass`` repo root:
+
+.. code-block:: bash
+
+    source ./load/load_compass_env.sh -m badger -c gnu
+
+To build the MPAS model with
+
+.. code-block:: bash
+
+    make CORE=landice gfortran
+
+or
+
+.. code-block:: bash
+
+    make CORE=ocean gfortran

--- a/docs/developers_guide/machines/chrysalis.rst
+++ b/docs/developers_guide/machines/chrysalis.rst
@@ -6,12 +6,13 @@ Chrysalis
 intel
 -----
 
-To load the compass environment and modules, and set appropriate environment
-variables run this in the ``compass`` repo root:
+This is the default ``compass`` compiler on Chrysalis.  To activate the compass
+environment, load modules, and set appropriate environment variables, run this
+in the ``compass`` repo root:
 
 .. code-block:: bash
 
-    source ./load/load_compass_env.sh -m chrysalis -c intel
+    source ./load/load_compass_env.sh
 
 To build the MPAS model with
 
@@ -28,12 +29,12 @@ or
 gnu
 ---
 
-To load the compass environment and modules, and set appropriate environment
-variables run this in the ``compass`` repo root:
+To activate the compass environment, load modules, and set appropriate
+environment variables, run this in the ``compass`` repo root:
 
 .. code-block:: bash
 
-    source ./load/load_compass_env.sh -m anvil -c gnu
+    source ./load/load_compass_env.sh -c gnu
 
 To build the MPAS model with
 

--- a/docs/developers_guide/machines/chrysalis.rst
+++ b/docs/developers_guide/machines/chrysalis.rst
@@ -1,0 +1,48 @@
+.. _dev_machine_chrysalis:
+
+Chrysalis
+=========
+
+intel
+-----
+
+To load the compass environment and modules, and set appropriate environment
+variables run this in the ``compass`` repo root:
+
+.. code-block:: bash
+
+    source ./load/load_compass_env.sh -m chrysalis -c intel
+
+To build the MPAS model with
+
+.. code-block:: bash
+
+    make CORE=landice intel-mpi
+
+or
+
+.. code-block:: bash
+
+    make CORE=ocean intel-mpi
+
+gnu
+---
+
+To load the compass environment and modules, and set appropriate environment
+variables run this in the ``compass`` repo root:
+
+.. code-block:: bash
+
+    source ./load/load_compass_env.sh -m anvil -c gnu
+
+To build the MPAS model with
+
+.. code-block:: bash
+
+    make CORE=landice gfortran
+
+or
+
+.. code-block:: bash
+
+    make CORE=ocean gfortran

--- a/docs/developers_guide/machines/compy.rst
+++ b/docs/developers_guide/machines/compy.rst
@@ -1,0 +1,33 @@
+.. _machine_compy:
+
+CompyMcNodeFace
+===============
+
+So far, we have not got ``compass`` to successfully build and run Compy.  We
+will update this page when we do.
+
+intel
+-----
+
+This works to build (but not yet run) standalone MPAS.  Again, we will update
+as soon as we have a solution.
+
+To load the compass environment and modules, and set appropriate environment
+variables run this in the ``compass`` repo root:
+
+.. code-block:: bash
+
+    source ./load/load_compass_env.sh -m compy -c intel
+
+To build the MPAS model with
+
+.. code-block:: bash
+
+    make CORE=landice intel-mpi
+
+or
+
+.. code-block:: bash
+
+    make CORE=ocean intel-mpi
+

--- a/docs/developers_guide/machines/compy.rst
+++ b/docs/developers_guide/machines/compy.rst
@@ -3,8 +3,12 @@
 CompyMcNodeFace
 ===============
 
-So far, we have not got ``compass`` to successfully build and run Compy.  We
-will update this page when we do.
+.. note::
+
+    So far, we have not got ``compass`` to successfully build and run Compy.
+    We will update this page when we do. See
+    `this issue <https://github.com/MPAS-Dev/compass/issues/57>`_ for more
+    discussion.
 
 intel
 -----
@@ -12,12 +16,13 @@ intel
 This works to build (but not yet run) standalone MPAS.  Again, we will update
 as soon as we have a solution.
 
-To load the compass environment and modules, and set appropriate environment
-variables run this in the ``compass`` repo root:
+This is the default ``compass`` compiler on CompyMcNodeFace.  To activate the
+compass environment, load modules, and set appropriate environment variables,
+run this in the ``compass`` repo root:
 
 .. code-block:: bash
 
-    source ./load/load_compass_env.sh -m compy -c intel
+    source ./load/load_compass_env.sh
 
 To build the MPAS model with
 

--- a/docs/developers_guide/machines/cori.rst
+++ b/docs/developers_guide/machines/cori.rst
@@ -1,0 +1,94 @@
+Cori
+====
+
+cori-haswell, gnu
+-----------------
+
+To load the compass environment and modules, and set appropriate environment
+variables run this in the ``compass`` repo root:
+
+.. code-block:: bash
+
+    source ./load/load_compass_env.sh -m cori-haswell -c gnu
+
+To build the MPAS model with
+
+.. code-block:: bash
+
+    make CORE=landice gnu-nersc
+
+or
+
+.. code-block:: bash
+
+    make CORE=ocean gnu-nersc
+
+
+cori-haswell, intel
+-------------------
+
+To load the compass environment and modules, and set appropriate environment
+variables run this in the ``compass`` repo root:
+
+.. code-block:: bash
+
+    source ./load/load_compass_env.sh -m cori-haswell -c intel
+
+
+To build the MPAS model with
+
+.. code-block:: bash
+
+    make CORE=landice intel-nersc
+
+or
+
+.. code-block:: bash
+
+    make CORE=ocean intel-nersc
+
+cori-knl, gnu
+-------------
+
+To load the compass environment and modules, and set appropriate environment
+variables run this in the ``compass`` repo root:
+
+.. code-block:: bash
+
+    source ./load/load_compass_env.sh -m cori-knl -c gnu
+
+
+To build the MPAS model with
+
+.. code-block:: bash
+
+    make CORE=landice gnu-nersc
+
+or
+
+.. code-block:: bash
+
+    make CORE=ocean gnu-nersc
+
+
+cori-knl, intel
+---------------
+
+To load the compass environment and modules, and set appropriate environment
+variables run this in the ``compass`` repo root:
+
+.. code-block:: bash
+
+    source ./load/load_compass_env.sh -m cori-knl -c intel
+
+To build the MPAS model with
+
+.. code-block:: bash
+
+    make CORE=landice intel-nersc
+
+or
+
+.. code-block:: bash
+
+    make CORE=ocean intel-nersc

--- a/docs/developers_guide/machines/cori.rst
+++ b/docs/developers_guide/machines/cori.rst
@@ -1,15 +1,44 @@
 Cori
 ====
 
+cori-haswell, intel
+-------------------
+
+This is the default ``compass`` architecture and compiler on Cori.  To activate
+the compass environment, load modules, and set appropriate environment
+variables, run this in the ``compass`` repo root:
+
+.. code-block:: bash
+
+    source ./load/load_compass_env.sh -m cori-haswell
+
+You don't have to supply ``-m cori-haswell`` but it will prevent you from
+getting a warning that you might want ``cori-knl``.
+
+To build the MPAS model with
+
+.. code-block:: bash
+
+    make CORE=landice intel-nersc
+
+or
+
+.. code-block:: bash
+
+    make CORE=ocean intel-nersc
+
 cori-haswell, gnu
 -----------------
 
-To load the compass environment and modules, and set appropriate environment
-variables run this in the ``compass`` repo root:
+To activate the compass environment, load modules, and set appropriate
+environment variables, run this in the ``compass`` repo root:
 
 .. code-block:: bash
 
     source ./load/load_compass_env.sh -m cori-haswell -c gnu
+
+As above, you don't have to supply ``-m cori-haswell`` but it will prevent you
+from getting a warning that you might want ``cori-knl``.
 
 To build the MPAS model with
 
@@ -23,17 +52,16 @@ or
 
     make CORE=ocean gnu-nersc
 
+cori-knl, intel
+---------------
 
-cori-haswell, intel
--------------------
-
-To load the compass environment and modules, and set appropriate environment
-variables run this in the ``compass`` repo root:
+This is the default ``compass`` compiler on Cori-KNL.  To activate the compass
+environment, load modules, and set appropriate environment variables, run this
+in the ``compass`` repo root:
 
 .. code-block:: bash
 
-    source ./load/load_compass_env.sh -m cori-haswell -c intel
-
+    source ./load/load_compass_env.sh -m cori-knl
 
 To build the MPAS model with
 
@@ -50,8 +78,8 @@ or
 cori-knl, gnu
 -------------
 
-To load the compass environment and modules, and set appropriate environment
-variables run this in the ``compass`` repo root:
+To activate the compass environment, load modules, and set appropriate
+environment variables, run this in the ``compass`` repo root:
 
 .. code-block:: bash
 
@@ -70,25 +98,3 @@ or
 
     make CORE=ocean gnu-nersc
 
-
-cori-knl, intel
----------------
-
-To load the compass environment and modules, and set appropriate environment
-variables run this in the ``compass`` repo root:
-
-.. code-block:: bash
-
-    source ./load/load_compass_env.sh -m cori-knl -c intel
-
-To build the MPAS model with
-
-.. code-block:: bash
-
-    make CORE=landice intel-nersc
-
-or
-
-.. code-block:: bash
-
-    make CORE=ocean intel-nersc

--- a/docs/developers_guide/machines/grizzly.rst
+++ b/docs/developers_guide/machines/grizzly.rst
@@ -6,12 +6,13 @@ Grizzly
 intel
 -----
 
-To load the compass environment and modules, and set appropriate environment
-variables run this in the ``compass`` repo root:
+This is the default ``compass`` compiler on Grizzly.  To activate the compass
+environment, load modules, and set appropriate environment variables, run this
+in the ``compass`` repo root:
 
 .. code-block:: bash
 
-    source ./load/load_compass_env.sh -m grizzly -c intel
+    source ./load/load_compass_env.sh
 
 To build the MPAS model with
 
@@ -28,12 +29,12 @@ or
 gnu
 ---
 
-To load the compass environment and modules, and set appropriate environment
-variables run this in the ``compass`` repo root:
+To activate the compass environment, load modules, and set appropriate
+environment variables, run this in the ``compass`` repo root:
 
 .. code-block:: bash
 
-    source ./load/load_compass_env.sh -m grizzly -c gnu
+    source ./load/load_compass_env.sh -c gnu
 
 To build the MPAS model with
 

--- a/docs/developers_guide/machines/grizzly.rst
+++ b/docs/developers_guide/machines/grizzly.rst
@@ -1,0 +1,48 @@
+.. _dev_machine_grizzly:
+
+Grizzly
+=======
+
+intel
+-----
+
+To load the compass environment and modules, and set appropriate environment
+variables run this in the ``compass`` repo root:
+
+.. code-block:: bash
+
+    source ./load/load_compass_env.sh -m grizzly -c intel
+
+To build the MPAS model with
+
+.. code-block:: bash
+
+    make CORE=landice intel-mpi
+
+or
+
+.. code-block:: bash
+
+    make CORE=ocean intel-mpi
+
+gnu
+---
+
+To load the compass environment and modules, and set appropriate environment
+variables run this in the ``compass`` repo root:
+
+.. code-block:: bash
+
+    source ./load/load_compass_env.sh -m grizzly -c gnu
+
+To build the MPAS model with
+
+.. code-block:: bash
+
+    make CORE=landice gfortran
+
+or
+
+.. code-block:: bash
+
+    make CORE=ocean gfortran

--- a/docs/developers_guide/machines/grizzly.rst
+++ b/docs/developers_guide/machines/grizzly.rst
@@ -3,6 +3,23 @@
 Grizzly
 =======
 
+.. note::
+
+  It is important that you not point to custom module files for the compiler,
+  MPI, and netcdf modules on Grizzly to work properly.  If you have:
+
+  .. code-block:: bash
+
+    module use /usr/projects/climate/SHARED_CLIMATE/modulefiles/all
+
+  or similar commands in your ``.bashrc``, please either comment them out or
+  make sure to run
+
+  .. code-block:: bash
+
+    module unuse /usr/projects/climate/SHARED_CLIMATE/modulefiles/all
+
+
 intel
 -----
 

--- a/docs/developers_guide/machines/index.rst
+++ b/docs/developers_guide/machines/index.rst
@@ -1,0 +1,54 @@
+.. _dev_machines:
+
+Machines
+========
+
+One of the major advantages of ``compass`` over :ref:`legacy_compass` is that it
+attempts to be aware of the capabilities of the machine it is running on.  This
+is a particular advantage for so-called "supported" machines with a config file
+defined for them in the ``compass`` package.  But even for "unknown" machines,
+it is not difficult to set a few config options in your user config file to
+describe your machine.  Then, ``compass`` can use this data to make sure test
+cases are configured in a way that is appropriate for your machine.
+
+.. _dev_supported_machines:
+
+Supported Machines
+------------------
+
+We have activation scripts, typically for two compiler flavors, on each
+supported machine.  The easiest way to load these for a developer is to run
+the following in the root of the local clone of the compass repo:
+
+.. code-block:: bash
+
+    source ./load/load_compass_env.sh -m <machine> -c <compiler>
+
+This will then source an appropriate script that will load the compass
+conda environment and the compiler and MPI modules, and set environment
+variables needed compile MPAS.
+
+After loading this environment, you can set up test cases or test suites, and
+a link ``load_compass_env.sh`` will be included in each suite or test case
+work directory that can be sourced on a compute node (e.g. in a job script).
+to load the same conda environment and compiler and MPI modules.
+
+Below are specifics for each supported machine
+.. toctree::
+   :titlesonly:
+
+   anvil
+   badger
+   chrysalis
+   compy
+   cori
+   grizzly
+
+
+.. _dev_other_machines:
+
+Other Machines
+--------------
+
+For a discussion on this, see the user's guid one :ref:`other_machines`.
+

--- a/docs/developers_guide/machines/index.rst
+++ b/docs/developers_guide/machines/index.rst
@@ -34,9 +34,27 @@ you run into trouble with the automatic recognition (e.g. if you're setting
 up test cases on a compute node).
 
 If you do not supply a compiler set with ``-c``, you will get the default
-compiler for each machine.  Currently, we only support one MPI flavor per
+compiler for each machine.  Typically, we only support one MPI flavor per
 compiler, so you should not need to specify which MPI version to use.  This
 follows automatically from the choice of compilers.
+
+To list the available compilers and MPI libraries on a machine, run:
+
+.. code-block:: bash
+
+    source ./load/load_compass_env.sh --list
+
+You will see something like:
+
+.. code-block:: none
+
+    Default compiler and MPI library:
+      -c intel -i impi
+
+    Available compilers and MPI libraries:
+      -c intel -i impi
+      -c gnu -i mvapich
+      -c intel -i mvapich
 
 After loading this environment, you can set up test cases or test suites, and
 a link ``load_compass_env.sh`` will be included in each suite or test case

--- a/docs/developers_guide/machines/index.rst
+++ b/docs/developers_guide/machines/index.rst
@@ -22,16 +22,29 @@ the following in the root of the local clone of the compass repo:
 
 .. code-block:: bash
 
-    source ./load/load_compass_env.sh -m <machine> -c <compiler>
+    source ./load/load_compass_env.sh [-m <machine>] [-c <compiler>]
 
-This will then source an appropriate script that will load the compass
-conda environment and the compiler and MPI modules, and set environment
+This will then source an appropriate script that will activate the compass
+conda environment, load the compiler and MPI modules, and set environment
 variables needed compile MPAS.
+
+If you are on a login node, the script should automatically recognize what
+machine you are on.  You can supply the machine name with ``-m <machine>`` if
+you run into trouble with the automatic recognition (e.g. if you're setting
+up test cases on a compute node).
+
+If you do not supply a compiler set with ``-c``, you will get the default
+compiler for each machine.  Currently, we only support one MPI flavor per
+compiler, so you should not need to specify which MPI version to use.  This
+follows automatically from the choice of compilers.
 
 After loading this environment, you can set up test cases or test suites, and
 a link ``load_compass_env.sh`` will be included in each suite or test case
-work directory that can be sourced on a compute node (e.g. in a job script).
-to load the same conda environment and compiler and MPI modules.
+work directory.  This is a link to a specific activation script for that
+machine and compiler (so not a link to ``load/load_compass_env.sh``, it just
+happens to be given the same name).  You can can source this file on a
+compute node (e.g. in a job script) to get the right compass conda environment,
+compilers, MPI libraries and environment variables for running MPAS.
 
 Below are specifics for each supported machine
 .. toctree::

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -58,6 +58,7 @@ components themselves evolves and new functionality is added.
    developers_guide/landice/index
    developers_guide/ocean/index
    developers_guide/framework
+   developers_guide/machines/index
    developers_guide/docs
    developers_guide/building_docs
    developers_guide/api

--- a/docs/users_guide/machines/anvil.rst
+++ b/docs/users_guide/machines/anvil.rst
@@ -51,41 +51,12 @@ setting up test cases or a test suite:
 intel18 on anvil
 ----------------
 
-First, you might want to build SCORPIO (see below), or use the one from
-`xylar <http://github.com/xylar>`_ referenced here:
+To load the compass environment and modules, and set appropriate environment
+variables:
 
 .. code-block:: bash
 
-    source /lcrc/soft/climate/e3sm-unified/load_latest_compass.sh
-
-    module purge
-    module load cmake/3.14.2-gvwazz3
-    module load intel/18.0.4-62uvgmb
-    module load intel-mkl/2018.4.274-jwaeshj
-    module load netcdf/4.4.1-fijcsqi
-    module load netcdf-cxx/4.2-cixenix
-    module load netcdf-fortran/4.4.4-mmtrep3
-    module load mvapich2/2.2-verbs-m57bia7
-    module load parallel-netcdf/1.11.0-ny4vo3o
-
-    export NETCDF=$(dirname $(dirname $(which nc-config)))
-    export NETCDFF=$(dirname $(dirname $(which nf-config)))
-    export PNETCDF=$(dirname $(dirname $(which pnetcdf-config)))
-
-    export PIO=/lcrc/soft/climate/compass/anvil/compass-1.0.0/scorpio-1.1.6/intel18/mvapich
-    export ESMF=/lcrc/soft/climate/compass/anvil/compass-1.0.0/esmf-8.1.0/intel18/mvapich
-
-    export I_MPI_CC=icc
-    export I_MPI_CXX=icpc
-    export I_MPI_F77=ifort
-    export I_MPI_F90=ifort
-    export MV2_ENABLE_AFFINITY=0
-    export MV2_SHOW_CPU_BINDING=1
-
-    export AUTOCLEAN=true
-    export USE_PIO2=true
-    export HDF5_USE_FILE_LOCKING=FALSE
-
+    source /lcrc/soft/climate/compass/anvil/load_compass1.0.0_intel18_mvapich.sh
 
 To build the MPAS model with
 
@@ -102,33 +73,12 @@ or
 gnu on anvil
 ------------
 
+To load the compass environment and modules, and set appropriate environment
+variables:
+
 .. code-block:: bash
 
-    source /lcrc/soft/climate/e3sm-unified/load_latest_compass.sh
-
-    module purge
-    module load cmake/3.14.2-gvwazz3
-    module load gcc/8.2.0-xhxgy33
-    module load intel-mkl/2018.4.274-2amycpi
-    module load netcdf/4.4.1-ve2zfkw
-    module load netcdf-cxx/4.2-2rkopdl
-    module load netcdf-fortran/4.4.4-thtylny
-    module load mvapich2/2.2-verbs-ppznoge
-    module load parallel-netcdf/1.11.0-c22b2bn
-
-    export NETCDF=$(dirname $(dirname $(which nc-config)))
-    export NETCDFF=$(dirname $(dirname $(which nf-config)))
-    export PNETCDF=$(dirname $(dirname $(which pnetcdf-config)))
-
-    export PIO=/lcrc/soft/climate/compass/anvil/compass-1.0.0/scorpio-1.1.6/gnu/mvapich
-    export ESMF=/lcrc/soft/climate/compass/anvil/compass-1.0.0/esmf-8.1.0/gnu/mvapich
-
-    export MV2_ENABLE_AFFINITY=0
-    export MV2_SHOW_CPU_BINDING=1
-
-    export AUTOCLEAN=true
-    export USE_PIO2=true
-    export HDF5_USE_FILE_LOCKING=FALSE
+    source /lcrc/soft/climate/compass/anvil/load_compass1.0.0_gnu_mvapich.sh
 
 To build the MPAS model with
 

--- a/docs/users_guide/machines/badger.rst
+++ b/docs/users_guide/machines/badger.rst
@@ -54,30 +54,13 @@ setting up test cases or a test suite:
 badger, intel
 -------------
 
+To load the compass environment and modules, and set appropriate environment
+variables:
+
 .. code-block:: bash
 
-    source /usr/projects/climate/SHARED_CLIMATE/anaconda_envs/load_latest_compass.sh
+    source /usr/projects/climate/SHARED_CLIMATE/compass/badger/load_compass1.0.0_intel_impi.sh
 
-    module purge
-    module load cmake/3.16.2
-    module load intel/19.0.4
-    module load intel-mpi/2019.4
-    module load friendly-testing
-    module load hdf5-parallel/1.8.16
-    module load pnetcdf/1.11.2
-    module load netcdf-h5parallel/4.7.3
-    module load mkl/2019.0.4
-
-    export NETCDF=$(dirname $(dirname $(which nc-config)))
-    export NETCDFF=$(dirname $(dirname $(which nf-config)))
-    export PNETCDF=$(dirname $(dirname $(which pnetcdf-config)))
-
-    export PIO=/usr/projects/climate/SHARED_CLIMATE/compass/badger/compass-1.0.0/scorpio-1.1.6/intel/impi
-    export ESMF=/usr/projects/climate/SHARED_CLIMATE/compass/badger/compass-1.0.0/esmf-8.1.0/intel/impi
-
-    export AUTOCLEAN=true
-    export USE_PIO2=true
-    export HDF5_USE_FILE_LOCKING=FALSE
 
 To build the MPAS model with
 
@@ -95,33 +78,13 @@ or
 badger, gnu
 -----------
 
+To load the compass environment and modules, and set appropriate environment
+variables:
+
 .. code-block:: bash
 
-    source /usr/projects/climate/SHARED_CLIMATE/anaconda_envs/load_latest_compass.sh
+    source /usr/projects/climate/SHARED_CLIMATE/compass/badger/load_compass1.0.0_gnu_mvapich.sh
 
-    module purge
-    module load cmake/3.16.2
-    module load gcc/6.4.0
-    module load mvapich2/2.3
-    module load friendly-testing
-    module load hdf5-parallel/1.8.16
-    module load pnetcdf/1.11.2
-    module load netcdf-h5parallel/4.7.3
-    module load mkl/2019.0.4
-
-    export NETCDF=$(dirname $(dirname $(which nc-config)))
-    export NETCDFF=$(dirname $(dirname $(which nf-config)))
-    export PNETCDF=$(dirname $(dirname $(which pnetcdf-config)))
-
-    export PIO=/usr/projects/climate/SHARED_CLIMATE/compass/badger/compass-1.0.0/scorpio-1.1.6/gnu/mvapich
-    export ESMF=/usr/projects/climate/SHARED_CLIMATE/compass/badger/compass-1.0.0/esmf-8.1.0/gnu/mvapich
-
-    export MV2_ENABLE_AFFINITY=0
-    export MV2_SHOW_CPU_BINDING=1
-
-    export AUTOCLEAN=true
-    export USE_PIO2=true
-    export HDF5_USE_FILE_LOCKING=FALSE
 
 To build the MPAS model with
 

--- a/docs/users_guide/machines/chrysalis.rst
+++ b/docs/users_guide/machines/chrysalis.rst
@@ -47,32 +47,12 @@ setting up test cases or a test suite:
 intel on Chrysalis
 ------------------
 
+To load the compass environment and modules, and set appropriate environment
+variables:
+
 .. code-block:: bash
 
-    source /lcrc/soft/climate/e3sm-unified/load_latest_compass.sh
-
-    module purge
-    module load subversion/1.14.0-e4smcy3
-    module load perl/5.32.0-bsnc6lt
-    module load intel/20.0.4-kodw73g
-    module load intel-mkl/2020.4.304-g2qaxzf
-    module load intel-mpi/2019.9.304-tkzvizk
-    module load hdf5/1.8.16-se4xyo7
-    module load netcdf-c/4.4.1-qvxyzq2
-    module load netcdf-cxx/4.2-binixgj
-    module load netcdf-fortran/4.4.4-rdxohvp
-    module load parallel-netcdf/1.11.0-b74wv4m
-
-    export NETCDF=$(dirname $(dirname $(which nc-config)))
-    export NETCDFF=$(dirname $(dirname $(which nf-config)))
-    export PNETCDF=$(dirname $(dirname $(which pnetcdf-config)))
-
-    export PIO=/lcrc/soft/climate/compass/chrysalis/compass-1.0.0/scorpio-1.1.6/intel/impi
-    export ESMF=/lcrc/soft/climate/compass/chrysalis/compass-1.0.0/esmf-8.1.0/intel/impi
-
-    export AUTOCLEAN=true
-    export USE_PIO2=true
-    export HDF5_USE_FILE_LOCKING=FALSE
+    source /lcrc/soft/climate/compass/chrysalis/load_compass1.0.0_intel_impi.sh
 
 To build the MPAS model with
 
@@ -90,32 +70,12 @@ or
 gnu on Chrysalis
 ----------------
 
+To load the compass environment and modules, and set appropriate environment
+variables:
+
 .. code-block:: bash
 
-    source /lcrc/soft/climate/e3sm-unified/load_latest_compass.sh
-
-    module purge
-    module load subversion/1.14.0-e4smcy3
-    module load perl/5.32.0-bsnc6lt
-    module load gcc/9.2.0-ugetvbp
-    module load intel-mkl/2020.4.304-n3b5fye
-    module load openmpi/4.0.4-hpcx-hghvhj5
-    module load hdf5/1.10.7-sbsigon
-    module load netcdf-c/4.7.4-a4uk6zy
-    module load netcdf-cxx/4.2-fz347dw
-    module load netcdf-fortran/4.5.3-i5ah7u2
-    module load parallel-netcdf/1.12.1-e7w4x32
-
-    export NETCDF=$(dirname $(dirname $(which nc-config)))
-    export NETCDFF=$(dirname $(dirname $(which nf-config)))
-    export PNETCDF=$(dirname $(dirname $(which pnetcdf-config)))
-
-    export PIO=/lcrc/soft/climate/compass/chrysalis/compass-1.0.0/scorpio-1.1.6/gnu/openmpi
-    export ESMF=/lcrc/soft/climate/compass/chrysalis/compass-1.0.0/esmf-8.0.1/gnu/openmpi
-
-    export AUTOCLEAN=true
-    export USE_PIO2=true
-    export HDF5_USE_FILE_LOCKING=FALSE
+    source /lcrc/soft/climate/compass/chrysalis/load_compass1.0.0_gnu_openmpi.sh
 
 To build the MPAS model with
 

--- a/docs/users_guide/machines/cori.rst
+++ b/docs/users_guide/machines/cori.rst
@@ -130,67 +130,12 @@ And here are the same for ``-m cori-knl``:
 cori-haswell, gnu
 -----------------
 
+To load the compass environment and modules, and set appropriate environment
+variables:
+
 .. code-block:: bash
 
-    module rm PrgEnv-intel
-    module rm PrgEnv-cray
-    module rm PrgEnv-gnu
-    module rm intel
-    module rm cce
-    module rm gcc
-    module rm cray-parallel-netcdf
-    module rm cray-hdf5-parallel
-    module rm pmi
-    module rm cray-libsci
-    module rm cray-mpich2
-    module rm cray-mpich
-    module rm cray-netcdf
-    module rm cray-hdf5
-    module rm cray-netcdf-hdf5parallel
-    module rm craype-sandybridge
-    module rm craype-ivybridge
-    module rm craype
-    module rm papi
-    module rm cmake
-    module rm cray-petsc
-    module rm esmf
-    module rm zlib
-    module rm craype-hugepages2M
-    module rm darshan
-    module load craype
-    module load PrgEnv-intel
-    module load cray-mpich
-    module rm craype-mic-knl
-    module load craype-haswell
-    module swap cray-mpich cray-mpich/7.7.10
-    module swap PrgEnv-intel PrgEnv-gnu/6.0.5
-    module rm gcc
-    module load gcc/8.3.0
-    module rm cray-libsci
-    module load cray-libsci/19.06.1
-    module swap craype craype/2.6.2
-    module rm pmi
-    module load pmi/5.0.14
-    module rm craype-mic-knl
-    module load craype-haswell
-    module rm cray-netcdf-hdf5parallel
-    module load cray-netcdf-hdf5parallel/4.6.3.2
-    module load cray-hdf5-parallel/1.10.5.2
-    module load cray-parallel-netcdf/1.11.1.1
-    module rm git
-    module load git
-    module rm cmake
-    module load cmake/3.14.4
-
-    export NETCDF=$NETCDF_DIR
-    export NETCDFF=$NETCDF_DIR
-    export PNETCDF=$PNETCDF_DIR
-
-    export PIO=/global/cfs/cdirs/e3sm/software/compass/cori-haswell/compass-1.0.0/scorpio-1.1.6/gnu/mpt
-
-    export AUTOCLEAN=true
-    export USE_PIO2=true
-    export HDF5_USE_FILE_LOCKING=FALSE
+    source /global/cfs/cdirs/e3sm/software/compass/cori-haswell/load_compass1.0.0_gnu_mpt.sh
 
 To build the MPAS model with
 
@@ -208,67 +153,12 @@ or
 cori-haswell, intel
 -------------------
 
+To load the compass environment and modules, and set appropriate environment
+variables:
+
 .. code-block:: bash
 
-    source /global/cfs/cdirs/e3sm/software/anaconda_envs/load_latest_compass.sh
-
-    module rm PrgEnv-intel
-    module rm PrgEnv-cray
-    module rm PrgEnv-gnu
-    module rm intel
-    module rm cce
-    module rm gcc
-    module rm cray-parallel-netcdf
-    module rm cray-hdf5-parallel
-    module rm pmi
-    module rm cray-libsci
-    module rm cray-mpich2
-    module rm cray-mpich
-    module rm cray-netcdf
-    module rm cray-hdf5
-    module rm cray-netcdf-hdf5parallel
-    module rm craype-sandybridge
-    module rm craype-ivybridge
-    module rm craype
-    module rm papi
-    module rm cmake
-    module rm cray-petsc
-    module rm esmf
-    module rm zlib
-    module rm craype-hugepages2M
-    module rm darshan
-    module load craype
-    module load PrgEnv-intel
-    module load cray-mpich
-    module rm craype-mic-knl
-    module load craype-haswell
-    module swap cray-mpich cray-mpich/7.7.10
-    module load PrgEnv-intel/6.0.5
-    module rm intel
-    module load intel/19.0.3.199
-    module swap craype craype/2.6.2
-    module rm pmi
-    module load pmi/5.0.14
-    module rm craype-mic-knl
-    module load craype-haswell
-    module rm cray-netcdf-hdf5parallel
-    module load cray-netcdf-hdf5parallel/4.6.3.2
-    module load cray-hdf5-parallel/1.10.5.2
-    module load cray-parallel-netcdf/1.11.1.1
-    module rm git
-    module load git
-    module rm cmake
-    module load cmake/3.14.4
-
-    export NETCDF_C_PATH=$NETCDF_DIR
-    export NETCDF_FORTRAN_PATH=$NETCDF_DIR
-    export PNETCDF_PATH=$PNETCDF_DIR
-
-    export PIO=/global/cfs/cdirs/e3sm/software/compass/cori-haswell/compass-1.0.0/scorpio-1.1.6/intel/mpt
-
-    export AUTOCLEAN=true
-    export USE_PIO2=true
-    export HDF5_USE_FILE_LOCKING=FALSE
+    source /global/cfs/cdirs/e3sm/software/compass/cori-haswell/load_compass1.0.0_intel_mpt.sh
 
 To build the MPAS model with
 
@@ -281,6 +171,53 @@ or
 .. code-block:: bash
 
     make CORE=ocean intel-nersc
+
+cori-knl, gnu
+-------------
+
+To load the compass environment and modules, and set appropriate environment
+variables:
+
+.. code-block:: bash
+
+    source /global/cfs/cdirs/e3sm/software/compass/cori-knl/load_compass1.0.0_gnu_mpt.sh
+
+To build the MPAS model with
+
+.. code-block:: bash
+
+    make CORE=landice gnu-nersc
+
+or
+
+.. code-block:: bash
+
+    make CORE=ocean gnu-nersc
+
+
+cori-knl, intel
+---------------
+
+To load the compass environment and modules, and set appropriate environment
+variables:
+
+.. code-block:: bash
+
+    source /global/cfs/cdirs/e3sm/software/compass/cori-knl/load_compass1.0.0_intel_impi.sh
+
+To build the MPAS model with
+
+.. code-block:: bash
+
+    make CORE=landice intel-nersc
+
+or
+
+.. code-block:: bash
+
+    make CORE=ocean intel-nersc
+
+
 
 Jupyter notebook on remote data
 -------------------------------

--- a/docs/users_guide/machines/grizzly.rst
+++ b/docs/users_guide/machines/grizzly.rst
@@ -131,33 +131,12 @@ setting up test cases or a test suite:
 grizzly, gnu
 ------------
 
+To load the compass environment and modules, and set appropriate environment
+variables:
+
 .. code-block:: bash
 
-    source /usr/projects/climate/SHARED_CLIMATE/anaconda_envs/load_latest_compass.sh
-
-    module purge
-    module load cmake/3.16.2
-    module load gcc/6.4.0
-    module load mvapich2/2.3
-    module load friendly-testing
-    module load hdf5-parallel/1.8.16
-    module load pnetcdf/1.11.2
-    module load netcdf-h5parallel/4.7.3
-    module load mkl/2019.0.4
-
-    export NETCDF=$(dirname $(dirname $(which nc-config)))
-    export NETCDFF=$(dirname $(dirname $(which nf-config)))
-    export PNETCDF=$(dirname $(dirname $(which pnetcdf-config)))
-
-    export PIO=/usr/projects/climate/SHARED_CLIMATE/compass/grizzly/compass-1.0.0/scorpio-1.1.6/gnu/mvapich
-    export ESMF=/usr/projects/climate/SHARED_CLIMATE/compass/grizzly/compass-1.0.0/esmf-8.1.0/gnu/mvapich
-
-    export MV2_ENABLE_AFFINITY=0
-    export MV2_SHOW_CPU_BINDING=1
-
-    export AUTOCLEAN=true
-    export USE_PIO2=true
-    export HDF5_USE_FILE_LOCKING=FALSE
+    source /usr/projects/climate/SHARED_CLIMATE/compass/badger/load_compass1.0.0_gnu_mvapich.sh
 
 To build the MPAS model with
 
@@ -174,28 +153,12 @@ or
 grizzly, intel
 --------------
 
+To load the compass environment and modules, and set appropriate environment
+variables:
+
 .. code-block:: bash
 
-    module purge
-    module load cmake/3.16.2
-    module load intel/19.0.4
-    module load intel-mpi/2019.4
-    module load friendly-testing
-    module load hdf5-parallel/1.8.16
-    module load pnetcdf/1.11.2
-    module load netcdf-h5parallel/4.7.3
-    module load mkl/2019.0.4
-
-    export NETCDF=$(dirname $(dirname $(which nc-config)))
-    export NETCDFF=$(dirname $(dirname $(which nf-config)))
-    export PNETCDF=$(dirname $(dirname $(which pnetcdf-config)))
-
-    export PIO=/usr/projects/climate/SHARED_CLIMATE/compass/grizzly/compass-1.0.0/scorpio-1.1.6/intel/impi
-    export ESMF=/usr/projects/climate/SHARED_CLIMATE/compass/grizzly/compass-1.0.0/esmf-8.1.0/intel/impi
-
-    export AUTOCLEAN=true
-    export USE_PIO2=true
-    export HDF5_USE_FILE_LOCKING=FALSE
+    source /usr/projects/climate/SHARED_CLIMATE/compass/badger/load_compass1.0.0_intel_impi.sh
 
 To build the MPAS model with
 

--- a/docs/users_guide/machines/index.rst
+++ b/docs/users_guide/machines/index.rst
@@ -78,6 +78,19 @@ Here are some basic commands:
 Supported Machines
 ------------------
 
+Compass 1.0.0 has not yet been released.  The documentation for supported
+machines is what we anticipate once the release has occurred.  Developers or
+users working off of the `master <https://github.com/MPAS-Dev/compass/tree/master>`_
+branch (as opposed to a ``compass`` release), you should look at the
+developer's guide on :ref:`dev_supported_machines`.
+
+the approach that will be used to activate a conda
+environment with the ``compass`` package
+load modules We have activation scripts, typically for two compiler flavors, on each
+supported machine.  These scripts will first load the conda environment for
+``compass``, then it will load modules and set environment variables that will
+allow you to build and run the MPAS model.
+
 .. toctree::
    :titlesonly:
 

--- a/load/get_activation_script.py
+++ b/load/get_activation_script.py
@@ -54,7 +54,7 @@ if __name__ == '__main__':
             machine = 'cori-haswell'
         elif hostname.startswith('blueslogin'):
             machine = 'anvil'
-        elif hostname.startswith('chrysalis'):
+        elif hostname.startswith('chrlogin'):
             machine = 'chrysalis'
         elif hostname.startswith('compy'):
             machine = 'compy'

--- a/load/get_activation_script.py
+++ b/load/get_activation_script.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python
+
+import os
+import argparse
+import sys
+import re
+import configparser
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(
+        description='Deploy a compass conda environment')
+    parser.add_argument("-m", "--machine", dest="machine", required=True,
+                        help="The name of the machine")
+    parser.add_argument("-c", "--compiler", dest="compiler", type=str,
+                        help="The name of the compiler")
+    parser.add_argument("-i", "--mpi", dest="mpi", type=str,
+                        help="The MPI library")
+
+    args = parser.parse_args(sys.argv[1:])
+
+    here = os.path.abspath(os.path.dirname(__file__))
+    with open(os.path.join(here, '..', 'compass', '__init__.py')) as f:
+        init_file = f.read()
+
+    version = re.search(r'{}\s*=\s*[(]([^)]*)[)]'.format('__version_info__'),
+                        init_file).group(1).replace(', ', '.')
+
+    default_config = os.path.join(here, '..', 'compass', 'default.cfg')
+    config = configparser.ConfigParser(
+        interpolation=configparser.ExtendedInterpolation())
+    config.read(default_config)
+    machine = args.machine
+    machine_config = os.path.join(here, '..', 'compass', 'machines',
+                                  '{}.cfg'.format(machine))
+    config.read(machine_config)
+
+    if args.compiler is not None:
+        compiler = args.compiler
+    else:
+        compiler = config.get('deploy', 'compiler')
+
+    if args.mpi is not None:
+        mpi = args.mpi
+    else:
+        mpi = config.get('deploy', 'mpi_{}'.format(compiler))
+
+    suffix = '_{}_{}'.format(compiler, mpi)
+
+    base_path = config.get('paths', 'compass_envs')
+    activ_path = os.path.abspath(os.path.join(base_path, '..'))
+
+    script_filename = '{}/test_compass{}{}.sh'.format(
+        activ_path, version, suffix)
+
+    print(script_filename)

--- a/load/get_activation_script.py
+++ b/load/get_activation_script.py
@@ -1,12 +1,24 @@
 #!/usr/bin/env python
 
+from __future__ import print_function
+
 import os
 import argparse
 import sys
 import re
-import configparser
 import socket
 import warnings
+
+try:
+    from configparser import ConfigParser
+except ImportError:
+    from six.moves import configparser
+    import six
+
+    if six.PY2:
+        ConfigParser = configparser.SafeConfigParser
+    else:
+        ConfigParser = configparser.ConfigParser
 
 
 if __name__ == '__main__':
@@ -29,8 +41,7 @@ if __name__ == '__main__':
                         init_file).group(1).replace(', ', '.')
 
     default_config = os.path.join(here, '..', 'compass', 'default.cfg')
-    config = configparser.ConfigParser(
-        interpolation=configparser.ExtendedInterpolation())
+    config = ConfigParser()
     config.read(default_config)
 
     if args.machine is not None:

--- a/load/load_compass_env.sh
+++ b/load/load_compass_env.sh
@@ -1,8 +1,11 @@
 #!/bin/bash
 
-script=$(./load/get_activation_script.py "$@")
-if [ $? -eq 0 ]
+./load/get_activation_script.py "$@"
+
+if [ -f ./load/tmp_script_name ]
 then
+  script=$(cat ./load/tmp_script_name)
+  rm ./load/tmp_script_name
   echo "sourcing: ${script}"
   source ${script}
 fi

--- a/load/load_compass_env.sh
+++ b/load/load_compass_env.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 
 script=$(./load/get_activation_script.py "$@")
+if [ $? -eq 0 ]
+then
+  echo "sourcing: ${script}"
+  source ${script}
+fi
 
-echo "sourcing: ${script}"
-source ${script}

--- a/load/load_compass_env.sh
+++ b/load/load_compass_env.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+script=$(./load/get_activation_script.py "$@")
+
+echo "sourcing: ${script}"
+source ${script}


### PR DESCRIPTION
This merge adds many features related 
* making activation scripts that 
  * activate the ``compass`` conda environment
  * loading modules
  * setting environment variables (`NETCDF`, `PIO`, etc.)
* Use E3SM compilers and MPI libraries on each machine to build:
  * ESMF (needed to make mapping files efficiently)
  * SCORPIO
* Documenting these chnages
* Updating the user's guide to make clearer that the instructions won't work yet (not until we have a 1.0.0 release).

As I added to the documentation, with these changes, a developer should now be able to run:
```
source ./load/load_compass_env.sh -m <machine> -c <compiler>
```
in the local compass branch to active the appropriate compass test environment as well as load the system modules and set the environment variables needed to build MPAS in standalone.  This always includes setting the environment variable to point to a SCORPIO build.

I have build SCORPIO on all machines with all compiler/MPI combinations I intend to support.  I have also build ESMF on all machines and compilers except Cori (no luck there so Cori will use the serial conda-forge version).

You no longer need the `-m <machine>` flag in `python -m compass setup` or `python -m compass suite`.  It knows what machine you are on because of the source command above.

When you set up a test case or suite, there will be a local link to the the environment activation script.  All you have to do there is:
```
source load_compass_env.sh
```
It already knows what machine and what compilers you asked for.

