### PR TITLE
Add z-level ice-shelf 2d test cases

### DIFF
--- a/compass/ocean/suites/nightly.txt
+++ b/compass/ocean/suites/nightly.txt
@@ -22,7 +22,8 @@ ocean/global_ocean/QU240/EN4_1900/performance_test
 ocean/global_ocean/QU240/PHC_BGC/init
 ocean/global_ocean/QU240/PHC_BGC/performance_test
 
-ocean/ice_shelf_2d/5km/restart_test
+ocean/ice_shelf_2d/5km/z-star/restart_test
+ocean/ice_shelf_2d/5km/z-level/restart_test
 
 ocean/ziso/20km/default
 ocean/ziso/20km/with_frazil

--- a/compass/ocean/tests/ice_shelf_2d/__init__.py
+++ b/compass/ocean/tests/ice_shelf_2d/__init__.py
@@ -15,23 +15,26 @@ class IceShelf2d(TestGroup):
         super().__init__(mpas_core=mpas_core, name='ice_shelf_2d')
 
         for resolution in ['5km']:
-            self.add_test_case(
-                Default(test_group=self, resolution=resolution))
-            self.add_test_case(
-                RestartTest(test_group=self, resolution=resolution))
+            for coord_type in ['z-star', 'z-level']:
+                self.add_test_case(
+                    Default(test_group=self, resolution=resolution,
+                            coord_type=coord_type))
+                self.add_test_case(
+                    RestartTest(test_group=self, resolution=resolution,
+                                coord_type=coord_type))
 
 
-def configure(name, resolution, config):
+def configure(resolution, coord_type, config):
     """
     Modify the configuration options for this test case
 
     Parameters
     ----------
-    name : str
-        the name of the test case
-
     resolution : str
         The resolution of the test case
+
+    coord_type : str
+        The type of vertical coordinate (``z-star``, ``z-level``, etc.)
 
     config : configparser.ConfigParser
         Configuration options for this test case
@@ -44,3 +47,8 @@ def configure(name, resolution, config):
     res_params = res_params[resolution]
     for param in res_params:
         config.set('ice_shelf_2d', param, '{}'.format(res_params[param]))
+
+    config.set('vertical_grid', 'coord_type', coord_type)
+    if coord_type == 'z-level':
+        # we need more vertical resolution
+        config.set('vertical_grid', 'vert_levels', '100')

--- a/compass/ocean/tests/ice_shelf_2d/default/__init__.py
+++ b/compass/ocean/tests/ice_shelf_2d/default/__init__.py
@@ -2,6 +2,7 @@ from compass.testcase import TestCase
 from compass.ocean.tests.ice_shelf_2d.initial_state import InitialState
 from compass.ocean.tests.ice_shelf_2d.ssh_adjustment import SshAdjustment
 from compass.ocean.tests.ice_shelf_2d.forward import Forward
+from compass.ocean.tests.ice_shelf_2d.viz import Viz
 from compass.ocean.tests import ice_shelf_2d
 from compass.validate import compare_variables
 
@@ -50,6 +51,7 @@ class Default(TestCase):
         self.add_step(
             Forward(test_case=self, cores=4, threads=1, resolution=resolution,
                     with_frazil=True))
+        self.add_step(Viz(test_case=self), run_by_default=False)
 
     def configure(self):
         """

--- a/compass/ocean/tests/ice_shelf_2d/default/__init__.py
+++ b/compass/ocean/tests/ice_shelf_2d/default/__init__.py
@@ -16,9 +16,12 @@ class Default(TestCase):
     ----------
     resolution : str
         The horizontal resolution of the test case
+
+    coord_type : str
+        The type of vertical coordinate (``z-star``, ``z-level``, etc.)
     """
 
-    def __init__(self, test_group, resolution):
+    def __init__(self, test_group, resolution, coord_type):
         """
         Create the test case
 
@@ -29,10 +32,14 @@ class Default(TestCase):
 
         resolution : str
             The resolution of the test case
