### PR TITLE
Add README files as package data

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,8 @@ version = re.search(r'{}\s*=\s*[(]([^)]*)[)]'.format('__version_info__'),
 
 os.chdir(here)
 
-data_files = package_files('compass', prefixes=['namelist', 'streams'],
+data_files = package_files('compass',
+                           prefixes=['namelist', 'streams', 'README'],
                            extensions=['cfg', 'template', 'json', 'txt',
                                        'geojson', 'mat'])
 


### PR DESCRIPTION
Previously, some README files weren't getting linked when running from the package (as opposed to the repo) because the README files aren't included in the package.  This merge fixes that issue.

closes #70 