### PR TITLE
`compass run` runs a single suite without arg

### DIFF
--- a/compass/run.py
+++ b/compass/run.py
@@ -5,6 +5,7 @@ import pickle
 import configparser
 import time
 import numpy
+import glob
 
 from mpas_tools.logging import LoggingContext
 
@@ -213,5 +214,13 @@ def main():
     elif os.path.exists('step.pickle'):
         run_step()
     else:
-        raise OSError('A suite name was not given but the current directory '
-                      'does not contain a test case or step.')
+        pickles = glob.glob('*.pickle')
+        if len(pickles) == 1:
+            suite = os.path.splitext(os.path.basename(pickles[0]))[0]
+            run_suite(suite)
+        elif len(pickles) == 0:
+            raise OSError('No pickle files were found. Are you sure this is '
+                          'a compass suite, test-case or step work directory?')
+        else:
+            raise ValueError('More than one suite was found. Please specify '
+                             'which to run: compass run <suite>')

--- a/docs/developers_guide/command_line.rst
+++ b/docs/developers_guide/command_line.rst
@@ -217,7 +217,7 @@ that has been set up in the current directory:
 
 Whereas other ``compass`` commands are typically run in the local clone of the
 compass repo, ``compass run`` needs to be run in the appropriate work
-directory. If you are running a test suite, you need to provide the name of the
-test suite because more than one suite can be set up in the same work
+directory. If you are running a test suite, you may need to provide the name
+of the test suite if more than one suite has been set up in the same work
 directory.  If you are in the work directory for a test case or step, you do
 not need to provide any arguments.

--- a/docs/users_guide/quick_start.rst
+++ b/docs/users_guide/quick_start.rst
@@ -251,7 +251,7 @@ and
 .. code-block:: bash
 
     cd $WORKDIR
-    compass run nightly
+    compass run [nightly]
 
-In this case, you have to specify the name of the suite to run because you can
-set up multiple suites in the same ``$WORKDIR``.
+In this case, you can specify the name of the suite to run.  This is required
+if there are multiple suites in the same ``$WORKDIR``.


### PR DESCRIPTION
With this merge, if you only set up a single test suite in a work directory, `compass run` will work without the need to specify the suite name.  Since this is by far the most common work flow, this change should save a little trouble nearly every time a test suite is run.