### PR TITLE
Added a case to validate the implementation of suspended sediment as a tracer

### DIFF
--- a/ocean/regression_suites/nightly.xml
+++ b/ocean/regression_suites/nightly.xml
@@ -53,4 +53,7 @@
 	<test name="Periodic Planar 20km - LIGHT particle time reset test" core="ocean" configuration="periodic_planar" resolution="20km" test="time_reset_light_test">
 		<script name="run_test.py"/>
 	</test>
+	<test name="Sediment 100m - Tracer regression test" core="ocean" configuration="sediment" resolution="100m" test="tracer_regression">
+		<script name="run_test.py"/>
+	</test>
 </regression_suite>

--- a/ocean/sediment/100m/tracer_advection_diffusion/config_driver.xml
+++ b/ocean/sediment/100m/tracer_advection_diffusion/config_driver.xml
@@ -1,0 +1,8 @@
+<driver_script name="run_test.py">
+	<case name="init">
+		<step executable="./run.py" quiet="true" pre_message=" * Running init" post_message="     Complete"/>
+	</case>
+	<case name="forward">
+		<step executable="./run.py" quiet="true" pre_message=" * Running forward" post_message="     Complete"/>
+	</case>
+</driver_script>

--- a/ocean/sediment/100m/tracer_advection_diffusion/config_forward.xml
+++ b/ocean/sediment/100m/tracer_advection_diffusion/config_forward.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0"?>
+<config case="forward">
+	<add_link source="../init/ocean.nc" dest="init.nc"/>
+	<add_link source="../init/mesh.nc" dest="mesh.nc"/>
+	<add_link source="../init/graph.info" dest="graph.info"/>
+	<copy_file source_path="script_test_dir" source="gotmturb.nml" dest="gotmturb.nml"/>
+
+	<add_executable source="model" dest="ocean_model"/>
+
+	<namelist name="namelist.ocean" mode="forward">
+		<option name="config_ocean_run_mode">'forward'</option>
+		<option name="config_dt">'00:00:10'</option>
+		<option name="config_time_integrator">'RK4'</option>
+		<option name="config_run_duration">'0006_00:00:00'</option>
+		<option name="config_disable_tr_adv">.false.</option>
+		<option name="config_use_debugTracers">.true.</option>
+		<option name="config_use_sedimentTracers">.true.</option>
+		<option name="config_use_mom_del2">.true.</option>
+		<option name="config_mom_del2">1.0e-2</option>
+		<option name="config_use_tracer_del2">.true.</option>
+		<option name="config_tracer_del2">10.0</option>
+		<option name="config_use_cvmix">.false.</option>
+		<option name="config_use_gotm">.true.</option>
+		<option name="config_gotm_namelist_file">'gotmturb.nml'</option>
+		<option name="config_gotm_constant_bottom_roughness_length">5.0e-3</option>
+		<option name="config_gotm_constant_bottom_drag_coeff">1.73e-2</option>
+		<option name="config_use_implicit_bottom_drag">.true.</option>
+		<option name="config_implicit_bottom_drag_coeff">1.73e-2</option>
+	</namelist>
+
+	<streams name="streams.ocean" keep="immutable" mode="forward">
+		<stream name="mesh">
+			<attribute name="filename_template">mesh.nc</attribute>
+		</stream>
+		<stream name="input">
+			<attribute name="filename_template">init.nc</attribute>
+		</stream>
+		<stream name="output">
+			<attribute name="type">output</attribute>
+			<attribute name="filename_template">output.nc</attribute>
+			<attribute name="output_interval">0000-00-00_01:00:00</attribute>
+			<attribute name="clobber_mode">truncate</attribute>
+			<add_contents>
+				<member name="tracers" type="var_struct"/>
+				<member name="velocityZonal" type="var"/>
+				<member name="velocityMeridional" type="var"/>
+				<member name="normalVelocity" type="var"/>
+				<member name="mesh" type="stream"/>
+				<member name="xtime" type="var"/>
+				<member name="layerThickness" type="var"/>
+			</add_contents>
+		</stream>
+	</streams>
+
+	<run_script name="run.py">
+		<step executable="gpmetis">
+			<argument flag="graph.info">2</argument>
+		</step>
+		<model_run procs="2" threads="1" namelist="namelist.ocean" streams="streams.ocean"/>
+	</run_script>
+</config>

--- a/ocean/sediment/100m/tracer_advection_diffusion/config_init.xml
+++ b/ocean/sediment/100m/tracer_advection_diffusion/config_init.xml
@@ -1,0 +1,68 @@
+<?xml version="1.0"?>
+<config case="init">
+	<add_executable source="model" dest="ocean_model"/>
+	<namelist name="namelist.ocean" mode="init">
+		<option name="config_ocean_run_mode">'init'</option>
+		<option name="config_init_configuration">'lock_exchange'</option>
+		<option name="config_vert_levels">-1</option>
+		<option name="config_write_cull_cell_mask">.true.</option>
+		<option name="config_use_debugTracers">.true.</option>
+		<option name="config_use_sedimentTracers">.true.</option>
+		<option name="config_lock_exchange_direction">'y'</option>
+		<option name="config_lock_exchange_vert_levels">50</option>
+		<option name="config_lock_exchange_bottom_depth">10.0</option>
+		<option name="config_lock_exchange_warm_temperature">30.0</option>
+		<option name="config_lock_exchange_cold_temperature">10.0</option>
+		<option name="config_lock_exchange_high_sedConcen">10.0</option>
+		<option name="config_lock_exchange_low_sedConcen">0.0</option>
+		<option name="config_lock_exchange_high_tracer">10.0</option>
+		<option name="config_lock_exchange_low_tracer">0.0</option>
+	</namelist>
+
+	<streams name="streams.ocean" keep="immutable" mode="init">
+		<stream name="input_init">
+			<attribute name="filename_template">mesh.nc</attribute>
+		</stream>
+		<stream name="output_init">
+			<attribute name="type">output</attribute>
+			<attribute name="output_interval">0000-00-00_00:00:01</attribute>
+			<attribute name="clobber_mode">truncate</attribute>
+			<attribute name="filename_template">ocean.nc</attribute>
+			<add_contents>
+				<member name="input_init" type="stream"/>
+				<member name="tracers" type="var_struct"/>
+				<member name="refZMid" type="var"/>
+				<member name="normalVelocity" type="var"/>
+				<member name="layerThickness" type="var"/>
+				<member name="restingThickness" type="var"/>
+				<member name="refBottomDepth" type="var"/>
+				<member name="bottomDepth" type="var"/>
+				<member name="minLevelCell" type="var"/>
+				<member name="maxLevelCell" type="var"/>
+				<member name="vertCoordMovementWeights" type="var"/>
+				<member name="edgeMask" type="var"/>
+				<member name="cullCell" type="var"/>
+			</add_contents>
+		</stream>
+	</streams>
+
+	<run_script name="run.py">
+		<step executable="planar_hex">
+			<argument flag="--nx">4</argument>
+			<argument flag="--ny">50</argument>
+			<argument flag="--dc">100.0</argument>
+			<argument flag="--npy"></argument>
+			<argument flag="-o">grid.nc</argument>
+		</step>
+		<step executable="MpasCellCuller.x">
+			<argument flag="">grid.nc</argument>
+			<argument flag="">culled_mesh.nc</argument>
+		</step>
+		<step executable="MpasMeshConverter.x">
+			<argument flag="">culled_mesh.nc</argument>
+			<argument flag="">mesh.nc</argument>
+		</step>
+		<model_run procs="1" threads="1" namelist="namelist.ocean" streams="streams.ocean"/>
+	</run_script>
+
+</config>

