### PR TITLE
Require ESMF to run with system MPI 

### DIFF
--- a/compass/ocean/suites/sowisc12to60.txt
+++ b/compass/ocean/suites/sowisc12to60.txt
@@ -1,0 +1,5 @@
+ocean/global_ocean/SOwISC12to60/mesh
+ocean/global_ocean/SOwISC12to60/PHC/init
+ocean/global_ocean/SOwISC12to60/PHC/performance_test
+ocean/global_ocean/SOwISC12to60/PHC/dynamic_adjustment
+ocean/global_ocean/SOwISC12to60/PHC/files_for_e3sm

--- a/compass/ocean/tests/global_ocean/files_for_e3sm/diagnostics_files.py
+++ b/compass/ocean/tests/global_ocean/files_for_e3sm/diagnostics_files.py
@@ -151,12 +151,8 @@ def _make_analysis_lat_lon_map(config, mesh_name, cores, logger):
                                            dLat=comparisonLonResolution)
     outGridName = outDescriptor.meshName
 
-    mappingFileName = 'map_{}_to_{}_bilinear.nc'.format(mesh_name, outGridName)
-
-    remapper = Remapper(inDescriptor, outDescriptor, mappingFileName)
-
-    remapper.build_mapping_file(method='bilinear', mpiTasks=cores, tempdir='.',
-                                logger=logger)
+    _make_mapping_file(mesh_name, outGridName, inDescriptor, outDescriptor,
+                       cores, config, logger)
 
 
 def _make_analysis_polar_map(config, mesh_name, projection, cores, logger):
@@ -181,12 +177,22 @@ def _make_analysis_polar_map(config, mesh_name, projection, cores, logger):
         comparisonStereoWidth,  comparisonStereoWidth,
         comparisonStereoResolution, upperProj)
 
+    _make_mapping_file(mesh_name, outGridName, inDescriptor, outDescriptor,
+                       cores, config, logger)
+
+
+def _make_mapping_file(mesh_name, outGridName, inDescriptor, outDescriptor,
+                       cores, config, logger):
+
+    parallel_executable = config.get('parallel', 'parallel_executable')
+
     mappingFileName = 'map_{}_to_{}_bilinear.nc'.format(mesh_name, outGridName)
 
     remapper = Remapper(inDescriptor, outDescriptor, mappingFileName)
 
     remapper.build_mapping_file(method='bilinear', mpiTasks=cores, tempdir='.',
-                                logger=logger)
+                                logger=logger,
+                                esmf_parallel_exec=parallel_executable)
 
 
 def _make_moc_masks(mesh_short_name, logger):

--- a/deploy/create_compass_env.py
+++ b/deploy/create_compass_env.py
@@ -410,6 +410,9 @@ def main():
         if esmf != 'None':
             sys_info['env_vars'].append('export PATH="{}:$PATH"'.format(
                 os.path.join(esmf_path, 'bin')))
+            sys_info['env_vars'].append(
+                'export LD_LIBRARY_PATH={}:$LD_LIBRARY_PATH'.format(
+                    os.path.join(esmf_path, 'lib')))
 
         if scorpio != 'None':
             sys_info['env_vars'].append('export PIO={}'.format(scorpio_path))


### PR DESCRIPTION
For systems that work with conda-forge MPI, this should work as normal as long as they use `mpi_run` as their `parallel_executable`.

For supported machines, ESMF will be built as part of deploying compass, and should run with the system libraries that are also used to build MPAS.

This merge adds the ESMF library to the `LD_LIBRARY_PATH` in the activation script.  Testing this PR revealed this problem at least on Anvil.

This merge adds a test suite for the `SOwISC12to60`.  This is for convenience of running the 4 test cases associated with creating an E3SM initial condition (and the performance test case) all in one command, just as with the `EC*30to60` meshes.

closes #58 