+
+        coord_type : str
+            The type of vertical coordinate (``z-star``, ``z-level``, etc.)
         """
         name = 'default'
         self.resolution = resolution
-        subdir = '{}/{}'.format(resolution, name)
+        self.coord_type = coord_type
+        subdir = '{}/{}/{}'.format(resolution, coord_type, name)
         super().__init__(test_group=test_group, name=name,
                          subdir=subdir)
 
@@ -48,7 +55,7 @@ class Default(TestCase):
         """
         Modify the configuration options for this test case.
         """
-        ice_shelf_2d.configure(self.name, self.resolution, self.config)
+        ice_shelf_2d.configure(self.resolution, self.coord_type, self.config)
 
     # no run() method is needed
 

--- a/compass/ocean/tests/ice_shelf_2d/ice_shelf_2d.cfg
+++ b/compass/ocean/tests/ice_shelf_2d/ice_shelf_2d.cfg
@@ -14,7 +14,7 @@ bottom_depth = 2000.0
 coord_type = z-star
 
 # Whether to use "partial" or "full", or "None" to not alter the topography
-partial_cell_type = None
+partial_cell_type = partial
 
 # The minimum fraction of a layer for partial cells
 min_pc_fraction = 0.1
@@ -24,7 +24,7 @@ min_pc_fraction = 0.1
 [ice_shelf_2d]
 
 # Vertical thickness of ocean sub-ice cavity
-cavity_thickness = 10.0
+cavity_thickness = 50.0
 
 # Vertical thickness of fixed slope
 slope_height = 500.0

--- a/compass/ocean/tests/ice_shelf_2d/restart_test/__init__.py
+++ b/compass/ocean/tests/ice_shelf_2d/restart_test/__init__.py
@@ -16,9 +16,12 @@ class RestartTest(TestCase):
     ----------
     resolution : str
         The resolution of the test case
+
+    coord_type : str
+        The type of vertical coordinate (``z-star``, ``z-level``, etc.)
     """
 
-    def __init__(self, test_group, resolution):
+    def __init__(self, test_group, resolution, coord_type):
         """
         Create the test case
 
@@ -29,10 +32,14 @@ class RestartTest(TestCase):
 
         resolution : str
             The resolution of the test case
+
+        coord_type : str
+            The type of vertical coordinate (``z-star``, ``z-level``, etc.)
         """
         name = 'restart_test'
         self.resolution = resolution
-        subdir = '{}/{}'.format(resolution, name)
+        self.coord_type = coord_type
+        subdir = '{}/{}/{}'.format(resolution, coord_type, name)
         super().__init__(test_group=test_group, name=name,
                          subdir=subdir)
 
@@ -58,7 +65,7 @@ class RestartTest(TestCase):
         """
         Modify the configuration options for this test case.
         """
-        ice_shelf_2d.configure(self.name, self.resolution, self.config)
+        ice_shelf_2d.configure(self.resolution, self.coord_type, self.config)
 
     # no run() method is needed
 

--- a/compass/ocean/tests/ice_shelf_2d/restart_test/__init__.py
+++ b/compass/ocean/tests/ice_shelf_2d/restart_test/__init__.py
@@ -2,6 +2,7 @@ from compass.testcase import TestCase
 from compass.ocean.tests.ice_shelf_2d.initial_state import InitialState
 from compass.ocean.tests.ice_shelf_2d.ssh_adjustment import SshAdjustment
 from compass.ocean.tests.ice_shelf_2d.forward import Forward
+from compass.ocean.tests.ice_shelf_2d.viz import Viz
 from compass.ocean.tests import ice_shelf_2d
 from compass.validate import compare_variables
 
@@ -60,6 +61,8 @@ class RestartTest(TestCase):
                 'compass.ocean.tests.ice_shelf_2d.restart_test',
                 'streams.{}'.format(part))
             self.add_step(step)
