### PR TITLE
Split `Testcase.run()` into `run()` and `validate()` methods

### DIFF
--- a/compass/landice/tests/dome/decomposition_test/__init__.py
+++ b/compass/landice/tests/dome/decomposition_test/__init__.py
@@ -52,13 +52,13 @@ class DecompositionTest(TestCase):
 
     # no configure() method is needed
 
-    def run(self):
-        """
-        Run each step of the test case
-        """
-        # run the steps
-        super().run()
+    # no run() method is needed
 
+    def validate(self):
+        """
+        Test cases can override this method to perform validation of variables
+        and timers
+        """
         variables = ['thickness', 'normalVelocity']
         steps = self.steps_to_run
         if '1proc_run' in steps and '4proc_run' in steps:

--- a/compass/landice/tests/dome/restart_test/__init__.py
+++ b/compass/landice/tests/dome/restart_test/__init__.py
@@ -85,13 +85,13 @@ class RestartTest(TestCase):
 
     # no configure() method is needed
 
-    def run(self):
-        """
-        Run each step of the test case
-        """
-        # run the steps
-        super().run()
+    # no run() method is needed
 
+    def validate(self):
+        """
+        Test cases can override this method to perform validation of variables
+        and timers
+        """
         variables = ['thickness', 'normalVelocity']
         steps = self.steps_to_run
         if 'full_run' in steps and 'restart_run' in steps:

--- a/compass/landice/tests/eismint2/decomposition_test/__init__.py
+++ b/compass/landice/tests/eismint2/decomposition_test/__init__.py
@@ -52,13 +52,13 @@ class DecompositionTest(TestCase):
 
     # no configure() method is needed
 
-    def run(self):
-        """
-        Run each step of the test case
-        """
-        # run the steps
-        super().run()
+    # no run() method is needed
 
+    def validate(self):
+        """
+        Test cases can override this method to perform validation of variables
+        and timers
+        """
         variables = ['thickness', 'temperature', 'basalTemperature',
                      'heatDissipation']
         steps = self.steps_to_run

--- a/compass/landice/tests/eismint2/restart_test/__init__.py
+++ b/compass/landice/tests/eismint2/restart_test/__init__.py
@@ -78,13 +78,13 @@ class RestartTest(TestCase):
 
     # no configure() method is needed
 
-    def run(self):
-        """
-        Run each step of the test case
-        """
-        # run the steps
-        super().run()
+    # no run() method is needed
 
+    def validate(self):
+        """
+        Test cases can override this method to perform validation of variables
+        and timers
+        """
         variables = ['thickness', 'temperature', 'basalTemperature',
                      'heatDissipation']
         steps = self.steps_to_run

--- a/compass/landice/tests/enthalpy_benchmark/A/__init__.py
+++ b/compass/landice/tests/enthalpy_benchmark/A/__init__.py
@@ -59,12 +59,13 @@ class A(TestCase):
                 target:
             symlink(str(target), '{}/README'.format(self.work_dir))
 
-    def run(self):
+    # no run() method is needed
+
+    def validate(self):
         """
-        Run each step of the test case
+        Test cases can override this method to perform validation of variables
+        and timers
         """
