### PR TITLE
Add a `package` argument to `add_input_file()`

### DIFF
--- a/compass/landice/tests/enthalpy_benchmark/A/__init__.py
+++ b/compass/landice/tests/enthalpy_benchmark/A/__init__.py
@@ -1,7 +1,6 @@
 from importlib.resources import path
 
 from compass.io import symlink
-from compass.config import add_config
 from compass.validate import compare_variables
 from compass.landice.tests.enthalpy_benchmark.setup_mesh import SetupMesh
 from compass.landice.tests.enthalpy_benchmark.run_model import RunModel

--- a/compass/landice/tests/enthalpy_benchmark/A/visualize.py
+++ b/compass/landice/tests/enthalpy_benchmark/A/visualize.py
@@ -2,7 +2,6 @@ import numpy as np
 from netCDF4 import Dataset
 import matplotlib.pyplot as plt
 from scipy.io import loadmat
-from importlib.resources import path
 
 from compass.step import Step
 
@@ -26,10 +25,9 @@ class Visualize(Step):
             self.add_input_file(filename='output{}.nc'.format(phase),
                                 target='../phase{}/output.nc'.format(phase))
 
-        filename = 'enthA_analy_result.mat'
-        with path('compass.landice.tests.enthalpy_benchmark.A', filename) as \
-                target:
-            self.add_input_file(filename=filename, target=str(target))
+        self.add_input_file(
+            filename='enthA_analy_result.mat',
+            package='compass.landice.tests.enthalpy_benchmark.A')
 
     # no setup() method is needed
 

--- a/compass/landice/tests/enthalpy_benchmark/B/__init__.py
+++ b/compass/landice/tests/enthalpy_benchmark/B/__init__.py
@@ -1,7 +1,6 @@
 from importlib.resources import path
 
 from compass.io import symlink
-from compass.config import add_config
 from compass.landice.tests.enthalpy_benchmark.setup_mesh import SetupMesh
 from compass.landice.tests.enthalpy_benchmark.run_model import RunModel
 from compass.landice.tests.enthalpy_benchmark.A.visualize import Visualize

--- a/compass/landice/tests/enthalpy_benchmark/B/visualize.py
+++ b/compass/landice/tests/enthalpy_benchmark/B/visualize.py
@@ -2,7 +2,6 @@ import numpy as np
 from netCDF4 import Dataset
 import matplotlib.pyplot as plt
 from scipy.io import loadmat
-from importlib.resources import path
 
 from compass.step import Step
 
@@ -25,10 +24,9 @@ class Visualize(Step):
         self.add_input_file(filename='output.nc',
                             target='../run_model/output.nc')
 
-        filename = 'enthB_analy_result.mat'
-        with path('compass.landice.tests.enthalpy_benchmark.B', filename) as \
-                target:
-            self.add_input_file(filename=filename, target=str(target))
+        self.add_input_file(
+            filename='enthB_analy_result.mat',
+            package='compass.landice.tests.enthalpy_benchmark.B')
 
     # no setup function is needed
 

--- a/compass/landice/tests/hydro_radial/setup_mesh.py
+++ b/compass/landice/tests/hydro_radial/setup_mesh.py
@@ -1,6 +1,5 @@
 import numpy as np
 from netCDF4 import Dataset as NetCDFFile
-from importlib.resources import path
 
 from mpas_tools.planar_hex import make_planar_hex_mesh
 from mpas_tools.io import write_netcdf
@@ -40,9 +39,8 @@ class SetupMesh(Step):
         self.initial_condition = initial_condition
 
         if initial_condition == 'exact':
-            filename = 'near_exact_solution_r_P_W.txt'
-            with path('compass.landice.tests.hydro_radial', filename) as target:
-                self.add_input_file(filename=filename, target=str(target))
+            self.add_input_file(filename='near_exact_solution_r_P_W.txt',
+                                package='compass.landice.tests.hydro_radial')
         elif initial_condition != 'zero':
             raise ValueError("Unknown initial condition type specified "
                              "{}.".format(initial_condition))