--- a/ocean/sediment/100m/tracer_advection_diffusion/gotmturb.nml
+++ b/ocean/sediment/100m/tracer_advection_diffusion/gotmturb.nml
@@ -1,0 +1,400 @@
+!-------------------------------------------------------------------------------
+! general
+!-------------------------------------------------------------------------------
+! turb_method      [integer]
+!                    type of turbulence closure
+!                    0: convective adjustment
+!                    1: analytical eddy visc. and diff. profiles, not coded yet
+!                    2: turbulence Model calculating TKE and length scale
+!                    3: second-order model
+!                    98: OSMOSIS model
+!                    99: KPP model
+!                    100: MOM turbulence model
+! tke_method       [integer]
+!                    type of equation for TKE
+!                    1: algebraic equation
+!                    2: dynamic equation (k-epsilon style)
+!                    3: dynamic equation (Mellor-Yamada style)
+!                    4: dynamic equation with Stokes production (Kantha and
+!                      Clayson, 2004)
+!                    This variable is only used if (turb_method = 2 or
+!                      turb_method = 3)
+! len_scale_method [integer]
+!                    type of model for dissipative length scale
+!                    1: parabolic shape
+!                    2: triangle shape
+!                    3: Xing and Davies [1995]
+!                    4: Robert and Ouellet [1987]
+!                    5: Blackadar (two boundaries) [1962]
+!                    6: Bougeault and Andre [1986]
+!                    7: Eifler and Schrimpf (ISPRAMIX) [1992]
+!                    8: dynamic dissipation rate equation
+!                    9: dynamic Mellor-Yamada q^2l-equation
+!                    10: generic length scale (GLS)
+!                    This variable is only used if (turb_method = 2 or
+!                      turb_method = 3)
+! stab_method      [integer]
+!                    type of stability function
+!                    1: constant stability functions
+!                    2: Munk and Anderson [1954]
+!                    3: Schumann and Gerz [1995]
+!                    4: Eifler and Schrimpf [1992]
+!                    This variable is only used if turb_method = 2
+!-------------------------------------------------------------------------------
+
+&turbulence
+   turb_method = 3,
+   tke_method = 2,
+   len_scale_method = 10,
+   stab_method = 1,
+/
+
+!-------------------------------------------------------------------------------
+! boundary conditions
+!-------------------------------------------------------------------------------
+! k_ubc    [integer]
+!            upper boundary condition for k-equation
+!            0: prescribed BC
+!            1: flux BC
+! k_lbc    [integer]
+!            lower boundary condition for k-equation
+!            0: prescribed BC
+!            1: flux BC
+! psi_ubc  [integer]
+!            upper boundary condition for the length-scale equation (e.g.
+!              epsilon, kl, omega, GLS)
+!            0: prescribed BC
+!            1: flux BC
+! psi_lbc  [integer]
+!            lower boundary condition for the length-scale equation (e.g.
+!              epsilon, kl, omega, GLS)
+!            0: prescribed BC
+!            1: flux BC
+! ubc_type [integer]
+!            type of upper boundary layer
+!            0: viscous sublayer (not yet impl.)
+!            1: logarithmic law of the wall
+!            2: tke-injection (breaking waves)
+! lbc_type [integer]
+!            type of lower boundary layer
+!            0: viscous sublayer (not yet impl.)
+!            1: logarithmic law of the wall
+!-------------------------------------------------------------------------------
+
+&bc
+   k_ubc = 1,
+   k_lbc = 1,
+   psi_ubc = 1,
+   psi_lbc = 1,
+   ubc_type = 1,
+   lbc_type = 1,
+/
+
+!-------------------------------------------------------------------------------
+! turbulence parameters
+!-------------------------------------------------------------------------------
+! cm0_fix       [float]
+!                 value of cm0
+!                 This variable is only used if /gotmturb/turbulence/turb_method
+!                   = 2
+! Prandtl0_fix  [float]
+!                 value of the turbulent Prandtl-number
+!                 This variable is only used if /gotmturb/turbulence/turb_method
+!                   = 2
+! cw            [float]
+!                 constant of the wave-breaking model (Craig & Banner (1994) use
+!                   cw=100)
+! compute_kappa [bool]
+!                 compute von Karman constant from model parameters
+! kappa         [float]
+!                 the desired von Karman constant
+!                 This variable is only used if compute_kappa = True
+! compute_c3    [bool]
+!                 compute c3 (E3 for Mellor-Yamada) for given Ri_st
+! Ri_st         [float]
+!                 the desired steady-state Richardson number
+!                 This variable is only used if compute_c3 = True
+! length_lim    [bool]
+!                 apply length scale limitation (see Galperin et al. 1988)
+! galp          [float]
+!                 coef. for length scale limitation
+!                 This variable is only used if length_lim = True
+! const_num     [float, unit = m^2/s]
+!                 minimum eddy diffusivity
+!                 This variable is only used if /gotmturb/turbulence/turb_method
+!                   = 0
+! const_nuh     [float, unit = m^2/s]
+!                 minimum heat diffusivity
+!                 This variable is only used if /gotmturb/turbulence/turb_method
+!                   = 0
+! k_min         [float, unit = m^2/s^2]
+!                 minimum TKE
+! eps_min       [float, unit = m^2/s^3]
+!                 minimum dissipation rate
+! kb_min        [float, unit = m^2/s^4]
+!                 minimum buoyancy variance
+! epsb_min      [float, unit = m^2/s^5]
+!                 minimum buoyancy variance destruction rate
+!-------------------------------------------------------------------------------
+
+&turb_param
+   cm0_fix = 0.5477,
+   Prandtl0_fix = 0.74,
+   cw = 100.0,
+   compute_kappa = .false.,
+   kappa = 0.4,
+   compute_c3 = .false.,
+   Ri_st = 0.25,
+   length_lim = .false.,
+   galp = 0.53,
+   const_num = 0.0005,
+   const_nuh = 0.0005,
+   k_min = 1e-10,
+   eps_min = 1e-12,
+   kb_min = 1e-10,
+   epsb_min = 1e-14,
+/
+
+!-------------------------------------------------------------------------------
+! the generic model (Umlauf & Burchard, J. Mar. Res., 2003)
+!-------------------------------------------------------------------------------
+! compute_param [bool]
+!                 compute the model parameters
+! gen_m         [float]
+!                 exponent for k
+! gen_n         [float]
+!                 exponent for l
+!                 This variable is only used if compute_param = False
+! gen_p         [float]
+!                 exponent for cm0
+!                 This variable is only used if compute_param = False
+! cpsi1         [float]
+!                 emp. coef. cpsi1 in psi equation
+!                 This variable is only used if compute_param = False
+! cpsi2         [float]
+!                 emp. coef. cpsi2 in psi equation
+!                 This variable is only used if compute_param = False
+! cpsi3minus    [float]
+!                 cpsi3 for stable stratification
+!                 This variable is only used if compute_param = False
+! cpsi3plus     [float]
+!                 cpsi3 for unstable stratification
+!                 This variable is only used if compute_param = False
+! sig_kpsi      [float]
+!                 Schmidt number for TKE diffusivity
+!                 This variable is only used if compute_param = False
+! sig_psi       [float]
+!                 Schmidt number for psi diffusivity
+!                 This variable is only used if compute_param = False
+! gen_d         [float]
+!                 gen_d
+!                 This variable is only used if compute_param = False
+! gen_alpha     [float]
+!                 gen_alpha
+!                 This variable is only used if compute_param = False
+! gen_l         [float]
+!                 gen_l
+!                 This variable is only used if compute_param = False
+!-------------------------------------------------------------------------------
+
+&generic
+   compute_param = .false.,
+   gen_m = 1.5,
+   gen_n = -1.0,
+   gen_p = 3.0,
+   cpsi1 = 1.44,
+   cpsi2 = 1.92,
+   cpsi3minus = -0.63,
+   cpsi3plus = 1.0,
+   sig_kpsi = 1.0,
+   sig_psi = 1.3,
+   gen_d = -1.2,
+   gen_alpha = -2.0,
+   gen_l = 0.2,
+/
+
+!-------------------------------------------------------------------------------
+! the k-epsilon model (Rodi 1987)
+!-------------------------------------------------------------------------------
+! ce1      [float]
+!            emp. coef. ce1 in diss. eq.
+! ce2      [float]
+!            emp. coef. ce2 in diss. eq.
+! ce3minus [float]
+!            ce3 for stable stratification
+!            This variable is not used if /gotmturb/turb_param/compute_c3 = True
+! ce3plus  [float]
+!            ce3 for unstable stratification (Rodi 1987: ce3plus=1.0)
+! sig_k    [float]
+!            Schmidt number for TKE diffusivity
+! sig_e    [float]
+!            Schmidt number for diss. diffusivity
+! sig_peps [bool]
+!            if .true. -> the wave breaking parameterisation suggested by
+!              Burchard (JPO 31, 2001, 3133-3145) will be used.
+!-------------------------------------------------------------------------------
+
+&keps
+   ce1 = 1.44,
+   ce2 = 1.92,
+   ce3minus = 0.0,
+   ce3plus = 1.0,
+   sig_k = 1.0,
+   sig_e = 1.3,
+   sig_peps = .false.,
+/
+
+!-------------------------------------------------------------------------------
+! the Mellor-Yamada model (Mellor & Yamada 1982)
+!-------------------------------------------------------------------------------
+! e1         [float]
+!              coef. e1 in MY q**2 l equation
+! e2         [float]
+!              coef. e2 in MY q**2 l equation
+! e3         [float]
+!              coef. e3 in MY q**2 l equation
+! sq         [float]
+!              turbulent diffusivities of q**2 (= 2k)
+! sl         [float]
+!              turbulent diffusivities of q**2 l
+! my_length  [integer]
+!              prescribed barotropic lengthscale in q**2 l equation of MY
+!              1: parabolic
+!              2: triangular
+!              3: lin. from surface
+! new_constr [bool]
+!              stabilisation of Mellor-Yamada stability functions according to
+!                Burchard & Deleersnijder (2001)
+!-------------------------------------------------------------------------------
+
+&my
+   e1 = 1.8,
+   e2 = 1.33,
+   e3 = 1.8,
+   sq = 0.2,
+   sl = 0.2,
+   my_length = 1,
+   new_constr = .false.,
+/
+
+!-------------------------------------------------------------------------------
+! the second-order model
+!-------------------------------------------------------------------------------
+! scnd_method [integer]
+!               type of second-order model
+!               1: EASM with quasi-equilibrium
+!               2: EASM with weak equilibrium, buoy.-variance algebraic
+!               3: EASM with weak equilibrium, buoy.-variance from PDE
+! kb_method   [integer]
+!               type of equation for buoyancy variance
+!               1: algebraic equation for buoyancy variance
+!               2: PDE for buoyancy variance
+! epsb_method [integer]
+!               type of equation for variance destruction
+!               1: algebraic equation for variance destruction
+!               2: PDE for variance destruction
+! scnd_coeff  [integer]
+!               coefficients of second-order model
+!               0: read the coefficients from this file
+!               1: coefficients of Gibson and Launder (1978)
+!               2: coefficients of Mellor and Yamada (1982)
+!               3: coefficients of Kantha and Clayson (1994)
+!               4: coefficients of Luyten et al. (1996)
+!               5: coefficients of Canuto et al. (2001) (version A)
+!               6: coefficients of Canuto et al. (2001) (version B)
+!               7: coefficients of Cheng et al. (2002)
+! cc1         [float]
+!               coefficient cc1
+!               This variable is only used if scnd_coeff = 0
+! cc2         [float]
+!               coefficient cc2
+!               This variable is only used if scnd_coeff = 0
+! cc3         [float]
+!               coefficient cc3
+!               This variable is only used if scnd_coeff = 0
+! cc4         [float]
+!               coefficient cc4
+!               This variable is only used if scnd_coeff = 0
+! cc5         [float]
+!               coefficient cc5
+!               This variable is only used if scnd_coeff = 0
+! cc6         [float]
+!               coefficient cc6
+!               This variable is only used if scnd_coeff = 0
+! ct1         [float]
+!               coefficient ct1
+!               This variable is only used if scnd_coeff = 0
+! ct2         [float]
+!               coefficient ct2
+!               This variable is only used if scnd_coeff = 0
+! ct3         [float]
+!               coefficient ct3
+!               This variable is only used if scnd_coeff = 0
+! ct4         [float]
+!               coefficient ct4
+!               This variable is only used if scnd_coeff = 0
+! ct5         [float]
+!               coefficient ct5
+!               This variable is only used if scnd_coeff = 0
+! ctt         [float]
+!               coefficient ctt
+!               This variable is only used if scnd_coeff = 0
+!-------------------------------------------------------------------------------
+
+&scnd
+   scnd_method = 2,
+   kb_method = 1,
+   epsb_method = 1,
+   scnd_coeff = 5,
+   cc1 = 3.6,
+   cc2 = 0.8,
+   cc3 = 1.2,
+   cc4 = 1.2,
+   cc5 = 0.0,
+   cc6 = 0.3,
+   ct1 = 3.28,
+   ct2 = 0.4,
+   ct3 = 0.4,
+   ct4 = 0.0,
+   ct5 = 0.4,
+   ctt = 0.8,
+/
+
+!-------------------------------------------------------------------------------
+! internal wave model
+!-------------------------------------------------------------------------------
+! iw_model [integer]
+!            method to compute internal wave mixing
+!            0: no internal wave mixing parameterisation
+!            1: Mellor 1989 internal wave mixing
+!            2: Large et al. 1994 internal wave mixing
+! alpha    [float]
+!            coeff. for Mellor IWmodel (0: no IW, 0.7 Mellor 1989)
+!            This variable is only used if iw_model = 1
+! klimiw   [float, unit = m**2/s**2]
+!            critical value of TKE
+!            This variable is only used if iw_model = 2
+! rich_cr  [float]
+!            critical Richardson number for shear instability
+!            This variable is only used if iw_model = 2
+! numshear [float, unit = m**2/s]
+!            background diffusivity for shear instability
+!            This variable is only used if iw_model = 2
+! numiw    [float, unit = m**2/s]
+!            background viscosity for internal wave breaking
+!            This variable is only used if iw_model = 2
+! nuhiw    [float, unit = m**2/s]
+!            background diffusivity for internal wave breaking
+!            This variable is only used if iw_model = 2
+!-------------------------------------------------------------------------------
+
+&iw
+   iw_model = 0,
+   alpha = 0.0,
+   klimiw = 1e-06,
+   rich_cr = 0.7,
+   numshear = 0.005,
+   numiw = 0.0001,
+   nuhiw = 1e-05,
+/
+

