### PR TITLE
Symlink load_compass_env.sh in test case work dirs

### DIFF
--- a/compass/setup.py
+++ b/compass/setup.py
@@ -227,7 +227,8 @@ def setup_case(path, test_case, config_file, machine, work_dir, baseline_dir,
     if 'LOAD_COMPASS_ENV' in os.environ:
         script_filename = os.environ['LOAD_COMPASS_ENV']
         # make a symlink to the script for loading the compass conda env.
-        symlink(script_filename, os.path.join(work_dir, 'load_compass_env.sh'))
+        symlink(script_filename, os.path.join(test_case_dir,
+                                              'load_compass_env.sh'))
 
 
 def main():


### PR DESCRIPTION
This was supposed to happen already but is linking in the base work directory, not the test case's work dir.