### PR TITLE
Fix mixedLayerDepth (non)output for ssh_adjustment

### DIFF
--- a/compass/ocean/namelists/namelist.ssh_adjust
+++ b/compass/ocean/namelists/namelist.ssh_adjust
@@ -1,2 +1,3 @@
 config_run_duration = '0000_01:00:00'
+config_check_ssh_consistency = .false.
 config_land_ice_flux_mode = 'pressure_only'

--- a/compass/ocean/tests/global_ocean/init/streams.ssh_adjust
+++ b/compass/ocean/tests/global_ocean/init/streams.ssh_adjust
@@ -1,6 +1,6 @@
 <streams>
 
 <stream name="mixedLayerDepthsOutput"
-        type="none"/>
+        output_interval="none"/>
 
 </streams>


### PR DESCRIPTION
Also disable SSH consistency check.

These errors aren't fatal but they mean that the `ssh_adjustment` directory has a number of MPAS-Ocean error files, which looks troubling.  Better to prevent them.

closes #68 