--- a/ocean/sediment/100m/tracer_diffusion/config_driver.xml
+++ b/ocean/sediment/100m/tracer_diffusion/config_driver.xml
@@ -1,0 +1,8 @@
+<driver_script name="run_test.py">
+	<case name="init">
+		<step executable="./run.py" quiet="true" pre_message=" * Running init" post_message="     Complete"/>
+	</case>
+	<case name="forward">
+		<step executable="./run.py" quiet="true" pre_message=" * Running forward" post_message="     Complete"/>
+	</case>
+</driver_script>

--- a/ocean/sediment/100m/tracer_diffusion/config_forward.xml
+++ b/ocean/sediment/100m/tracer_diffusion/config_forward.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0"?>
+<config case="forward">
+	<add_link source="../init/ocean.nc" dest="init.nc"/>
+	<add_link source="../init/mesh.nc" dest="mesh.nc"/>
+	<add_link source="../init/graph.info" dest="graph.info"/>
+	<copy_file source_path="script_test_dir" source="gotmturb.nml" dest="gotmturb.nml"/>
+
+	<add_executable source="model" dest="ocean_model"/>
+
+	<namelist name="namelist.ocean" mode="forward">
+		<option name="config_ocean_run_mode">'forward'</option>
+		<option name="config_dt">'00:00:10'</option>
+		<option name="config_time_integrator">'RK4'</option>
+		<option name="config_run_duration">'0006_00:00:00'</option>
+		<option name="config_disable_tr_adv">.true.</option>
+		<option name="config_use_debugTracers">.true.</option>
+		<option name="config_use_sedimentTracers">.true.</option>
+		<option name="config_use_mom_del2">.true.</option>
+		<option name="config_mom_del2">1.0e-2</option>
+		<option name="config_use_tracer_del2">.true.</option>
+		<option name="config_tracer_del2">10.0</option>
+		<option name="config_use_cvmix">.false.</option>
+		<option name="config_use_gotm">.true.</option>
+		<option name="config_gotm_namelist_file">'gotmturb.nml'</option>
+		<option name="config_gotm_constant_bottom_roughness_length">5.0e-3</option>
+		<option name="config_gotm_constant_bottom_drag_coeff">1.73e-2</option>
+		<option name="config_use_implicit_bottom_drag">.true.</option>
+		<option name="config_implicit_bottom_drag_coeff">1.73e-2</option>
+	</namelist>
+
+	<streams name="streams.ocean" keep="immutable" mode="forward">
+		<stream name="mesh">
+			<attribute name="filename_template">mesh.nc</attribute>
+		</stream>
+		<stream name="input">
+			<attribute name="filename_template">init.nc</attribute>
+		</stream>
+		<stream name="output">
+			<attribute name="type">output</attribute>
+			<attribute name="filename_template">output.nc</attribute>
+			<attribute name="output_interval">0000-00-00_01:00:00</attribute>
+			<attribute name="clobber_mode">truncate</attribute>
+			<add_contents>
+				<member name="tracers" type="var_struct"/>
+				<member name="velocityZonal" type="var"/>
+				<member name="velocityMeridional" type="var"/>
+				<member name="normalVelocity" type="var"/>
+				<member name="mesh" type="stream"/>
+				<member name="xtime" type="var"/>
+				<member name="layerThickness" type="var"/>
+			</add_contents>
+		</stream>
+	</streams>
+
+	<run_script name="run.py">
+		<step executable="gpmetis">
+			<argument flag="graph.info">2</argument>
+		</step>
+		<model_run procs="2" threads="1" namelist="namelist.ocean" streams="streams.ocean"/>
+	</run_script>
+</config>

