### PR TITLE
Fix pattern for xml search

### DIFF
--- a/list_testcases.py
+++ b/list_testcases.py
@@ -72,43 +72,42 @@ if __name__ == "__main__":
     os.chdir(script_path)
 
     # Iterate over all cores
-    for core_dir in sorted(os.listdir('.')):
-        if os.path.isdir(core_dir) and core_dir != '.git':
-            # Iterate over all configurations within a core
-            for config_dir in sorted(os.listdir(core_dir)):
-                config_path = '{}/{}'.format(core_dir, config_dir)
-                if os.path.isdir(config_path):
-                    # Iterate over all resolutions within a configuration
-                    for res_dir in sorted(os.listdir(config_path)):
-                        res_path = '{}/{}'.format(config_path, res_dir)
-                        if os.path.isdir(res_path):
-                            # Iterate over all tests within a resolution
-                            for test_dir in sorted(os.listdir(res_path)):
-                                test_path = '{}/{}'.format(res_path, test_dir)
-                                if os.path.isdir(test_path):
-                                    do_print = False
-                                    # Iterate over all files within a test
-                                    for case_file in sorted(
-                                            os.listdir(test_path)):
-                                        if fnmatch.fnmatch(case_file, '*.xml'):
-                                            tree = ET.parse('{}/{}'.format(
-                                                test_path, case_file))
-                                            root = tree.getroot()
+    for core_dir in ['landice', 'ocean', 'test']:
+        # Iterate over all configurations within a core
+        for config_dir in sorted(os.listdir(core_dir)):
+            config_path = '{}/{}'.format(core_dir, config_dir)
+            if os.path.isdir(config_path):
+                # Iterate over all resolutions within a configuration
+                for res_dir in sorted(os.listdir(config_path)):
+                    res_path = '{}/{}'.format(config_path, res_dir)
+                    if os.path.isdir(res_path):
+                        # Iterate over all tests within a resolution
+                        for test_dir in sorted(os.listdir(res_path)):
+                            test_path = '{}/{}'.format(res_path, test_dir)
+                            if os.path.isdir(test_path):
+                                do_print = False
+                                # Iterate over all files within a test
+                                for case_file in sorted(
+                                        os.listdir(test_path)):
+                                    if fnmatch.fnmatch(case_file, '*.xml'):
+                                        tree = ET.parse('{}/{}'.format(
+                                            test_path, case_file))
+                                        root = tree.getroot()
 
-                                            # Check to make sure the test is
-                                            # either a config file or a
-                                            # driver_script file
-                                            if root.tag == 'config' or \
-                                                    root.tag == \
-                                                    'driver_script':
-                                                do_print = True
+                                        # Check to make sure the test is
+                                        # either a config file or a
+                                        # driver_script file
+                                        if root.tag == 'config' or \
+                                                root.tag == \
+                                                'driver_script':
+                                            do_print = True
 
-                                            del root
-                                            del tree
+                                        del root
+                                        del tree
 
-                                    if do_print:
-                                        case_num = print_case(
-                                            quiet, args, core_dir, config_dir,
-                                            res_dir, test_dir, case_num)
+                                if do_print:
+                                    case_num = print_case(
+                                        quiet, args, core_dir, config_dir,
+                                        res_dir, test_dir, case_num)
 
 # vim: foldmethod=marker ai ts=4 sts=4 et sw=4 ft=python


### PR DESCRIPTION
After the introduction of the E3SM submodules, `list_testcases.py` now finds some XML files in E3SM that it tries (and fails) to
parse.  One solution would be to have a try/except but the approach taken in this merge is to assume all COMPASS xml files start with `config`.  The XML files from E3SM that are causing trouble do not.