-        # run the steps
-        super().run()
         variables = ['temperature', 'basalWaterThickness',
                      'groundedBasalMassBal']
         compare_variables(test_case=self, variables=variables,

--- a/compass/landice/tests/greenland/decomposition_test/__init__.py
+++ b/compass/landice/tests/greenland/decomposition_test/__init__.py
@@ -30,13 +30,13 @@ class DecompositionTest(TestCase):
 
     # no configure() method is needed
 
-    def run(self):
-        """
-        Run each step of the test case
-        """
-        # run the steps
-        super().run()
+    # no run() method is needed
 
+    def validate(self):
+        """
+        Test cases can override this method to perform validation of variables
+        and timers
+        """
         variables = ['thickness', 'normalVelocity']
         steps = self.steps_to_run
         if '1proc_run' in steps and '8proc_run' in steps:

--- a/compass/landice/tests/greenland/restart_test/__init__.py
+++ b/compass/landice/tests/greenland/restart_test/__init__.py
@@ -56,13 +56,13 @@ class RestartTest(TestCase):
 
     # no configure() method is needed
 
-    def run(self):
-        """
-        Run each step of the test case
-        """
-        # run the steps
-        super().run()
+    # no run() method is needed
 
+    def validate(self):
+        """
+        Test cases can override this method to perform validation of variables
+        and timers
+        """
         variables = ['thickness', 'normalVelocity']
         steps = self.steps_to_run
         if 'full_run' in steps and 'restart_run' in steps:

--- a/compass/landice/tests/hydro_radial/decomposition_test/__init__.py
+++ b/compass/landice/tests/hydro_radial/decomposition_test/__init__.py
@@ -40,13 +40,13 @@ class DecompositionTest(TestCase):
 
     # no configure() method is needed
 
-    def run(self):
-        """
-        Run each step of the test case
-        """
-        # run the steps
-        super().run()
+    # no run() method is needed
 
+    def validate(self):
+        """
+        Test cases can override this method to perform validation of variables
+        and timers
+        """
         variables = ['waterThickness', 'waterPressure']
         steps = self.steps_to_run
         if '1proc_run' in steps and '3proc_run' in steps:

--- a/compass/landice/tests/hydro_radial/restart_test/__init__.py
+++ b/compass/landice/tests/hydro_radial/restart_test/__init__.py
@@ -74,13 +74,13 @@ class RestartTest(TestCase):
 
     # no configure() method is needed
 
-    def run(self):
-        """
-        Run each step of the test case
-        """
-        # run the steps
-        super().run()
+    # no run() method is needed
 
+    def validate(self):
+        """
+        Test cases can override this method to perform validation of variables
+        and timers
+        """
         variables = ['waterThickness', 'waterPressure']
         steps = self.steps_to_run
         if 'full_run' in steps and 'restart_run' in steps:

--- a/compass/ocean/tests/baroclinic_channel/decomp_test/__init__.py
+++ b/compass/ocean/tests/baroclinic_channel/decomp_test/__init__.py
@@ -49,14 +49,13 @@ class DecompTest(TestCase):
         """
         baroclinic_channel.configure(self.resolution, self.config)
 
-    def run(self):
-        """
-        Run each step of the test case
-        """
-        # run the steps
-        super().run()
+    # no run() method is needed
 
-        # perform validation
+    def validate(self):
+        """
+        Test cases can override this method to perform validation of variables
+        and timers
+        """
         variables = ['temperature', 'salinity', 'layerThickness',
                      'normalVelocity']
         steps = self.steps_to_run

--- a/compass/ocean/tests/baroclinic_channel/restart_test/__init__.py
+++ b/compass/ocean/tests/baroclinic_channel/restart_test/__init__.py
@@ -57,14 +57,13 @@ class RestartTest(TestCase):
         """
         baroclinic_channel.configure(self.resolution, self.config)
 
-    def run(self):
-        """
-        Run each step of the test case
-        """
-        # run the steps
-        super().run()
+    # no run() method is needed
 
-        # perform validation
+    def validate(self):
+        """
+        Test cases can override this method to perform validation of variables
+        and timers
+        """
         variables = ['temperature', 'salinity', 'layerThickness',
                      'normalVelocity']
         steps = self.steps_to_run

--- a/compass/ocean/tests/baroclinic_channel/threads_test/__init__.py
+++ b/compass/ocean/tests/baroclinic_channel/threads_test/__init__.py
@@ -49,14 +49,13 @@ class ThreadsTest(TestCase):
         """
         baroclinic_channel.configure(self.resolution, self.config)
 
-    def run(self):
-        """
-        Run each step of the test case
-        """
-        # run the steps
-        super().run()
+    # no run() method is needed
 
-        # perform validation
+    def validate(self):
+        """
+        Test cases can override this method to perform validation of variables
+        and timers
+        """
         variables = ['temperature', 'salinity', 'layerThickness',
                      'normalVelocity']
         steps = self.steps_to_run

--- a/compass/ocean/tests/global_ocean/analysis_test/__init__.py
+++ b/compass/ocean/tests/global_ocean/analysis_test/__init__.py
@@ -43,13 +43,13 @@ class AnalysisTest(ForwardTestCase):
         step.add_streams_file(module, 'streams.forward')
         self.add_step(step)
 
-    def run(self):
-        """
-        Run each step of the testcase
-        """
-        # get cores, threads from config options and run the steps
-        super().run()
+    # no run() method is needed
 
+    def validate(self):
+        """
+        Test cases can override this method to perform validation of variables
+        and timers
+        """
         config = self.config
         work_dir = self.work_dir
 

--- a/compass/ocean/tests/global_ocean/daily_output_test/__init__.py
+++ b/compass/ocean/tests/global_ocean/daily_output_test/__init__.py
@@ -41,16 +41,13 @@ class DailyOutputTest(ForwardTestCase):
         step.add_streams_file(module, 'streams.forward')
         self.add_step(step)
 
-    def run(self):
-        """
-        Run each step of the testcase
-        """
-        # get cores, threads from config options and run the steps
-        super().run()
+    # no run() method is needed
 
-        config = self.config
-        work_dir = self.work_dir
-
+    def validate(self):
+        """
+        Test cases can override this method to perform validation of variables
+        and timers
+        """
         variables = [
             'timeDaily_avg_activeTracers_temperature',
             'timeDaily_avg_activeTracers_salinity',

--- a/compass/ocean/tests/global_ocean/decomp_test/__init__.py
+++ b/compass/ocean/tests/global_ocean/decomp_test/__init__.py
@@ -37,13 +37,13 @@ class DecompTest(ForwardTestCase):
                             time_integrator=time_integrator, name=name,
                             subdir=name, cores=procs, threads=1))
 
-    def run(self):
-        """
-        Run each step of the testcase
-        """
-        # get cores, threads from config options and run the steps
-        super().run()
+    # no run() method is needed
 
+    def validate(self):
+        """
+        Test cases can override this method to perform validation of variables
+        and timers
+        """
         variables = ['temperature', 'salinity', 'layerThickness',
                      'normalVelocity']
         steps = self.steps_to_run

--- a/compass/ocean/tests/global_ocean/dynamic_adjustment.py
+++ b/compass/ocean/tests/global_ocean/dynamic_adjustment.py
@@ -45,13 +45,13 @@ class DynamicAdjustment(ForwardTestCase):
 
         self.restart_filenames = restart_filenames
 
-    def run(self):
-        """
-        Run each step of the testcase
-        """
-        # get cores, threads from config options and run the steps
-        super().run()
+    # no run() method is needed
 
+    def validate(self):
+        """
+        Test cases can override this method to perform validation of variables
+        and timers
+        """
         variables = ['temperature', 'salinity', 'layerThickness',
                      'normalVelocity']
 

--- a/compass/ocean/tests/global_ocean/init/__init__.py
+++ b/compass/ocean/tests/global_ocean/init/__init__.py
@@ -79,7 +79,6 @@ class Init(TestCase):
         """
         config = self.config
         steps = self.steps_to_run
-        work_dir = self.work_dir
         if 'initial_state' in steps:
             step = self.steps['initial_state']
             # get the these properties from the config options
@@ -96,6 +95,13 @@ class Init(TestCase):
 
         # run the steps
         super().run()
+
+    def validate(self):
+        """
+        Test cases can override this method to perform validation of variables
+        and timers
+        """
+        steps = self.steps_to_run
 
         if 'initial_state' in steps:
             variables = ['temperature', 'salinity', 'layerThickness']

--- a/compass/ocean/tests/global_ocean/mesh/__init__.py
+++ b/compass/ocean/tests/global_ocean/mesh/__init__.py
@@ -75,6 +75,11 @@ class Mesh(TestCase):
         # run the step
         super().run()
 
+    def validate(self):
+        """
+        Test cases can override this method to perform validation of variables
+        and timers
+        """
         variables = ['xCell', 'yCell', 'zCell']
         compare_variables(test_case=self, variables=variables,
                           filename1='mesh/culled_mesh.nc')

--- a/compass/ocean/tests/global_ocean/performance_test/__init__.py
+++ b/compass/ocean/tests/global_ocean/performance_test/__init__.py
@@ -41,13 +41,13 @@ class PerformanceTest(ForwardTestCase):
             step.add_output_file(filename='land_ice_fluxes.nc')
         self.add_step(step)
 
-    def run(self):
-        """
-        Run each step of the testcase
-        """
-        # get cores, threads from config options and run the steps
-        super().run()
+    # no run() method is needed
 
+    def validate(self):
+        """
+        Test cases can override this method to perform validation of variables
+        and timers
+        """
         variables = ['temperature', 'salinity', 'layerThickness',
                      'normalVelocity']
         if self.init.with_bgc:

--- a/compass/ocean/tests/global_ocean/restart_test/__init__.py
+++ b/compass/ocean/tests/global_ocean/restart_test/__init__.py
@@ -53,13 +53,13 @@ class RestartTest(ForwardTestCase):
                 step.add_output_file(filename=output_file[part])
             self.add_step(step)
 
-    def run(self):
-        """
-        Run each step of the testcase
-        """
-        # get cores, threads from config options and run the steps
-        super().run()
+    # no run() method is needed
 
+    def validate(self):
+        """
+        Test cases can override this method to perform validation of variables
+        and timers
+        """
         variables = ['temperature', 'salinity', 'layerThickness',
                      'normalVelocity']
         steps = self.steps_to_run

--- a/compass/ocean/tests/global_ocean/threads_test/__init__.py
+++ b/compass/ocean/tests/global_ocean/threads_test/__init__.py
@@ -37,13 +37,13 @@ class ThreadsTest(ForwardTestCase):
                             time_integrator=time_integrator, name=name,
                             subdir=name, cores=4, threads=threads))
 