--- a/ocean/sediment/100m/tracer_diffusion/config_init.xml
+++ b/ocean/sediment/100m/tracer_diffusion/config_init.xml
@@ -1,0 +1,68 @@
+<?xml version="1.0"?>
+<config case="init">
+	<add_executable source="model" dest="ocean_model"/>
+	<namelist name="namelist.ocean" mode="init">
+		<option name="config_ocean_run_mode">'init'</option>
+		<option name="config_init_configuration">'lock_exchange'</option>
+		<option name="config_vert_levels">-1</option>
+		<option name="config_write_cull_cell_mask">.true.</option>
+		<option name="config_use_debugTracers">.true.</option>
+		<option name="config_use_sedimentTracers">.true.</option>
+		<option name="config_lock_exchange_direction">'y'</option>
+		<option name="config_lock_exchange_vert_levels">50</option>
+		<option name="config_lock_exchange_bottom_depth">10.0</option>
+		<option name="config_lock_exchange_warm_temperature">30.0</option>
+		<option name="config_lock_exchange_cold_temperature">10.0</option>
+		<option name="config_lock_exchange_high_sedConcen">10.0</option>
+		<option name="config_lock_exchange_low_sedConcen">0.0</option>
+		<option name="config_lock_exchange_high_tracer">10.0</option>
+		<option name="config_lock_exchange_low_tracer">0.0</option>
+	</namelist>
+
+	<streams name="streams.ocean" keep="immutable" mode="init">
+		<stream name="input_init">
+			<attribute name="filename_template">mesh.nc</attribute>
+		</stream>
+		<stream name="output_init">
+			<attribute name="type">output</attribute>
+			<attribute name="output_interval">0000-00-00_00:00:01</attribute>
+			<attribute name="clobber_mode">truncate</attribute>
+			<attribute name="filename_template">ocean.nc</attribute>
+			<add_contents>
+				<member name="input_init" type="stream"/>
+				<member name="tracers" type="var_struct"/>
+				<member name="refZMid" type="var"/>
+				<member name="normalVelocity" type="var"/>
+				<member name="layerThickness" type="var"/>
+				<member name="restingThickness" type="var"/>
+				<member name="refBottomDepth" type="var"/>
+				<member name="bottomDepth" type="var"/>
+				<member name="minLevelCell" type="var"/>
+				<member name="maxLevelCell" type="var"/>
+				<member name="vertCoordMovementWeights" type="var"/>
+				<member name="edgeMask" type="var"/>
+				<member name="cullCell" type="var"/>
+			</add_contents>
+		</stream>
+	</streams>
+
+	<run_script name="run.py">
+		<step executable="planar_hex">
+			<argument flag="--nx">4</argument>
+			<argument flag="--ny">50</argument>
+			<argument flag="--dc">100.0</argument>
+			<argument flag="--npy"></argument>
+			<argument flag="-o">grid.nc</argument>
+		</step>
+		<step executable="MpasCellCuller.x">
+			<argument flag="">grid.nc</argument>
+			<argument flag="">culled_mesh.nc</argument>
+		</step>
+		<step executable="MpasMeshConverter.x">
+			<argument flag="">culled_mesh.nc</argument>
+			<argument flag="">mesh.nc</argument>
+		</step>
+		<model_run procs="1" threads="1" namelist="namelist.ocean" streams="streams.ocean"/>
+	</run_script>
+
+</config>