--- a/compass/landice/tests/hydro_radial/visualize.py
+++ b/compass/landice/tests/hydro_radial/visualize.py
@@ -1,7 +1,6 @@
 import numpy as np
 import netCDF4
 import matplotlib.pyplot as plt
-from importlib.resources import path
 
 from compass.step import Step
 
@@ -38,9 +37,8 @@ class Visualize(Step):
         self.add_input_file(filename='landice_grid.nc',
                             target='../{}/landice_grid.nc'.format(input_dir))
 
-        filename = 'near_exact_solution_r_P_W.txt'
-        with path('compass.landice.tests.hydro_radial', filename) as target:
-            self.add_input_file(filename=filename, target=str(target))
+        self.add_input_file(filename='near_exact_solution_r_P_W.txt',
+                            package='compass.landice.tests.hydro_radial')
 
     # depending on settings, this will produce no outputs, so we won't add any
 

--- a/compass/ocean/tests/global_ocean/mesh/so12to60/__init__.py
+++ b/compass/ocean/tests/global_ocean/mesh/so12to60/__init__.py
@@ -1,5 +1,4 @@
 import numpy as np
-from importlib import resources
 
 import mpas_tools.mesh.creation.mesh_definition_tools as mdt
 from mpas_tools.mesh.creation.signed_distance import \
@@ -33,6 +32,12 @@ class SO12to60Mesh(MeshStep):
         super().__init__(test_case, mesh_name, with_ice_shelf_cavities,
                          package=self.__module__,
                          mesh_config_filename='so12to60.cfg')
+
+        self.add_input_file(filename='atlantic.geojson',
+                            package=self.__module__)
+
+        self.add_input_file(filename='high_res_region.geojson',
+                            package=self.__module__)
 
     def build_cell_width_lat_lon(self):
         """
@@ -95,8 +100,7 @@ class SO12to60Mesh(MeshStep):
 
         _, cellWidthAtlantic = np.meshgrid(lon, cellWidthAtlantic)
 
-        with resources.path(self.package, 'atlantic.geojson') as path:
-            fc = read_feature_collection(str(path))
+        fc = read_feature_collection('atlantic.geojson')
 
         atlantic_signed_distance = signed_distance_from_geojson(
             fc, lon, lat, earth_radius, max_length=0.25)
@@ -108,8 +112,7 @@ class SO12to60Mesh(MeshStep):
 
         cellWidth = cellWidthAtlantic * (1 - weights) + cellWidth * weights
 
-        with resources.path(self.package, 'high_res_region.geojson') as path:
-            fc = read_feature_collection(str(path))
+        fc = read_feature_collection('high_res_region.geojson')
 
         so_signed_distance = signed_distance_from_geojson(fc, lon, lat,
                                                           earth_radius,

--- a/docs/developers_guide/organization.rst
+++ b/docs/developers_guide/organization.rst
@@ -1383,22 +1383,17 @@ test case:
 
 .. code-block:: python
 
-    from importlib.resources import path
-
     from compass.io import add_input_file
 
 
     def __init__(self, test_case):
         ...
-        filename = 'enthA_analy_result.mat'
-        with path('compass.landice.tests.enthalpy_benchmark.A', filename) as \
-                target:
-            self.add_input_file(filename=filename, target=str(target))
+        self.add_input_file(
+            filename='enthA_analy_result.mat',
+            package='compass.landice.tests.enthalpy_benchmark.A')
 
-Here, we use a :py:class:`importlib.resources.path` object as the target of the
-symlink (converting it to a string: ``str(target)``), which lets python take
-care of figuring out where ``compass`` is installed so it can find the path to
-the resource.
+Here, we supply the name of the package that the file is in.  The ``compass``
+framework will take care of figuring out where the package is located.
 
 .. _dev_step_input_download:
 


### PR DESCRIPTION
This argument is used to make a symlink to a file in the ``compass`` package and set that file as an input to the step.

With this change, it's a lot easier to link files from the package in a similar manner to how we are used to doing this in legacy COMPASS.  You can link geojson files, READMEs or even python scripts that a user should optionally run (e.g. for quick and dirty viz).

The ocean and landice cores have been updated with this change, as has the documentation.

closes #75