### PR TITLE
Turn off surface restoring in global ocean

### DIFF
--- a/compass/ocean/tests/global_ocean/namelist.forward
+++ b/compass/ocean/tests/global_ocean/namelist.forward
@@ -14,7 +14,6 @@ config_eos_type = 'jm'
 config_implicit_bottom_drag_coeff = 1.0e-3
 config_use_bulk_wind_stress = .true.
 config_use_bulk_thickness_flux = .true.
-config_use_activeTracers_surface_restoring = .true.
 config_use_Redi = .true.
 config_use_GM = .true.
 config_AM_mixedLayerDepths_enable = .true.


### PR DESCRIPTION
We have discussed that we do not want to have surface restoring as part of dynamic adjustment anymore.