--- a/ocean/sediment/100m/tracer_diffusion/gotmturb.nml
+++ b/ocean/sediment/100m/tracer_diffusion/gotmturb.nml
@@ -1,0 +1,400 @@
+!-------------------------------------------------------------------------------
+! general
+!-------------------------------------------------------------------------------
+! turb_method      [integer]
+!                    type of turbulence closure
+!                    0: convective adjustment
+!                    1: analytical eddy visc. and diff. profiles, not coded yet
+!                    2: turbulence Model calculating TKE and length scale
+!                    3: second-order model
+!                    98: OSMOSIS model
+!                    99: KPP model
+!                    100: MOM turbulence model
+! tke_method       [integer]
+!                    type of equation for TKE
+!                    1: algebraic equation
+!                    2: dynamic equation (k-epsilon style)
+!                    3: dynamic equation (Mellor-Yamada style)
+!                    4: dynamic equation with Stokes production (Kantha and
+!                      Clayson, 2004)
+!                    This variable is only used if (turb_method = 2 or
+!                      turb_method = 3)
+! len_scale_method [integer]
+!                    type of model for dissipative length scale
+!                    1: parabolic shape
+!                    2: triangle shape
+!                    3: Xing and Davies [1995]
+!                    4: Robert and Ouellet [1987]
+!                    5: Blackadar (two boundaries) [1962]
+!                    6: Bougeault and Andre [1986]
+!                    7: Eifler and Schrimpf (ISPRAMIX) [1992]
+!                    8: dynamic dissipation rate equation
+!                    9: dynamic Mellor-Yamada q^2l-equation
+!                    10: generic length scale (GLS)
+!                    This variable is only used if (turb_method = 2 or
+!                      turb_method = 3)
+! stab_method      [integer]
+!                    type of stability function
+!                    1: constant stability functions
+!                    2: Munk and Anderson [1954]
+!                    3: Schumann and Gerz [1995]
+!                    4: Eifler and Schrimpf [1992]
+!                    This variable is only used if turb_method = 2
+!-------------------------------------------------------------------------------
+
+&turbulence
+   turb_method = 3,
+   tke_method = 2,
+   len_scale_method = 10,
+   stab_method = 1,
+/
+
+!-------------------------------------------------------------------------------
+! boundary conditions
+!-------------------------------------------------------------------------------
+! k_ubc    [integer]
+!            upper boundary condition for k-equation
+!            0: prescribed BC
+!            1: flux BC
+! k_lbc    [integer]
+!            lower boundary condition for k-equation
+!            0: prescribed BC
+!            1: flux BC
+! psi_ubc  [integer]
+!            upper boundary condition for the length-scale equation (e.g.
+!              epsilon, kl, omega, GLS)
+!            0: prescribed BC
+!            1: flux BC
+! psi_lbc  [integer]
+!            lower boundary condition for the length-scale equation (e.g.
+!              epsilon, kl, omega, GLS)
+!            0: prescribed BC
+!            1: flux BC
+! ubc_type [integer]
+!            type of upper boundary layer
+!            0: viscous sublayer (not yet impl.)
+!            1: logarithmic law of the wall
+!            2: tke-injection (breaking waves)
+! lbc_type [integer]
+!            type of lower boundary layer
+!            0: viscous sublayer (not yet impl.)
+!            1: logarithmic law of the wall
+!-------------------------------------------------------------------------------
+
+&bc
+   k_ubc = 1,
+   k_lbc = 1,
+   psi_ubc = 1,
+   psi_lbc = 1,
+   ubc_type = 1,
+   lbc_type = 1,
+/
+
+!-------------------------------------------------------------------------------
+! turbulence parameters
+!-------------------------------------------------------------------------------
+! cm0_fix       [float]
+!                 value of cm0
+!                 This variable is only used if /gotmturb/turbulence/turb_method
+!                   = 2
+! Prandtl0_fix  [float]
+!                 value of the turbulent Prandtl-number
+!                 This variable is only used if /gotmturb/turbulence/turb_method
+!                   = 2
+! cw            [float]
+!                 constant of the wave-breaking model (Craig & Banner (1994) use
+!                   cw=100)
+! compute_kappa [bool]
+!                 compute von Karman constant from model parameters
+! kappa         [float]
+!                 the desired von Karman constant
+!                 This variable is only used if compute_kappa = True
+! compute_c3    [bool]
+!                 compute c3 (E3 for Mellor-Yamada) for given Ri_st
+! Ri_st         [float]
+!                 the desired steady-state Richardson number
+!                 This variable is only used if compute_c3 = True
+! length_lim    [bool]
+!                 apply length scale limitation (see Galperin et al. 1988)
+! galp          [float]
+!                 coef. for length scale limitation
+!                 This variable is only used if length_lim = True
+! const_num     [float, unit = m^2/s]
+!                 minimum eddy diffusivity
+!                 This variable is only used if /gotmturb/turbulence/turb_method
+!                   = 0
+! const_nuh     [float, unit = m^2/s]
+!                 minimum heat diffusivity
+!                 This variable is only used if /gotmturb/turbulence/turb_method
+!                   = 0
+! k_min         [float, unit = m^2/s^2]
+!                 minimum TKE
+! eps_min       [float, unit = m^2/s^3]
+!                 minimum dissipation rate
+! kb_min        [float, unit = m^2/s^4]
+!                 minimum buoyancy variance
+! epsb_min      [float, unit = m^2/s^5]
+!                 minimum buoyancy variance destruction rate
+!-------------------------------------------------------------------------------
+
+&turb_param
+   cm0_fix = 0.5477,
+   Prandtl0_fix = 0.74,
+   cw = 100.0,
+   compute_kappa = .false.,
+   kappa = 0.4,
+   compute_c3 = .false.,
+   Ri_st = 0.25,
+   length_lim = .false.,
+   galp = 0.53,
+   const_num = 0.0005,
+   const_nuh = 0.0005,
+   k_min = 1e-10,
+   eps_min = 1e-12,
+   kb_min = 1e-10,
+   epsb_min = 1e-14,
+/
+
+!-------------------------------------------------------------------------------
+! the generic model (Umlauf & Burchard, J. Mar. Res., 2003)
+!-------------------------------------------------------------------------------
+! compute_param [bool]
+!                 compute the model parameters
+! gen_m         [float]
+!                 exponent for k
+! gen_n         [float]
+!                 exponent for l
+!                 This variable is only used if compute_param = False
+! gen_p         [float]
+!                 exponent for cm0
+!                 This variable is only used if compute_param = False
+! cpsi1         [float]
+!                 emp. coef. cpsi1 in psi equation
+!                 This variable is only used if compute_param = False
+! cpsi2         [float]
+!                 emp. coef. cpsi2 in psi equation
+!                 This variable is only used if compute_param = False
+! cpsi3minus    [float]
+!                 cpsi3 for stable stratification
+!                 This variable is only used if compute_param = False
+! cpsi3plus     [float]
+!                 cpsi3 for unstable stratification
+!                 This variable is only used if compute_param = False
+! sig_kpsi      [float]
+!                 Schmidt number for TKE diffusivity
+!                 This variable is only used if compute_param = False
+! sig_psi       [float]
+!                 Schmidt number for psi diffusivity
+!                 This variable is only used if compute_param = False
+! gen_d         [float]
+!                 gen_d
+!                 This variable is only used if compute_param = False
+! gen_alpha     [float]
+!                 gen_alpha
+!                 This variable is only used if compute_param = False
+! gen_l         [float]
+!                 gen_l
+!                 This variable is only used if compute_param = False
+!-------------------------------------------------------------------------------
+
+&generic
+   compute_param = .false.,
+   gen_m = 1.5,
+   gen_n = -1.0,
+   gen_p = 3.0,
+   cpsi1 = 1.44,
+   cpsi2 = 1.92,
+   cpsi3minus = -0.63,
+   cpsi3plus = 1.0,
+   sig_kpsi = 1.0,
+   sig_psi = 1.3,
+   gen_d = -1.2,
+   gen_alpha = -2.0,
+   gen_l = 0.2,
+/
+
+!-------------------------------------------------------------------------------
+! the k-epsilon model (Rodi 1987)
+!-------------------------------------------------------------------------------
+! ce1      [float]
+!            emp. coef. ce1 in diss. eq.
+! ce2      [float]
+!            emp. coef. ce2 in diss. eq.
+! ce3minus [float]
+!            ce3 for stable stratification
+!            This variable is not used if /gotmturb/turb_param/compute_c3 = True
+! ce3plus  [float]
+!            ce3 for unstable stratification (Rodi 1987: ce3plus=1.0)
+! sig_k    [float]
+!            Schmidt number for TKE diffusivity
+! sig_e    [float]
+!            Schmidt number for diss. diffusivity
+! sig_peps [bool]
+!            if .true. -> the wave breaking parameterisation suggested by
+!              Burchard (JPO 31, 2001, 3133-3145) will be used.
+!-------------------------------------------------------------------------------
+
+&keps
+   ce1 = 1.44,
+   ce2 = 1.92,
+   ce3minus = 0.0,
+   ce3plus = 1.0,
+   sig_k = 1.0,
+   sig_e = 1.3,
+   sig_peps = .false.,
+/
+
+!-------------------------------------------------------------------------------
+! the Mellor-Yamada model (Mellor & Yamada 1982)
+!-------------------------------------------------------------------------------
+! e1         [float]
+!              coef. e1 in MY q**2 l equation
+! e2         [float]
+!              coef. e2 in MY q**2 l equation
+! e3         [float]
+!              coef. e3 in MY q**2 l equation
+! sq         [float]
+!              turbulent diffusivities of q**2 (= 2k)
+! sl         [float]
+!              turbulent diffusivities of q**2 l
+! my_length  [integer]
+!              prescribed barotropic lengthscale in q**2 l equation of MY
+!              1: parabolic
+!              2: triangular
+!              3: lin. from surface
+! new_constr [bool]
+!              stabilisation of Mellor-Yamada stability functions according to
+!                Burchard & Deleersnijder (2001)
+!-------------------------------------------------------------------------------
+
+&my
+   e1 = 1.8,
+   e2 = 1.33,
+   e3 = 1.8,
+   sq = 0.2,
+   sl = 0.2,
+   my_length = 1,
+   new_constr = .false.,
+/
+
+!-------------------------------------------------------------------------------
+! the second-order model
+!-------------------------------------------------------------------------------
+! scnd_method [integer]
+!               type of second-order model
+!               1: EASM with quasi-equilibrium
+!               2: EASM with weak equilibrium, buoy.-variance algebraic
+!               3: EASM with weak equilibrium, buoy.-variance from PDE
+! kb_method   [integer]
+!               type of equation for buoyancy variance
+!               1: algebraic equation for buoyancy variance
+!               2: PDE for buoyancy variance
+! epsb_method [integer]
+!               type of equation for variance destruction
+!               1: algebraic equation for variance destruction
+!               2: PDE for variance destruction
+! scnd_coeff  [integer]
+!               coefficients of second-order model
+!               0: read the coefficients from this file
+!               1: coefficients of Gibson and Launder (1978)
+!               2: coefficients of Mellor and Yamada (1982)
+!               3: coefficients of Kantha and Clayson (1994)
+!               4: coefficients of Luyten et al. (1996)
+!               5: coefficients of Canuto et al. (2001) (version A)
+!               6: coefficients of Canuto et al. (2001) (version B)
+!               7: coefficients of Cheng et al. (2002)
+! cc1         [float]
+!               coefficient cc1
+!               This variable is only used if scnd_coeff = 0
+! cc2         [float]
+!               coefficient cc2
+!               This variable is only used if scnd_coeff = 0
+! cc3         [float]
+!               coefficient cc3
+!               This variable is only used if scnd_coeff = 0
+! cc4         [float]
+!               coefficient cc4
+!               This variable is only used if scnd_coeff = 0
+! cc5         [float]
+!               coefficient cc5
+!               This variable is only used if scnd_coeff = 0
+! cc6         [float]
+!               coefficient cc6
+!               This variable is only used if scnd_coeff = 0
+! ct1         [float]
+!               coefficient ct1
+!               This variable is only used if scnd_coeff = 0
+! ct2         [float]
+!               coefficient ct2
+!               This variable is only used if scnd_coeff = 0
+! ct3         [float]
+!               coefficient ct3
+!               This variable is only used if scnd_coeff = 0
+! ct4         [float]
+!               coefficient ct4
+!               This variable is only used if scnd_coeff = 0
+! ct5         [float]
+!               coefficient ct5
+!               This variable is only used if scnd_coeff = 0
+! ctt         [float]
+!               coefficient ctt
+!               This variable is only used if scnd_coeff = 0
+!-------------------------------------------------------------------------------
+
+&scnd
+   scnd_method = 2,
+   kb_method = 1,
+   epsb_method = 1,
+   scnd_coeff = 5,
+   cc1 = 3.6,
+   cc2 = 0.8,
+   cc3 = 1.2,
+   cc4 = 1.2,
+   cc5 = 0.0,
+   cc6 = 0.3,
+   ct1 = 3.28,
+   ct2 = 0.4,
+   ct3 = 0.4,
+   ct4 = 0.0,
+   ct5 = 0.4,
+   ctt = 0.8,
+/
+
+!-------------------------------------------------------------------------------
+! internal wave model
+!-------------------------------------------------------------------------------
+! iw_model [integer]
+!            method to compute internal wave mixing
+!            0: no internal wave mixing parameterisation
+!            1: Mellor 1989 internal wave mixing
+!            2: Large et al. 1994 internal wave mixing
+! alpha    [float]
+!            coeff. for Mellor IWmodel (0: no IW, 0.7 Mellor 1989)
+!            This variable is only used if iw_model = 1
+! klimiw   [float, unit = m**2/s**2]
+!            critical value of TKE
+!            This variable is only used if iw_model = 2
+! rich_cr  [float]
+!            critical Richardson number for shear instability
+!            This variable is only used if iw_model = 2
+! numshear [float, unit = m**2/s]
+!            background diffusivity for shear instability
+!            This variable is only used if iw_model = 2
+! numiw    [float, unit = m**2/s]
+!            background viscosity for internal wave breaking
+!            This variable is only used if iw_model = 2
+! nuhiw    [float, unit = m**2/s]
+!            background diffusivity for internal wave breaking
+!            This variable is only used if iw_model = 2
+!-------------------------------------------------------------------------------
+
+&iw
+   iw_model = 0,
+   alpha = 0.0,
+   klimiw = 1e-06,
+   rich_cr = 0.7,
+   numshear = 0.005,
+   numiw = 0.0001,
+   nuhiw = 1e-05,
+/
+

