### PR TITLE
Allow `add_model_as_input()` to be called in `__init__()`

### DIFF
--- a/compass/landice/tests/dome/run_model.py
+++ b/compass/landice/tests/dome/run_model.py
@@ -80,15 +80,11 @@ class RunModel(Step):
                             target='../setup_mesh/landice_grid.nc')
         self.add_input_file(filename='graph.info',
                             target='../setup_mesh/graph.info')
+        self.add_model_as_input()
 
         self.add_output_file(filename='output.nc')
 
-    def setup(self):
-        """
-        Set up the test case in the work directory, including downloading any
-        dependencies
-        """
-        self.add_model_as_input()
+    # no setup() is needed
 
     def run(self):
         """

--- a/compass/landice/tests/eismint2/run_experiment.py
+++ b/compass/landice/tests/eismint2/run_experiment.py
@@ -91,15 +91,11 @@ class RunExperiment(Step):
 
         self.add_input_file(filename='graph.info',
                             target='../setup_mesh/graph.info')
+        self.add_model_as_input()
 
         self.add_output_file(filename='output.nc')
 
-    def setup(self):
-        """
-        Set up the test case in the work directory, including downloading any
-        dependencies
-        """
-        self.add_model_as_input()
+    # no setup() is needed
 
     def run(self):
         """

--- a/compass/landice/tests/enthalpy_benchmark/run_model.py
+++ b/compass/landice/tests/enthalpy_benchmark/run_model.py
@@ -65,14 +65,11 @@ class RunModel(Step):
             filename = os.path.basename(restart_filename)
             self.add_input_file(filename=filename, target=restart_filename)
 
+        self.add_model_as_input()
+
         self.add_output_file(filename='output.nc')
 
-    def setup(self):
-        """
-        Set up the test case in the work directory, including downloading any
-        dependencies
-        """
-        self.add_model_as_input()
+    # no setup() is needed
 
     def run(self):
         """

--- a/compass/landice/tests/greenland/run_model.py
+++ b/compass/landice/tests/greenland/run_model.py
@@ -73,14 +73,11 @@ class RunModel(Step):
                 'compass.landice.tests.greenland', 'streams.landice',
                 out_name='streams.{}'.format(suffix))
 
+        self.add_model_as_input()
+
         self.add_output_file(filename='output.nc')
 
-    def setup(self):
-        """
-        Set up the test case in the work directory, including downloading any
-        dependencies
-        """
-        self.add_model_as_input()
+    # no setup() is needed
 
     def run(self):
         """

--- a/compass/landice/tests/hydro_radial/run_model.py
+++ b/compass/landice/tests/hydro_radial/run_model.py
@@ -72,15 +72,11 @@ class RunModel(Step):
                             target='../setup_mesh/landice_grid.nc')
         self.add_input_file(filename='graph.info',
                             target='../setup_mesh/graph.info')
+        self.add_model_as_input()
 
         self.add_output_file(filename='output.nc')
 
-    def setup(self):
-        """
-        Set up the test case in the work directory, including downloading any
-        dependencies
-        """
-        self.add_model_as_input()
+    # no setup() is needed
 
     def run(self):
         """

--- a/compass/ocean/tests/baroclinic_channel/forward.py
+++ b/compass/ocean/tests/baroclinic_channel/forward.py
@@ -68,14 +68,11 @@ class Forward(Step):
         self.add_input_file(filename='graph.info',
                             target='../initial_state/culled_graph.info')
 
+        self.add_model_as_input()
+
         self.add_output_file(filename='output.nc')
 
-    def setup(self):
-        """
-        Set up the test case in the work directory, including downloading any
-        dependencies
-        """
-        self.add_model_as_input()
+    # no setup() is needed
 
     def run(self):
         """

--- a/compass/ocean/tests/global_ocean/forward.py
+++ b/compass/ocean/tests/global_ocean/forward.py
@@ -117,6 +117,8 @@ class ForwardStep(Step):
             filename='graph.info',
             work_dir_target='{}/culled_graph.info'.format(mesh_path))
 
