### PR TITLE
Two small fixes to the `setup` module

### DIFF
--- a/compass/setup.py
+++ b/compass/setup.py
@@ -208,7 +208,7 @@ def setup_case(path, test_case, config_file, machine, work_dir, baseline_dir,
         except OSError:
             pass
 
-        symlink(os.path.join('..', test_case_config),
+        symlink(os.path.join(test_case_dir, test_case_config),
                 os.path.join(step_dir, test_case_config))
 
         step.work_dir = step_dir

--- a/compass/setup.py
+++ b/compass/setup.py
@@ -167,11 +167,17 @@ def setup_case(path, test_case, config_file, machine, work_dir, baseline_dir,
     test_case.work_dir = test_case_dir
     test_case.base_work_dir = work_dir
 
+    # add the custom config file once before calling configure() in case we
+    # need to use the config options from there
+    if config_file is not None:
+        config.read(config_file)
+
     # add config options specific to the test case
     test_case.config = config
     test_case.configure()
 
-    # add the custom config file last, so these options are the defaults
+    # add the custom config file (again) last, so these options are the
+    # defaults
     if config_file is not None:
         config.read(config_file)
 


### PR DESCRIPTION
This came up in reorganizing #111.

First, it is convenient to add the custom config file to the config options both before and after calling the test case's `configure()` method.  It turns out that you can use config options to determine which steps to add to a test case if you do this.  This is really convenient for defining a flexible parameter study like the convergence test in #111.  You can make the parameter values a config option.  The user could make a custom config file and alter the config options there before setting up the test case.  Depending on how the test case is set up, altering the config options between setup and run might either have no effect (as in #111) or cause you trouble, so that would be something to document as part of each test case that uses this approach.

The second thing is that the symlink in each step to the test case's config file in the work directory was previously just `../<config>.cfg`.  But `compass` allows steps have a more complex directory structure, we just hadn't tried it before.  This merge makes the symlink using an absolute path to the test case's config file, which means we don't have to figure out the relative path between the step and the test case.  Since it isn't really possible to move a work directory without breaking things anyway (i.e. there are already symlinks with absolute paths within the work directory for other purposes), I think this is not a problem.