--- a/ocean/sediment/100m/tracer_regression/config_driver.xml
+++ b/ocean/sediment/100m/tracer_regression/config_driver.xml
@@ -1,0 +1,17 @@
+<driver_script name="run_test.py">
+	<case name="init">
+		<step executable="./run.py" quiet="true" pre_message=" * Running init" post_message="     Complete"/>
+	</case>
+	<case name="forward">
+		<step executable="./run.py" quiet="true" pre_message=" * Running forward" post_message="     Complete"/>
+	</case>
+	<validation>
+		<compare_fields file1="forward/output.nc">
+			<field name="sedConcen" l1_norm="0.0" l2_norm="0.0" linf_norm="0.0"/>
+			<field name="temperature" l1_norm="0.0" l2_norm="0.0" linf_norm="0.0"/>
+			<field name="salinity" l1_norm="0.0" l2_norm="0.0" linf_norm="0.0"/>
+			<field name="layerThickness" l1_norm="0.0" l2_norm="0.0" linf_norm="0.0"/>
+			<field name="normalVelocity" l1_norm="0.0" l2_norm="0.0" linf_norm="0.0"/>
+		</compare_fields>
+	</validation>
+</driver_script>

--- a/ocean/sediment/100m/tracer_regression/config_forward.xml
+++ b/ocean/sediment/100m/tracer_regression/config_forward.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0"?>
+<config case="forward">
+	<add_link source="../init/ocean.nc" dest="init.nc"/>
+	<add_link source="../init/mesh.nc" dest="mesh.nc"/>
+	<add_link source="../init/graph.info" dest="graph.info"/>
+	<copy_file source_path="script_test_dir" source="gotmturb.nml" dest="gotmturb.nml"/>
+
+	<add_executable source="model" dest="ocean_model"/>
+
+	<namelist name="namelist.ocean" mode="forward">
+		<option name="config_ocean_run_mode">'forward'</option>
+		<option name="config_dt">'00:00:10'</option>
+		<option name="config_time_integrator">'RK4'</option>
+		<option name="config_run_duration">'0000_00:01:00'</option>
+		<option name="config_disable_tr_adv">.false.</option>
+		<option name="config_use_debugTracers">.true.</option>
+		<option name="config_use_sedimentTracers">.true.</option>
+		<option name="config_use_mom_del2">.true.</option>
+		<option name="config_mom_del2">1.0e-2</option>
+		<option name="config_use_tracer_del2">.true.</option>
+		<option name="config_tracer_del2">10.0</option>
+		<option name="config_use_cvmix">.false.</option>
+		<option name="config_use_gotm">.true.</option>
+		<option name="config_gotm_namelist_file">'gotmturb.nml'</option>
+		<option name="config_gotm_constant_bottom_roughness_length">5.0e-3</option>
+		<option name="config_gotm_constant_bottom_drag_coeff">1.73e-2</option>
+		<option name="config_use_implicit_bottom_drag">.true.</option>
+		<option name="config_implicit_bottom_drag_coeff">1.73e-2</option>
+	</namelist>
+
+	<streams name="streams.ocean" keep="immutable" mode="forward">
+		<stream name="mesh">
+			<attribute name="filename_template">mesh.nc</attribute>
+		</stream>
+		<stream name="input">
+			<attribute name="filename_template">init.nc</attribute>
+		</stream>
+		<stream name="output">
+			<attribute name="type">output</attribute>
+			<attribute name="filename_template">output.nc</attribute>
+			<attribute name="output_interval">0000-00-00_00:01:00</attribute>
+			<attribute name="clobber_mode">truncate</attribute>
+			<add_contents>
+				<member name="tracers" type="var_struct"/>
+				<member name="velocityZonal" type="var"/>
+				<member name="velocityMeridional" type="var"/>
+				<member name="normalVelocity" type="var"/>
+				<member name="mesh" type="stream"/>
+				<member name="xtime" type="var"/>
+				<member name="layerThickness" type="var"/>
+			</add_contents>
+		</stream>
+	</streams>
+
+	<run_script name="run.py">
+		<step executable="gpmetis">
+			<argument flag="graph.info">2</argument>
+		</step>
+		<model_run procs="2" threads="1" namelist="namelist.ocean" streams="streams.ocean"/>
+	</run_script>
+</config>

--- a/ocean/sediment/100m/tracer_regression/config_init.xml
+++ b/ocean/sediment/100m/tracer_regression/config_init.xml
@@ -1,0 +1,68 @@
+<?xml version="1.0"?>
+<config case="init">
+	<add_executable source="model" dest="ocean_model"/>
+	<namelist name="namelist.ocean" mode="init">
+		<option name="config_ocean_run_mode">'init'</option>
+		<option name="config_init_configuration">'lock_exchange'</option>
+		<option name="config_vert_levels">-1</option>
+		<option name="config_write_cull_cell_mask">.true.</option>
+		<option name="config_use_debugTracers">.true.</option>
+		<option name="config_use_sedimentTracers">.true.</option>
+		<option name="config_lock_exchange_direction">'y'</option>
+		<option name="config_lock_exchange_vert_levels">50</option>
+		<option name="config_lock_exchange_bottom_depth">10.0</option>
+		<option name="config_lock_exchange_warm_temperature">30.0</option>
+		<option name="config_lock_exchange_cold_temperature">10.0</option>
+		<option name="config_lock_exchange_high_sedConcen">10.0</option>
+		<option name="config_lock_exchange_low_sedConcen">0.0</option>
+		<option name="config_lock_exchange_high_tracer">10.0</option>
+		<option name="config_lock_exchange_low_tracer">0.0</option>
+	</namelist>
+
+	<streams name="streams.ocean" keep="immutable" mode="init">
+		<stream name="input_init">
+			<attribute name="filename_template">mesh.nc</attribute>
+		</stream>
+		<stream name="output_init">
+			<attribute name="type">output</attribute>
+			<attribute name="output_interval">0000-00-00_00:00:01</attribute>
+			<attribute name="clobber_mode">truncate</attribute>
+			<attribute name="filename_template">ocean.nc</attribute>
+			<add_contents>
+				<member name="input_init" type="stream"/>
+				<member name="tracers" type="var_struct"/>
+				<member name="refZMid" type="var"/>
+				<member name="normalVelocity" type="var"/>
+				<member name="layerThickness" type="var"/>
+				<member name="restingThickness" type="var"/>
+				<member name="refBottomDepth" type="var"/>
+				<member name="bottomDepth" type="var"/>
+				<member name="minLevelCell" type="var"/>
+				<member name="maxLevelCell" type="var"/>
+				<member name="vertCoordMovementWeights" type="var"/>
+				<member name="edgeMask" type="var"/>
+				<member name="cullCell" type="var"/>
+			</add_contents>
+		</stream>
+	</streams>
+
+	<run_script name="run.py">
+		<step executable="planar_hex">
+			<argument flag="--nx">4</argument>
+			<argument flag="--ny">50</argument>
+			<argument flag="--dc">100.0</argument>
+			<argument flag="--npy"></argument>
+			<argument flag="-o">grid.nc</argument>
+		</step>
+		<step executable="MpasCellCuller.x">
+			<argument flag="">grid.nc</argument>
+			<argument flag="">culled_mesh.nc</argument>
+		</step>
+		<step executable="MpasMeshConverter.x">
+			<argument flag="">culled_mesh.nc</argument>
+			<argument flag="">mesh.nc</argument>
+		</step>
+		<model_run procs="1" threads="1" namelist="namelist.ocean" streams="streams.ocean"/>
+	</run_script>
+
+</config>

