### PR TITLE
Handle test cases that are not packages

### DIFF
--- a/compass/config.py
+++ b/compass/config.py
@@ -52,7 +52,7 @@ def add_config(config, package, config_file, exception=True):
     try:
         with resources.path(package, config_file) as path:
             config.read(path)
-    except (ModuleNotFoundError, FileNotFoundError):
+    except (ModuleNotFoundError, FileNotFoundError, TypeError):
         if exception:
             raise
 


### PR DESCRIPTION
Prior to this fix, if you have a `TestCase` child class that is in a module but not a package, it causes a `TypeError` to be raised when looking for a config file in the package (there is no package!).  With this change, we simply catch the exception and move on.