### PR TITLE
Alter `steps_to_run` in config file or command line

### DIFF
--- a/compass/default.cfg
+++ b/compass/default.cfg
@@ -1,3 +1,11 @@
+# Options related to the current test case
+[test_case]
+
+# The steps from the test case to run with "compass run"
+# This will be altered by the infrastructure to list the steps to run
+steps_to_run =
+
+
 # Options related to downloading files
 [download]
 

--- a/compass/run.py
+++ b/compass/run.py
@@ -168,11 +168,15 @@ def run_test_case():
     config.read(test_case.config_filename)
     test_case.config = config
 
+    steps = config.get('test_case', 'steps_to_run').replace(',', ' ').split()
+    test_case.steps_to_run = steps
+
     # start logging to stdout/stderr
     test_name = test_case.path.replace('/', '_')
     test_case.new_step_log_file = True
     with LoggingContext(name=test_name) as logger:
         test_case.logger = logger
+        logger.info('Running steps: {}'.format(', '.join(steps)))
         test_case.run()
         test_case.validate()
 

--- a/compass/run.py
+++ b/compass/run.py
@@ -69,6 +69,9 @@ def run_suite(suite_name):
                 config.read(test_case.config_filename)
                 test_case.config = config
 
+                test_case.steps_to_run = config.get(
+                    'test_case', 'steps_to_run').replace(',', ' ').split()
+
                 test_start = time.time()
                 try:
                     test_case.run()

--- a/compass/run.py
+++ b/compass/run.py
@@ -185,7 +185,20 @@ def run_test_case(steps_to_run=None, steps_not_to_run=None):
         steps_to_run = config.get('test_case',
                                   'steps_to_run').replace(',', ' ').split()
 
+    for step in steps_to_run:
+        if step not in test_case.steps:
+            raise ValueError(
+                'A step "{}" was requested but is not one of the steps in '
+                'this test case:\n{}'.format(step, list(test_case.steps)))
+
     if steps_not_to_run is not None:
+        for step in steps_not_to_run:
+            if step not in test_case.steps:
+                raise ValueError(
+                    'A step "{}" was flagged not to run but is not one of the '
+                    'steps in this test case:'
+                    '\n{}'.format(step, list(test_case.steps)))
+
         steps_to_run = [step for step in steps_to_run if step not in
                         steps_not_to_run]
 

--- a/compass/setup.py
+++ b/compass/setup.py
@@ -189,6 +189,8 @@ def setup_case(path, test_case, config_file, machine, work_dir, baseline_dir,
     if mpas_model_path is not None:
         config.set('paths', 'mpas_model', mpas_model_path)
 
+    config.set('test_case', 'steps_to_run', ' '.join(test_case.steps_to_run))
+
     # make sure all paths in the paths, namelists and streams sections are
     # absolute paths
     ensure_absolute_paths(config)

--- a/docs/developers_guide/command_line.rst
+++ b/docs/developers_guide/command_line.rst
@@ -212,7 +212,9 @@ that has been set up in the current directory:
 
 .. code-block:: none
 
-    compass run [-h] [suite]
+    compass run [-h] [--steps STEPS [STEPS ...]]
+                     [--no-steps NO_STEPS [NO_STEPS ...]]
+                     [suite]
 
 Whereas other ``compass`` commands are typically run in the local clone of the
 compass repo, ``compass run`` needs to be run in the appropriate work
@@ -220,3 +222,29 @@ directory. If you are running a test suite, you may need to provide the name
 of the test suite if more than one suite has been set up in the same work
 directory.  If you are in the work directory for a test case or step, you do
 not need to provide any arguments.
+
+If you want to explicitly select which steps in a test case you want to run,
+you have two options.  You can either edit the ``steps_to_run`` config options
+in the config file:
+
+.. code-block:: cfg
+
+    [test_case]
+    steps_to_run = initial_state full_run restart_run
+
+Or you can use ``--steps`` to supply a list of steps to run, or ``--no-steps``
+to supply a list of steps you do not want to run (from the defaults given in
+the config file).  For example,
+
+.. code-block:: none
+
+    python -m compass run --steps initial_state full_run
+
+or
+
+.. code-block:: none
+
+    python -m compass run --no-steps restart_run
+
+Would both accomplish the same thing in this example -- skipping the
+``restart_run`` step of the test case.

--- a/docs/developers_guide/command_line.rst
+++ b/docs/developers_guide/command_line.rst
@@ -248,3 +248,9 @@ or
 
 Would both accomplish the same thing in this example -- skipping the
 ``restart_run`` step of the test case.
+
+.. note::
+
+    If changes are made to ``steps_to_run`` in the config file and ``--steps``
+    is provided on the command line, the command-line flags take precedence
+    over the config option.


### PR DESCRIPTION
This merge adds the ability for users to choose which steps in a test case they want to run.  They have 2 options.

First, they can alter the `steps_to_run` config option in the `test_case` section at the very top of the test case's config file:
```
[test_case]
steps_to_run = initial_state full_run restart_run
```
The list of `steps_to_run` can be separated by spaces, commas or both.

Or they can specify which steps to run (or which steps not to run) via the ``--steps`` (or ``--no-steps``) flag to ``compass run``:

```
python -m compass run --steps initial_state full_run
python -m compass run --no-steps restart_run
```
Both of these accomplish the same thing -- skipping the ``restart_run`` step of the test case.

The new capability has been added to the documentation.

closes #80