--- a/ocean/sediment/100m/tracer_regression/gotmturb.nml
+++ b/ocean/sediment/100m/tracer_regression/gotmturb.nml
@@ -1,0 +1,400 @@
+!-------------------------------------------------------------------------------
+! general
+!-------------------------------------------------------------------------------
+! turb_method      [integer]
+!                    type of turbulence closure
+!                    0: convective adjustment
+!                    1: analytical eddy visc. and diff. profiles, not coded yet
+!                    2: turbulence Model calculating TKE and length scale
+!                    3: second-order model
+!                    98: OSMOSIS model
+!                    99: KPP model
+!                    100: MOM turbulence model
+! tke_method       [integer]
+!                    type of equation for TKE
+!                    1: algebraic equation
+!                    2: dynamic equation (k-epsilon style)
+!                    3: dynamic equation (Mellor-Yamada style)
+!                    4: dynamic equation with Stokes production (Kantha and
+!                      Clayson, 2004)
+!                    This variable is only used if (turb_method = 2 or
+!                      turb_method = 3)
+! len_scale_method [integer]
+!                    type of model for dissipative length scale
+!                    1: parabolic shape
+!                    2: triangle shape
+!                    3: Xing and Davies [1995]
+!                    4: Robert and Ouellet [1987]
+!                    5: Blackadar (two boundaries) [1962]
+!                    6: Bougeault and Andre [1986]
+!                    7: Eifler and Schrimpf (ISPRAMIX) [1992]
+!                    8: dynamic dissipation rate equation
+!                    9: dynamic Mellor-Yamada q^2l-equation
+!                    10: generic length scale (GLS)
+!                    This variable is only used if (turb_method = 2 or
+!                      turb_method = 3)
+! stab_method      [integer]
+!                    type of stability function
+!                    1: constant stability functions
+!                    2: Munk and Anderson [1954]
+!                    3: Schumann and Gerz [1995]
+!                    4: Eifler and Schrimpf [1992]
+!                    This variable is only used if turb_method = 2
+!-------------------------------------------------------------------------------
+
+&turbulence
+   turb_method = 3,
+   tke_method = 2,
+   len_scale_method = 10,
+   stab_method = 1,
+/
+
+!-------------------------------------------------------------------------------
+! boundary conditions
+!-------------------------------------------------------------------------------
+! k_ubc    [integer]
+!            upper boundary condition for k-equation
+!            0: prescribed BC
+!            1: flux BC
+! k_lbc    [integer]
+!            lower boundary condition for k-equation
+!            0: prescribed BC
+!            1: flux BC
+! psi_ubc  [integer]
+!            upper boundary condition for the length-scale equation (e.g.
+!              epsilon, kl, omega, GLS)
+!            0: prescribed BC
+!            1: flux BC
+! psi_lbc  [integer]
+!            lower boundary condition for the length-scale equation (e.g.
+!              epsilon, kl, omega, GLS)
+!            0: prescribed BC
+!            1: flux BC
+! ubc_type [integer]
+!            type of upper boundary layer
+!            0: viscous sublayer (not yet impl.)
+!            1: logarithmic law of the wall
+!            2: tke-injection (breaking waves)
+! lbc_type [integer]
+!            type of lower boundary layer
+!            0: viscous sublayer (not yet impl.)
+!            1: logarithmic law of the wall
+!-------------------------------------------------------------------------------
+
+&bc
+   k_ubc = 1,
+   k_lbc = 1,
+   psi_ubc = 1,
+   psi_lbc = 1,
+   ubc_type = 1,
+   lbc_type = 1,
+/
+
+!-------------------------------------------------------------------------------
+! turbulence parameters
+!-------------------------------------------------------------------------------
+! cm0_fix       [float]
+!                 value of cm0
+!                 This variable is only used if /gotmturb/turbulence/turb_method
+!                   = 2
+! Prandtl0_fix  [float]
+!                 value of the turbulent Prandtl-number
+!                 This variable is only used if /gotmturb/turbulence/turb_method
+!                   = 2
+! cw            [float]
+!                 constant of the wave-breaking model (Craig & Banner (1994) use
+!                   cw=100)
+! compute_kappa [bool]
+!                 compute von Karman constant from model parameters
+! kappa         [float]
+!                 the desired von Karman constant
+!                 This variable is only used if compute_kappa = True
+! compute_c3    [bool]
+!                 compute c3 (E3 for Mellor-Yamada) for given Ri_st
+! Ri_st         [float]
+!                 the desired steady-state Richardson number
+!                 This variable is only used if compute_c3 = True
+! length_lim    [bool]
+!                 apply length scale limitation (see Galperin et al. 1988)
+! galp          [float]
+!                 coef. for length scale limitation
+!                 This variable is only used if length_lim = True
+! const_num     [float, unit = m^2/s]
+!                 minimum eddy diffusivity
+!                 This variable is only used if /gotmturb/turbulence/turb_method
+!                   = 0
+! const_nuh     [float, unit = m^2/s]
+!                 minimum heat diffusivity
+!                 This variable is only used if /gotmturb/turbulence/turb_method
+!                   = 0
+! k_min         [float, unit = m^2/s^2]
+!                 minimum TKE
+! eps_min       [float, unit = m^2/s^3]
+!                 minimum dissipation rate
+! kb_min        [float, unit = m^2/s^4]
+!                 minimum buoyancy variance
+! epsb_min      [float, unit = m^2/s^5]
+!                 minimum buoyancy variance destruction rate
+!-------------------------------------------------------------------------------
+
+&turb_param
+   cm0_fix = 0.5477,
+   Prandtl0_fix = 0.74,
+   cw = 100.0,
+   compute_kappa = .false.,
+   kappa = 0.4,
+   compute_c3 = .false.,
+   Ri_st = 0.25,
+   length_lim = .false.,
+   galp = 0.53,
+   const_num = 0.0005,
+   const_nuh = 0.0005,
+   k_min = 1e-10,
+   eps_min = 1e-12,
+   kb_min = 1e-10,
+   epsb_min = 1e-14,
+/
+
+!-------------------------------------------------------------------------------
+! the generic model (Umlauf & Burchard, J. Mar. Res., 2003)
+!-------------------------------------------------------------------------------
+! compute_param [bool]
+!                 compute the model parameters
+! gen_m         [float]
+!                 exponent for k
+! gen_n         [float]
+!                 exponent for l
+!                 This variable is only used if compute_param = False
+! gen_p         [float]
+!                 exponent for cm0
+!                 This variable is only used if compute_param = False
+! cpsi1         [float]
+!                 emp. coef. cpsi1 in psi equation
+!                 This variable is only used if compute_param = False
+! cpsi2         [float]
+!                 emp. coef. cpsi2 in psi equation
+!                 This variable is only used if compute_param = False
+! cpsi3minus    [float]
+!                 cpsi3 for stable stratification
+!                 This variable is only used if compute_param = False
+! cpsi3plus     [float]
+!                 cpsi3 for unstable stratification
+!                 This variable is only used if compute_param = False
+! sig_kpsi      [float]
+!                 Schmidt number for TKE diffusivity
+!                 This variable is only used if compute_param = False
+! sig_psi       [float]
+!                 Schmidt number for psi diffusivity
+!                 This variable is only used if compute_param = False
+! gen_d         [float]
+!                 gen_d
+!                 This variable is only used if compute_param = False
+! gen_alpha     [float]
+!                 gen_alpha
+!                 This variable is only used if compute_param = False
+! gen_l         [float]
+!                 gen_l
+!                 This variable is only used if compute_param = False
+!-------------------------------------------------------------------------------
+
+&generic
+   compute_param = .false.,
+   gen_m = 1.5,
+   gen_n = -1.0,
+   gen_p = 3.0,
+   cpsi1 = 1.44,
+   cpsi2 = 1.92,
+   cpsi3minus = -0.63,
+   cpsi3plus = 1.0,
+   sig_kpsi = 1.0,
+   sig_psi = 1.3,
+   gen_d = -1.2,
+   gen_alpha = -2.0,
+   gen_l = 0.2,
+/
+
+!-------------------------------------------------------------------------------
+! the k-epsilon model (Rodi 1987)
+!-------------------------------------------------------------------------------
+! ce1      [float]
+!            emp. coef. ce1 in diss. eq.
+! ce2      [float]
+!            emp. coef. ce2 in diss. eq.
+! ce3minus [float]
+!            ce3 for stable stratification
+!            This variable is not used if /gotmturb/turb_param/compute_c3 = True
+! ce3plus  [float]
+!            ce3 for unstable stratification (Rodi 1987: ce3plus=1.0)
+! sig_k    [float]
+!            Schmidt number for TKE diffusivity
+! sig_e    [float]
+!            Schmidt number for diss. diffusivity
+! sig_peps [bool]
+!            if .true. -> the wave breaking parameterisation suggested by
+!              Burchard (JPO 31, 2001, 3133-3145) will be used.
+!-------------------------------------------------------------------------------
+
+&keps
+   ce1 = 1.44,
+   ce2 = 1.92,
+   ce3minus = 0.0,
+   ce3plus = 1.0,
+   sig_k = 1.0,
+   sig_e = 1.3,
+   sig_peps = .false.,
+/
+
+!-------------------------------------------------------------------------------
+! the Mellor-Yamada model (Mellor & Yamada 1982)
+!-------------------------------------------------------------------------------
+! e1         [float]
+!              coef. e1 in MY q**2 l equation
+! e2         [float]
+!              coef. e2 in MY q**2 l equation
+! e3         [float]
+!              coef. e3 in MY q**2 l equation
+! sq         [float]
+!              turbulent diffusivities of q**2 (= 2k)
+! sl         [float]
+!              turbulent diffusivities of q**2 l
+! my_length  [integer]
+!              prescribed barotropic lengthscale in q**2 l equation of MY
+!              1: parabolic
+!              2: triangular
+!              3: lin. from surface
+! new_constr [bool]
+!              stabilisation of Mellor-Yamada stability functions according to
+!                Burchard & Deleersnijder (2001)
+!-------------------------------------------------------------------------------
+
+&my
+   e1 = 1.8,
+   e2 = 1.33,
+   e3 = 1.8,
+   sq = 0.2,
+   sl = 0.2,
+   my_length = 1,
+   new_constr = .false.,
+/
+
+!-------------------------------------------------------------------------------
+! the second-order model
+!-------------------------------------------------------------------------------
+! scnd_method [integer]
+!               type of second-order model
+!               1: EASM with quasi-equilibrium
+!               2: EASM with weak equilibrium, buoy.-variance algebraic
+!               3: EASM with weak equilibrium, buoy.-variance from PDE
+! kb_method   [integer]
+!               type of equation for buoyancy variance
+!               1: algebraic equation for buoyancy variance
+!               2: PDE for buoyancy variance
+! epsb_method [integer]
+!               type of equation for variance destruction
+!               1: algebraic equation for variance destruction
+!               2: PDE for variance destruction
+! scnd_coeff  [integer]
+!               coefficients of second-order model
+!               0: read the coefficients from this file
+!               1: coefficients of Gibson and Launder (1978)
+!               2: coefficients of Mellor and Yamada (1982)
+!               3: coefficients of Kantha and Clayson (1994)
+!               4: coefficients of Luyten et al. (1996)
+!               5: coefficients of Canuto et al. (2001) (version A)
+!               6: coefficients of Canuto et al. (2001) (version B)
+!               7: coefficients of Cheng et al. (2002)
+! cc1         [float]
+!               coefficient cc1
+!               This variable is only used if scnd_coeff = 0
+! cc2         [float]
+!               coefficient cc2
+!               This variable is only used if scnd_coeff = 0
+! cc3         [float]
+!               coefficient cc3
+!               This variable is only used if scnd_coeff = 0
+! cc4         [float]
+!               coefficient cc4
+!               This variable is only used if scnd_coeff = 0
+! cc5         [float]
+!               coefficient cc5
+!               This variable is only used if scnd_coeff = 0
+! cc6         [float]
+!               coefficient cc6
+!               This variable is only used if scnd_coeff = 0
+! ct1         [float]
+!               coefficient ct1
+!               This variable is only used if scnd_coeff = 0
+! ct2         [float]
+!               coefficient ct2
+!               This variable is only used if scnd_coeff = 0
+! ct3         [float]
+!               coefficient ct3
+!               This variable is only used if scnd_coeff = 0
+! ct4         [float]
+!               coefficient ct4
+!               This variable is only used if scnd_coeff = 0
+! ct5         [float]
+!               coefficient ct5
+!               This variable is only used if scnd_coeff = 0
+! ctt         [float]
+!               coefficient ctt
+!               This variable is only used if scnd_coeff = 0
+!-------------------------------------------------------------------------------
+
+&scnd
+   scnd_method = 2,
+   kb_method = 1,
+   epsb_method = 1,
+   scnd_coeff = 5,
+   cc1 = 3.6,
+   cc2 = 0.8,
+   cc3 = 1.2,
+   cc4 = 1.2,
+   cc5 = 0.0,
+   cc6 = 0.3,
+   ct1 = 3.28,
+   ct2 = 0.4,
+   ct3 = 0.4,
+   ct4 = 0.0,
+   ct5 = 0.4,
+   ctt = 0.8,
+/
+
+!-------------------------------------------------------------------------------
+! internal wave model
+!-------------------------------------------------------------------------------
+! iw_model [integer]
+!            method to compute internal wave mixing
+!            0: no internal wave mixing parameterisation
+!            1: Mellor 1989 internal wave mixing
+!            2: Large et al. 1994 internal wave mixing
+! alpha    [float]
+!            coeff. for Mellor IWmodel (0: no IW, 0.7 Mellor 1989)
+!            This variable is only used if iw_model = 1
+! klimiw   [float, unit = m**2/s**2]
+!            critical value of TKE
+!            This variable is only used if iw_model = 2
+! rich_cr  [float]
+!            critical Richardson number for shear instability
+!            This variable is only used if iw_model = 2
+! numshear [float, unit = m**2/s]
+!            background diffusivity for shear instability
+!            This variable is only used if iw_model = 2
+! numiw    [float, unit = m**2/s]
+!            background viscosity for internal wave breaking
+!            This variable is only used if iw_model = 2
+! nuhiw    [float, unit = m**2/s]
+!            background diffusivity for internal wave breaking
+!            This variable is only used if iw_model = 2
+!-------------------------------------------------------------------------------
+
+&iw
+   iw_model = 0,
+   alpha = 0.0,
+   klimiw = 1e-06,
+   rich_cr = 0.7,
+   numshear = 0.005,
+   numiw = 0.0001,
+   nuhiw = 1e-05,
+/
+


