### PR TITLE
Automatically read test-case config files

### DIFF
--- a/compass/landice/tests/enthalpy_benchmark/A/__init__.py
+++ b/compass/landice/tests/enthalpy_benchmark/A/__init__.py
@@ -52,9 +52,6 @@ class A(TestCase):
         """
         Modify the configuration options for this test case
         """
-        add_config(self.config, 'compass.landice.tests.enthalpy_benchmark.A',
-                   'A.cfg', exception=True)
-
         with path('compass.landice.tests.enthalpy_benchmark', 'README') as \
                 target:
             symlink(str(target), '{}/README'.format(self.work_dir))

--- a/compass/landice/tests/enthalpy_benchmark/B/__init__.py
+++ b/compass/landice/tests/enthalpy_benchmark/B/__init__.py
@@ -38,9 +38,6 @@ class B(TestCase):
         """
         Modify the configuration options for this test case
         """
-        add_config(self.config, 'compass.landice.tests.enthalpy_benchmark.B',
-                   'B.cfg', exception=True)
-
         with path('compass.landice.tests.enthalpy_benchmark', 'README') as \
                 target:
             symlink(str(target), '{}/README'.format(self.work_dir))

--- a/compass/ocean/tests/global_ocean/configure.py
+++ b/compass/ocean/tests/global_ocean/configure.py
@@ -25,9 +25,6 @@ def configure_global_ocean(test_case, mesh, init=None):
         config.set('global_ocean', 'prefix', '{}wISC'.format(
             config.get('global_ocean', 'prefix')))
 
-    add_config(config, test_case.__module__, '{}.cfg'.format(test_case.name),
-               exception=False)
-
     # add a description of the initial condition
     if init is not None:
         initial_condition = init.initial_condition

--- a/compass/ocean/tests/ice_shelf_2d/__init__.py
+++ b/compass/ocean/tests/ice_shelf_2d/__init__.py
@@ -45,6 +45,3 @@ def configure(name, resolution, config):
     res_params = res_params[resolution]
     for param in res_params:
         config.set('ice_shelf_2d', param, '{}'.format(res_params[param]))
-
-    add_config(config, 'compass.ocean.tests.ice_shelf_2d.{}'.format(name),
-               '{}.cfg'.format(name), exception=False)

--- a/compass/ocean/tests/ziso/__init__.py
+++ b/compass/ocean/tests/ziso/__init__.py
@@ -47,6 +47,3 @@ def configure(name, resolution, config):
     res_params = res_params[resolution]
     for param in res_params:
         config.set('ziso', param, '{}'.format(res_params[param]))
-
-    add_config(config, 'compass.ocean.tests.ziso.{}'.format(name),
-               '{}.cfg'.format(name), exception=False)

--- a/compass/setup.py
+++ b/compass/setup.py
@@ -150,10 +150,14 @@ def setup_case(path, test_case, config_file, machine, work_dir, baseline_dir,
     add_config(config, 'compass.{}'.format(mpas_core),
                '{}.cfg'.format(mpas_core))
 
-    # add the config options for the configuration (if defined)
+    # add the config options for the test group (if defined)
     test_group = test_case.test_group.name
     add_config(config, 'compass.{}.tests.{}'.format(mpas_core, test_group),
                '{}.cfg'.format(test_group), exception=False)
+
+    # add the config options for the test case (if defined)
+    add_config(config, test_case.__module__,
+               '{}.cfg'.format(test_case.name), exception=False)
 
     test_case_dir = os.path.join(work_dir, path)
     try:

--- a/compass/testcase.py
+++ b/compass/testcase.py
@@ -123,7 +123,9 @@ class TestCase:
         Modify the configuration options for this test case. Test cases should
         override this method if they want to add config options specific to
         the test case, e.g. from a config file stored in the test case's python
-        package
+        package.  If a test case overrides this method, it should assume that
+        the ``<self.name>.cfg`` file in its package has already been added
+        to the config options prior to calling ``configure()``.
         """
         pass
 

--- a/docs/developers_guide/organization.rst
+++ b/docs/developers_guide/organization.rst
@@ -575,10 +575,16 @@ The :py:meth:`compass.TestCase.configure()` method can be overridden by a
 child class to set config options or build them up from defaults stored in
 config files within the test case or its test group. The ``self.config``
 attribute that is modified in this function will be written to a config file
-for the test case (see :ref:`config_files`). Since many test groups need
-similar behavior in the ``configure()`` method for each test case, it is common
-to have a shared function (sometimes also called ``configure()``) in the
-test group, as we discussed in :ref:`dev_test_groups`.
+for the test case (see :ref:`config_files`).
+
+If you override this method in a test case, you should assume that the
+``<test_case.name>.cfg`` file in its package has already been added to the
+config options prior to calling ``configure()``.  This happens automatically
+during test-case setup.
+
+Since many test groups need similar behavior in the ``configure()`` method for
+each test case, it is common to have a shared function (sometimes also called
+``configure()``) in the test group, as we discussed in :ref:`dev_test_groups`.
 
 :py:meth:`compass.ocean.tests.baroclinic_channel.rpe_test.RpeTest.configure()`
 simply calls the shared function in its test group,


### PR DESCRIPTION
This means test cases don't need to override the `configure()` method if all they want to do is load the config file `<test_case>.cfg` in the test-case package (directory).

Land-ice and ocean test case and test groups have been updated to no longer load the test case's config file (since this will have already happened automatically).  For now, this doesn't reduce code very much because in all of these cases, the `configure()` method (or shared configure function at the test group level) did more than just load the test case's config options.  But it is likely to make things simpler in the future.

closes #72 