+        self.add_model_as_input()
+
         self.add_output_file(filename='output.nc')
 
     def setup(self):
@@ -124,8 +126,6 @@ class ForwardStep(Step):
         Set up the test case in the work directory, including downloading any
         dependencies
         """
-        self.add_model_as_input()
-
         if self.cores is None:
             self.cores = self.config.getint(
                 'global_ocean', 'forward_cores')

--- a/compass/ocean/tests/global_ocean/init/initial_state.py
+++ b/compass/ocean/tests/global_ocean/init/initial_state.py
@@ -131,6 +131,8 @@ class InitialState(Step):
                 filename='land_ice_mask.nc',
                 work_dir_target='{}/land_ice_mask.nc'.format(mesh_path))
 
+        self.add_model_as_input()
+
         for file in ['initial_state.nc', 'init_mode_forcing_data.nc']:
             self.add_output_file(filename=file)
 
@@ -144,8 +146,6 @@ class InitialState(Step):
         self.cores = config.getint('global_ocean', 'init_cores')
         self.min_cores = config.getint('global_ocean', 'init_min_cores')
         self.threads = config.getint('global_ocean', 'init_threads')
-
-        self.add_model_as_input()
 
     def run(self):
         """

--- a/compass/ocean/tests/global_ocean/init/ssh_adjustment.py
+++ b/compass/ocean/tests/global_ocean/init/ssh_adjustment.py
@@ -57,6 +57,8 @@ class SshAdjustment(Step):
             filename='graph.info',
             work_dir_target='{}/culled_graph.info'.format(mesh_path))
 
+        self.add_model_as_input()
+
         self.add_output_file(filename='adjusted_init.nc')
 
     def setup(self):
@@ -64,8 +66,6 @@ class SshAdjustment(Step):
         Set up the test case in the work directory, including downloading any
         dependencies
         """
-        self.add_model_as_input()
-
         if self.cores is None:
             self.cores = self.config.getint(
                 'global_ocean', 'forward_cores')

--- a/compass/ocean/tests/ice_shelf_2d/forward.py
+++ b/compass/ocean/tests/ice_shelf_2d/forward.py
@@ -71,14 +71,11 @@ class Forward(Step):
         self.add_input_file(filename='graph.info',
                             target='../initial_state/culled_graph.info')
 
+        self.add_model_as_input()
+
         self.add_output_file('output.nc')
 
-    def setup(self):
-        """
-        Set up the test case in the work directory, including downloading any
-        dependencies
-        """
-        self.add_model_as_input()
+    # no setup() is needed
 
     def run(self):
         """

--- a/compass/ocean/tests/ice_shelf_2d/ssh_adjustment.py
+++ b/compass/ocean/tests/ice_shelf_2d/ssh_adjustment.py
@@ -54,14 +54,11 @@ class SshAdjustment(Step):
         self.add_input_file(filename='graph.info',
                             target='../initial_state/culled_graph.info')
 
+        self.add_model_as_input()
+
         self.add_output_file(filename='adjusted_init.nc')
 
-    def setup(self):
-        """
-        Set up the test case in the work directory, including downloading any
-        dependencies
-        """
-        self.add_model_as_input()
+    # no setup() is needed
 
     def run(self):
         """

--- a/compass/ocean/tests/ziso/forward.py
+++ b/compass/ocean/tests/ziso/forward.py
@@ -90,18 +90,15 @@ class Forward(Step):
         self.add_input_file(filename='graph.info',
                             target='../initial_state/culled_graph.info')
 
+        self.add_model_as_input()
+
         self.add_output_file(filename='output/output.0001-01-01_00.00.00.nc')
 
         if with_analysis:
             self.add_output_file(
                 filename='analysis_members/lagrPartTrack.0001-01-01_00.00.00.nc')
 
-    def setup(self):
-        """
-        Set up the test case in the work directory, including downloading any
-        dependencies
-        """
-        self.add_model_as_input()
+    # no setup() is needed
 
     def run(self):
         """