### PR DESCRIPTION
This PR added a `sed_tracer` case in the compass to validate the implementation of suspended sediment as a new tracer  (currently without source/sink terms) in MPAS-O. The corresponding code was submitted separately (https://github.com/MPAS-Dev/MPAS-Model/pull/858). 

The test case has the same configurations of the implemented sediment tracer (**SSC**) and an existing debug tracer (**tracer**) in a closed domain. The initial condition is that horizontally half of the domain has tracers and high water temperature, whereas the other half has no tracers and low water temperature. 

There are two scenarios in the test case:
Scenario 1) **tracer_diffusion** without advection by setting `config_disable_tr_adv = .true. `
Scenario 2) **tracer_advection_diffusion** with advection by setting `config_disable_tr_adv = .false. `

A _default_ case was also added as **tracer_regression**.

The validation idea is to check whether the results of `SSC` and `tracer` are identical in each scenario.

Here are the results:
**Scenario 1**
![SSC_1](https://user-images.githubusercontent.com/36651760/116469045-dd518000-a82e-11eb-8591-3666cd227a26.gif)
![tracer_1](https://user-images.githubusercontent.com/36651760/116469451-6963a780-a82f-11eb-879c-f19e31622f49.gif)

**Scenario 2**
![SSC_2](https://user-images.githubusercontent.com/36651760/116469475-71bbe280-a82f-11eb-9869-093331651671.gif)
![tracer_2](https://user-images.githubusercontent.com/36651760/116469490-76809680-a82f-11eb-89c7-892745b4a85a.gif)

Note: visualization scripts were adopted from https://github.com/qingli411/mpasview. Thank you @qingli411 for sharing.