-    def run(self):
-        """
-        Run each step of the testcase
-        """
-        # get cores, threads from config options and run the steps
-        super().run()
+    # no run() method is needed
 
+    def validate(self):
+        """
+        Test cases can override this method to perform validation of variables
+        and timers
+        """
         variables = ['temperature', 'salinity', 'layerThickness',
                      'normalVelocity']
         steps = self.steps_to_run

--- a/compass/ocean/tests/ice_shelf_2d/default/__init__.py
+++ b/compass/ocean/tests/ice_shelf_2d/default/__init__.py
@@ -50,14 +50,13 @@ class Default(TestCase):
         """
         ice_shelf_2d.configure(self.name, self.resolution, self.config)
 
-    def run(self):
-        """
-        Run each step of the test case
-        """
-        # run the steps
-        super().run()
+    # no run() method is needed
 
-        # perform validation
+    def validate(self):
+        """
+        Test cases can override this method to perform validation of variables
+        and timers
+        """
         variables = ['temperature', 'salinity', 'layerThickness',
                      'normalVelocity']
         compare_variables(test_case=self, variables=variables,

--- a/compass/ocean/tests/ice_shelf_2d/restart_test/__init__.py
+++ b/compass/ocean/tests/ice_shelf_2d/restart_test/__init__.py
@@ -60,14 +60,13 @@ class RestartTest(TestCase):
         """
         ice_shelf_2d.configure(self.name, self.resolution, self.config)
 
