### PR TITLE
Don't try to symlink compass to itself

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -114,3 +114,14 @@ ENV/
 
 # PyCharm
 .idea/
+
+# local config files
+/*.cfg
+
+# work directories in repo
+/ocean/
+/landice/
+/case_output/
+/provenance
+/*.pickle
+/load_compass_env.sh

--- a/compass/suite.py
+++ b/compass/suite.py
@@ -69,7 +69,10 @@ def setup_suite(mpas_core, suite_name, config_file=None, machine=None,
     # package and we'll want to link to that in the tests and steps
     compass_path = os.path.join(os.getcwd(), 'compass')
     if os.path.exists(os.path.join(compass_path, '__init__.py')):
-        symlink(compass_path, os.path.join(work_dir, 'compass'))
+        link_name = os.path.join(work_dir, 'compass')
+        if os.path.abspath(compass_path) != os.path.abspath(link_name):
+            # make sure we're not trying to overwrite compass with a symlink
+            symlink(compass_path, os.path.join(work_dir, 'compass'))
 
     test_suite = {'name': suite_name,
                   'test_cases': test_cases,


### PR DESCRIPTION
If the repo base is also the work directory (the default), we can't symlink compass to itself.

This merge also adds directories and files related to testing to `.gitignore` in case anyone does use the repo as the work directory.

closes #67