+
+        self.add_step(Viz(test_case=self), run_by_default=False)
 
     def configure(self):
         """

--- a/compass/ocean/tests/ice_shelf_2d/viz.py
+++ b/compass/ocean/tests/ice_shelf_2d/viz.py
@@ -1,0 +1,77 @@
+import xarray
+import numpy
+import matplotlib.pyplot as plt
+
+from compass.step import Step
+
+
+class Viz(Step):
+    """
+    A step for visualizing a cross-section through the 2D ice-shelf domain
+    """
+    def __init__(self, test_case):
+        """
+        Create the step
+
+        Parameters
+        ----------
+        test_case : compass.TestCase
+            The test case this step belongs to
+        """
+        super().__init__(test_case=test_case, name='viz')
+
+        self.add_input_file(filename='initial_state.nc',
+                            target='../initial_state/initial_state.nc')
+        self.add_output_file('vert_grid.png')
+
+    def run(self):
+        """
+        Run this step of the test case
+        """
+
+        ds = xarray.open_dataset('initial_state.nc')
+
+        if 'Time' in ds.dims:
+            ds = ds.isel(Time=0)
+
+        ds = ds.groupby('yCell').mean(dim='nCells')
+
+        nCells = ds.sizes['yCell']
+        nVertLevels = ds.sizes['nVertLevels']
+
+        zIndex = xarray.DataArray(data=numpy.arange(nVertLevels),
+                                  dims='nVertLevels')
+
+        minLevelCell = ds.minLevelCell - 1
+        maxLevelCell = ds.maxLevelCell - 1
+
+        cellMask = numpy.logical_and(zIndex >= minLevelCell,
+                                     zIndex <= maxLevelCell)
+
+        zIndex = xarray.DataArray(data=numpy.arange(nVertLevels + 1),
+                                  dims='nVertLevelsP1')
+
+        interfaceMask = numpy.logical_and(zIndex >= minLevelCell,
+                                          zIndex <= maxLevelCell + 1)
+
+        zMid = ds.zMid.where(cellMask)
+
+        zInterface = numpy.zeros((nCells, nVertLevels + 1))
+        zInterface[:, 0] = ds.ssh.values
+        for zIndex in range(nVertLevels):
+            thickness = ds.layerThickness.isel(nVertLevels=zIndex)
+            thickness = thickness.fillna(0.)
+            zInterface[:, zIndex + 1] = \
+                zInterface[:, zIndex] - thickness.values
+
+        zInterface = xarray.DataArray(data=zInterface,
+                                      dims=('yCell', 'nVertLevelsP1'))
+        zInterface = zInterface.where(interfaceMask)
+
+        plt.figure(figsize=[24, 12], dpi=100)
+        plt.plot(ds.yCell.values, zMid.values, 'b')
+        plt.plot(ds.yCell.values, zInterface.values, 'k')
+        plt.plot(ds.yCell.values, ds.ssh.values, 'g')
+        plt.plot(ds.yCell.values, -ds.bottomDepth.values, 'g')
+        plt.savefig('vert_grid.png', dpi=200)
+        plt.close()

--- a/docs/developers_guide/ocean/api.rst
+++ b/docs/developers_guide/ocean/api.rst
@@ -275,6 +275,9 @@ ice_shelf_2d
    ssh_adjustment.SshAdjustment.setup
    ssh_adjustment.SshAdjustment.run
 
+   viz.Viz
+   viz.Viz.run
+
 ziso
 ~~~~
 

--- a/docs/developers_guide/ocean/test_groups/ice_shelf_2d.rst
+++ b/docs/developers_guide/ocean/test_groups/ice_shelf_2d.rst
@@ -30,11 +30,12 @@ defines a step for setting up the initial state for each test case.
 First, a mesh appropriate for the resolution is generated using
 :py:func:`mpas_tools.planar_hex.make_planar_hex_mesh()`.  Then, the mesh is
 culled to remove periodicity in the y direction.  A vertical grid is generated,
-with 20 layers of 100-m thickness each by default.  Then, the 1D grid is
+with 20 layers of 100-m thickness each by default.  Then, the 1D grid is either
 "squashed" down so the sea-surface height corresponds to the location of the
-ice-ocean interface (ice draft) using a z-star :ref:`dev_ocean_framework_vertical`.
-Finally, the initial salinity profile is computed along with uniform
-temperature and zero initial velocity.
+ice-ocean interface (ice draft) using a z-star :ref:`dev_ocean_framework_vertical`
+or top layers are removed where there is an ice shelf using a z-level
+coordinate. Finally, the initial salinity profile is computed along with
+uniform temperature and zero initial velocity.
 
 ssh_adjustment
 ~~~~~~~~~~~~~~
@@ -65,11 +66,16 @@ A few namelist options are set and streams are added when frazil is included:
         self.add_namelist_options(options)
         self.add_streams_file('compass.ocean.streams', 'streams.frazil')
 
+viz
+~~~
+
+The class :py:class:`compass.ocean.tests.ice_shelf_2d.viz.Viz` does a
+quick-and-dirty visualization of the vertical coordinate (z-star or z-level).
+
 .. _dev_ocean_ice_shelf_2d_default:
 
 default
 -------
-
 
 The :py:class:`compass.ocean.tests.ice_shelf_2d.default.Default` test case
 includes the following default config options:

--- a/docs/users_guide/ocean/test_groups/ice_shelf_2d.rst
+++ b/docs/users_guide/ocean/test_groups/ice_shelf_2d.rst
@@ -30,11 +30,12 @@ The geometry does not represent a particularly realistic ice-shelf cavity but
 it is a quick and useful test of the parameterization of land-ice melt fluxes
 and of frazil formation below ice shelves.
 
-Both of the ``ice_shelf_2d`` test cases are composed of 3 types of steps:
+Both of the ``ice_shelf_2d`` test cases are composed of 4 types of steps:
 ``initial_state``, which defines the mesh and initial conditions for the model;
 ``ssh_adjustment``, which modifies the ``landIcePressure`` field to balance
 the ``ssh`` field, see :ref:`ocean_ssh_adjustment`; and ``forward``, which
-performs time integration of the model.
+performs time integration of the model.  The ``viz`` step can be used to plot
+the vertical coordinate, interpolated between adjacent cell centers.
 
 shared config options
 ---------------------


### PR DESCRIPTION
The z-star versions of the test cases are now in a z-star subdir.

The z-level restart test has been added to the nightly suite.

The cavity thickness has been increased from 10 to 50 m to accommodate the z-level coordinate.