--- a/compass/step.py
+++ b/compass/step.py
@@ -270,10 +270,7 @@ class Step:
         """
         make a link to the model executable and add it to the inputs
         """
-        model = self.config.get('executables', 'model')
-        model_basename = os.path.basename(model)
-        self.add_input_file(filename=model_basename,
-                            target=os.path.abspath(model))
+        self.add_input_file(filename='<<<model>>>')
 
     def add_namelist_file(self, package, namelist, out_name=None,
                           mode='forward'):
@@ -392,6 +389,11 @@ class Step:
             database = entry['database']
             url = entry['url']
             work_dir_target = entry['work_dir_target']
+
+            if filename == '<<<model>>>':
+                model = self.config.get('executables', 'model')
+                filename = os.path.basename(model)
+                target = os.path.abspath(model)
 
             if work_dir_target is not None:
                 target = os.path.join(self.base_work_dir, work_dir_target)

--- a/docs/developers_guide/framework.rst
+++ b/docs/developers_guide/framework.rst
@@ -238,7 +238,8 @@ Running MPAS
 ^^^^^^^^^^^^
 
 Steps that run the MPAS model should call the
-:py:meth:`compass.Step.add_model_as_input()` method their ``setup()`` method.
+:py:meth:`compass.Step.add_model_as_input()` method their ``__init__()``
+method.
 
 To run MPAS, call :py:func:`compass.model.run_model()`.  By default, this
 function first updates the namelist options associated with the

--- a/docs/developers_guide/organization.rst
+++ b/docs/developers_guide/organization.rst
@@ -1029,25 +1029,27 @@ files to the step by calling any of the following methods:
 
 If you are running the MPAS model, you should call
 :py:func:`compass.Step.add_model_as_input()` to create a symlink to the
-MPAS model's executable.  This must be done in ``setup()``, not in the
-constructor, because it requires config options that have not been set during
-init.
+MPAS model's executable.  This can be done in the constructor or the
+``setup()`` method.
 
 Set up should not do any major computations or any time-consuming operations
 other than downloading files.  Time-consuming work should be saved for
 ``run()`` whenever possible.
 
 As an example, here is
-:py:func:`compass.ocean.tests.baroclinic_channel.forward.Forward.setup()`:
+:py:func:`compass.ocean.tests.global_ocean.mesh.mesh.MeshStep.setup()`:
 
 .. code-block:: python
 
     def setup(self):
         """
         Set up the test case in the work directory, including downloading any
-        dependencies
+        dependencies.
         """
-        self.add_model_as_input()
+        # get the these properties from the config options
+        config = self.config
+        self.cores = config.getint('global_ocean', 'mesh_cores')
+        self.min_cores = config.getint('global_ocean', 'mesh_min_cores')
 
 The model's executable is linked (and included among the ``inputs``).
 
@@ -1691,7 +1693,8 @@ Adding MPAS model as an input
 
 If a step involves running MPAS, the model executable can be linked and added
 as an input to the step by calling :py:func:`compass.model.add_model_as_input()`
-in the ``setup()`` method.  This way, if the user has forgotten to compile the
-model, this will be obvious by the broken symlink and the step will immediately
-fail because of the missing input.  The path to the executable is automatically
-detected based on the work directory for the step and the config options.
+in ``__init__()`` or the ``setup()`` method.  This way, if the user has
+forgotten to compile the model, this will be obvious by the broken symlink and
+the step will immediately fail because of the missing input.  The path to the
+executable is automatically detected based on the work directory for the step
+and the config options.


### PR DESCRIPTION
This is more convenient, but means that the model shouldn't actually be added until the necessary config option is available after setup.

This merge moves `add_model_as_input()` to each test cases' `__init__()` 

The docs are updated based on this change.

closes #73 