-    def run(self):
-        """
-        Run each step of the test case
-        """
-        # run the steps
-        super().run()
+    # no run() method is needed
 
-        # perform validation
+    def validate(self):
+        """
+        Test cases can override this method to perform validation of variables
+        and timers
+        """
         steps = self.steps_to_run
         if 'full_run' in steps and 'restart_run' in steps:
             variables = ['temperature', 'salinity', 'layerThickness',

--- a/compass/ocean/tests/ziso/default/__init__.py
+++ b/compass/ocean/tests/ziso/default/__init__.py
@@ -64,14 +64,13 @@ class Default(TestCase):
         """
         ziso.configure(self.name, self.resolution, self.config)
 
-    def run(self):
-        """
-        Run each step of the test case
-        """
-        # run the steps
-        super().run()
+    # no run() method is needed
 
-        # perform validation
+    def validate(self):
+        """
+        Test cases can override this method to perform validation of variables
+        and timers
+        """
         config = self.config
         work_dir = self.work_dir
 

--- a/compass/ocean/tests/ziso/with_frazil/__init__.py
+++ b/compass/ocean/tests/ziso/with_frazil/__init__.py
@@ -59,17 +59,13 @@ class WithFrazil(TestCase):
         """
         ziso.configure(self.name, self.resolution, self.config)
 
-    def run(self):
-        """
-        Run each step of the test case
-        """
-        # run the steps
-        super().run()
+    # no run() method is needed
 
-        # perform validation
-        config = self.config
-        work_dir = self.work_dir
-
+    def validate(self):
+        """
+        Test cases can override this method to perform validation of variables
+        and timers
+        """
         steps = self.steps_to_run
         if 'forward' in steps:
             variables = ['temperature', 'layerThickness']

--- a/compass/run.py
+++ b/compass/run.py
@@ -62,10 +62,10 @@ def run_suite(suite_name):
                 test_start = time.time()
                 try:
                     test_case.run()
-                    run_status = 'PASS'
+                    run_status = 'SUCCESS'
                     test_pass = True
                 except BaseException:
-                    run_status = 'FAIL'
+                    run_status = 'ERROR'
                     test_pass = False
                     test_logger.exception('Exception raised')
 
@@ -101,12 +101,12 @@ def run_suite(suite_name):
                 if internal_status is None:
                     status = '  {}'.format(run_status)
                 elif baseline_status is None:
-                    status = '  test:                {}\n' \
-                             '  internal validation: {}'.format(
+                    status = '  test execution:  {}\n' \
+                             '  test validation: {}'.format(
                                   run_status, internal_status)
                 else:
-                    status = '  test:                {}\n' \
-                             '  internal validation: {}\n' \
+                    status = '  test execution:      {}\n' \
+                             '  test validation:     {}\n' \
                              '  baseline comparison: {}'.format(
                                   run_status, internal_status, baseline_status)
 

--- a/compass/run.py
+++ b/compass/run.py
@@ -76,28 +76,30 @@ def run_suite(suite_name):
                 except BaseException:
                     run_status = error_str
                     test_pass = False
-                    test_logger.exception('Exception raised')
+                    test_logger.exception('Exception raised in run()')
 
-                internal_status = None
                 if test_pass:
                     try:
                         test_case.validate()
-                        internal_status = pass_str
                     except BaseException:
-                        internal_status = fail_str
+                        run_status = error_str
                         test_pass = False
-                        test_logger.exception('Exception raised')
+                        test_logger.exception('Exception raised in validate()')
 
                 baseline_status = None
+                internal_status = None
                 if test_case.validation is not None:
                     internal_pass = test_case.validation['internal_pass']
                     baseline_pass = test_case.validation['baseline_pass']
 
-                    if internal_pass is not None and not internal_pass:
-                        internal_status = fail_str
-                        test_logger.exception(
-                            'Internal test case validation failed')
-                        test_pass = False
+                    if internal_pass is not None:
+                        if internal_pass:
+                            internal_status = pass_str
+                        else:
+                            internal_status = fail_str
+                            test_logger.exception(
+                                'Internal test case validation failed')
+                            test_pass = False
 
                     if baseline_pass is not None:
                         if baseline_pass:
@@ -107,17 +109,13 @@ def run_suite(suite_name):
                             test_logger.exception('Baseline validation failed')
                             test_pass = False
 
-                if internal_status is None:
-                    status = '  {}'.format(run_status)
-                elif baseline_status is None:
-                    status = '  test execution:      {}\n' \
-                             '  test validation:     {}'.format(
-                                  run_status, internal_status)
-                else:
-                    status = '  test execution:      {}\n' \
-                             '  test validation:     {}\n' \
-                             '  baseline comparison: {}'.format(
-                                  run_status, internal_status, baseline_status)
+                status = '  test execution:      {}'.format(run_status)
+                if internal_status is not None:
+                    status = '{}\n  test validation:     {}'.format(
+                        status, internal_status)
+                if baseline_status is not None:
+                    status = '{}\n  baseline comparison: {}'.format(
+                        status, baseline_status)
 
                 if test_pass:
                     logger.info(status)

--- a/compass/run.py
+++ b/compass/run.py
@@ -18,6 +18,15 @@ def run_suite(suite_name):
     suite_name : str
         The name of the test suite
     """
+    # ANSI fail text: https://stackoverflow.com/a/287944/7728169
+    start_fail = '\033[91m'
+    start_pass = '\033[92m'
+    end = '\033[0m'
+    pass_str = '{}PASS{}'.format(start_pass, end)
+    success_str = '{}SUCCESS{}'.format(start_pass, end)
+    fail_str = '{}FAIL{}'.format(start_fail, end)
+    error_str = '{}ERROR{}'.format(start_fail, end)
+
     if not os.path.exists('{}.pickle'.format(suite_name)):
         raise ValueError('The suite "{}" doesn\'t appear to have been set up '
                          'here.'.format(suite_name))
@@ -62,10 +71,10 @@ def run_suite(suite_name):
                 test_start = time.time()
                 try:
                     test_case.run()
-                    run_status = 'SUCCESS'
+                    run_status = success_str
                     test_pass = True
                 except BaseException:
-                    run_status = 'ERROR'
+                    run_status = error_str
                     test_pass = False
                     test_logger.exception('Exception raised')
 
@@ -73,9 +82,9 @@ def run_suite(suite_name):
                 if test_pass:
                     try:
                         test_case.validate()
-                        internal_status = 'PASS'
+                        internal_status = pass_str
                     except BaseException:
-                        internal_status = 'FAIL'
+                        internal_status = fail_str
                         test_pass = False
                         test_logger.exception('Exception raised')
 
@@ -85,24 +94,24 @@ def run_suite(suite_name):
                     baseline_pass = test_case.validation['baseline_pass']
 
                     if internal_pass is not None and not internal_pass:
-                        internal_status = 'FAIL'
+                        internal_status = fail_str
                         test_logger.exception(
                             'Internal test case validation failed')
                         test_pass = False
 
                     if baseline_pass is not None:
                         if baseline_pass:
-                            baseline_status = 'PASS'
+                            baseline_status = pass_str
                         else:
-                            baseline_status = 'FAIL'
+                            baseline_status = fail_str
                             test_logger.exception('Baseline validation failed')
                             test_pass = False
 
                 if internal_status is None:
                     status = '  {}'.format(run_status)
                 elif baseline_status is None:
-                    status = '  test execution:  {}\n' \
-                             '  test validation: {}'.format(
+                    status = '  test execution:      {}\n' \
+                             '  test validation:     {}'.format(
                                   run_status, internal_status)
                 else:
                     status = '  test execution:      {}\n' \
@@ -112,12 +121,12 @@ def run_suite(suite_name):
 
                 if test_pass:
                     logger.info(status)
-                    success[test_name] = 'PASS'
+                    success[test_name] = pass_str
                 else:
                     logger.error(status)
                     logger.error('  see: case_outputs/{}.log'.format(
                         test_name))
-                    success[test_name] = 'FAIL'
+                    success[test_name] = fail_str
                     failures += 1
 
                 test_times[test_name] = time.time() - test_start

--- a/compass/testcase.py
+++ b/compass/testcase.py
@@ -137,7 +137,7 @@ class TestCase:
         in the overridden ``run()`` method to actually call the steps of the
         run.  The developer will need to decide where in the overridden method
         to make the call to ``super().run()``, after any updates to steps
-        based on config options but before validation.
+        based on config options, typically at the end of the new method.
         """
         logger = self.logger
         cwd = os.getcwd()
@@ -168,6 +168,13 @@ class TestCase:
                 logger.info('     Complete')
 
             os.chdir(cwd)
+
+    def validate(self):
+        """
+        Test cases can override this method to perform validation of variables
+        and timers
+        """
+        pass
 
     def add_step(self, step, run_by_default=True):
         """

--- a/docs/developers_guide/api.rst
+++ b/docs/developers_guide/api.rst
@@ -124,6 +124,7 @@ testcase
    TestCase
    TestCase.configure
    TestCase.run
+   TestCase.validate
    TestCase.add_step
 
 step

--- a/docs/developers_guide/organization.rst
+++ b/docs/developers_guide/organization.rst
@@ -312,8 +312,8 @@ A test case can be a module but is usually a python package so it can
 incorporate modules for its steps and/or config files, namelists, and streams
 files.  The test case must include a class that descends from
 :py:class:`compass.TestCase`.  In addition to a constructor (``__init__()``),
-the class will often override the``run()`` and ``configure()`` methods of the
-base class, as described below.
+the class will often override the ``configure()``, ``run()`` and ``validate()``
+methods of the base class, as described below.
 
 .. _dev_test_case_class:
 
@@ -644,23 +644,16 @@ method with ``super().run()`` as part of overriding the ``run()`` method.
 Test case that just need to run their steps don't need to override the
 ``run()`` method at all.
 
-The most common reason that test cases will need to override ``run()`` is to
-perform :ref:`dev_validation` of variables in output files from a step and/or
-timers from the MPAS model.
+In some circumstances, it will be appropriate to update properties of the steps
+in the test case based on config options that the user may have changed.  This
+should only be necessary for config options related to the resources used by
+the step: the target number of cores, the minimum number of cores, and the
+number of threads.  Other config options can simply be read in from within the
+step's ``run()`` function as needed, but these performance-related config
+options affect how the step runs and must be set *before* the step can run.
 
-In some circumstances, it will also be appropriate to update properties of
-the steps in the test case based on config options that the user may have
-changed.  This should only be necessary for config options related to the
-resources used by the step: the target number of cores, the minimum number of
-cores, the number of threads.  Other config options can simply be read in from
-within the step's ``run()`` function as needed, but these performance-related
-config options affect how the step runs and must be set *before* the step can
-run.
-
-In this complex example,
-:py:meth:`compass.ocean.tests.global_ocean.init.Init.run()`, we see examples of
-both updating the steps' attributes based on config options and of validation
-of variables in the output:
+In :py:meth:`compass.ocean.tests.global_ocean.init.Init.run()`, we see examples
+of updating the steps' attributes based on config options:
 
 .. code-block:: python
 
@@ -688,9 +681,38 @@ of variables in the output:
         # run the steps
         super().run()
 
+As mentioned in :ref:`dev_test_case_class`, the ``self.steps_to_run`` attribute
+may either be the full list of steps that would typically be run to complete
+the test case (the value given to it at init) or it may be a single test case
+because the user is running the steps manually, one at a time.  For this
+reason, it is always a good idea to check if a given step is being run before
+altering the entries any of its attributes based on config options, as shown
+in the example.
+
+.. _dev_test_case_validate:
+
+validate()
+^^^^^^^^^^
+
+The base class's :py:meth:`compass.TestCase.validate()` can be overridden to
+perform :ref:`dev_validation` of variables in output files from a step and/or
+timers from the MPAS model.
+
+In  :py:meth:`compass.ocean.tests.global_ocean.init.Init.validate()`, we see
+examples of validation of variables from output files:
+
+.. code-block:: python
+
+    def validate(self):
+        """
+        Test cases can override this method to perform validation of variables
+        and timers
+        """
+        steps = self.steps_to_run
+
         if 'initial_state' in steps:
             variables = ['temperature', 'salinity', 'layerThickness']
-            compare_variables(variables, config, work_dir,
+            compare_variables(test_case=self, variables=variables,
                               filename1='initial_state/initial_state.nc')
 
             if self.with_bgc:
@@ -702,23 +724,21 @@ of variables in the output:
                     'diatFe', 'diatSi', 'diazChl', 'diazC', 'diazFe',
                     'phaeoChl', 'phaeoC', 'phaeoFe', 'DMS', 'DMSP', 'PROT',
                     'POLY', 'LIP']
-                compare_variables(variables, config, work_dir,
+                compare_variables(test_case=self, variables=variables,
                                   filename1='initial_state/initial_state.nc')
 
         if 'ssh_adjustment' in steps:
             variables = ['ssh', 'landIcePressure']
-            compare_variables(variables, config, work_dir,
+            compare_variables(test_case=self, variables=variables,
                               filename1='ssh_adjustment/adjusted_init.nc')
 
-As mentioned in :ref:`dev_test_case_class`, the ``self.steps_to_run`` attribute
-may either be the full list of steps that would typically be run to complete
-the test case (the value given to it at init) or it may be a single test case
-because the user is running the steps manually, one at a time.  For this
-reason, it is always a good idea to check if a given step is being run before
-altering the entries any of its attributes based on config options, as shown
-in the example.  Similarly, it is important to check if the step was run before
-running validation.  Otherwise, the validation may fail merely because the user
-didn't ask for that particular step.
+Again, as mentioned in :ref:`dev_test_case_class`, the ``self.steps_to_run``
+attribute may either be the full list of steps that would typically be run to
+complete the test case (the value given to it at init) or it may be a single
+test case because the user is running the steps manually, one at a time.  For
+this reason, it is important to check if the step was run before running
+validation on its outputs.  Otherwise, the validation may fail merely because
+the user didn't ask for that particular step.
 
 .. _dev_steps:
 


### PR DESCRIPTION
The `run()` method previously included validation of variables and timers, but things are cleaner in a few ways if running steps and validation are kept separate:

1. For steps that only need to validate variables or timers, there is no need to override the `run()` method at all, saving a (somewhat confusing) call to `super().run()`.  Since `TestCase.validate()` does nothing, there is no need to call `super().validate()`.
2. In test cases that do override `run()`, it is now clearer that `super().run()` should be called at the end of the new `run()` method to run the steps (e.g. after altering the number of cores that each step should run with based on config options).

All test cases have been updated with this split.

The output from test suites has been altered to indicate if the test, the internal validation, and the comparison with the baseline
passed:
```
ocean/baroclinic_channel/10km/default
  test execution:      SUCCESS
ocean/baroclinic_channel/10km/threads_test
  test execution:      SUCCESS
  test validation:     PASS
  baseline comparison: PASS
ocean/baroclinic_channel/10km/decomp_test
  test execution:      SUCCESS
  test validation:     PASS
  baseline comparison: PASS
```

The documentation has been updated to reflect these changes.

closes #74