### PR TITLE
Copy a list of tests in a suite to work dir 

### DIFF
--- a/compass/suite.py
+++ b/compass/suite.py
@@ -69,6 +69,8 @@ def setup_suite(mpas_core, suite_name, config_file=None, machine=None,
     filename = os.path.join(work_dir, '{}.txt'.format(suite_name))
 
     with open(filename, 'w') as f:
+        f.write('# A list of tests in the suite.  Remove or comment out tests '
+                'to skip them.\n')
         f.write('\n'.join(tests))
 
     test_cases = setup_cases(tests, config_file=config_file, machine=machine,

--- a/compass/suite.py
+++ b/compass/suite.py
@@ -54,12 +54,22 @@ def setup_suite(mpas_core, suite_name, config_file=None, machine=None,
     tests = list()
     for test in text.split('\n'):
         test = test.strip()
-        if len(test) > 0 and test not in tests:
+        if len(test) > 0 and test[0] != '#' and test not in tests:
             tests.append(test)
 
     if work_dir is None:
         work_dir = os.getcwd()
     work_dir = os.path.abspath(work_dir)
+
+    try:
+        os.makedirs(work_dir)
+    except OSError:
+        pass
+
+    filename = os.path.join(work_dir, '{}.txt'.format(suite_name))
+
+    with open(filename, 'w') as f:
+        f.write('\n'.join(tests))
 
     test_cases = setup_cases(tests, config_file=config_file, machine=machine,
                              work_dir=work_dir, baseline_dir=baseline_dir,

--- a/docs/users_guide/test_suites.rst
+++ b/docs/users_guide/test_suites.rst
@@ -59,3 +59,21 @@ for regression testing of MPAS-Ocean.  Here are the tests included:
     ocean/ice_shelf_2d/5km/restart_test
     ocean/ziso/20km/default
     ocean/ziso/20km/with_frazil
+
+After setting up a test case, you can see the tests in the case you opening
+the file ``<suite>.txt`` in the work directory.  You can remove or comment out
+(with ``#``) any tests you don't want to run before running the suite.
+
+To run the suite, call:
+
+.. code-block:: bash
+
+    compass run
+
+If you have set up multiple suites in the same directory, run:
+
+.. code-block:: bash
+
+    compass run <suite>
+
+to select a specific suite to run.


### PR DESCRIPTION
This list can be edited to remove or comment out (with `#`) the tests not to run.

The user's guide has been updated to mention this option.

closes #114 