### PR TITLE
Rename dev. conda env. from `test_compass*` to `dev_compass*`

### DIFF
--- a/conda/configure_compass_env.py
+++ b/conda/configure_compass_env.py
@@ -209,7 +209,7 @@ def build_env(is_test, recreate, machine, compiler, mpi, conda_mpi, version,
 
     if is_test:
         if env_name is None:
-            env_name = 'test_compass_{}{}'.format(version, env_suffix)
+            env_name = 'dev_compass_{}{}'.format(version, env_suffix)
     else:
         env_name = 'compass_{}{}'.format(version, env_suffix)
     env_path = os.path.join(conda_base, 'envs', env_name)
@@ -548,7 +548,7 @@ def write_load_compass(template_path, activ_path, conda_base, is_test, version,
 
     if is_test:
         if prefix is None:
-            prefix = 'test_compass_{}'.format(version)
+            prefix = 'load_dev_compass_{}'.format(version)
     else:
         prefix = 'load_compass_{}'.format(version)
 

--- a/docs/developers_guide/machines/anvil.rst
+++ b/docs/developers_guide/machines/anvil.rst
@@ -11,7 +11,7 @@ been set up properly (see :ref:`dev_conda_env`), you should be able to source:
 
 .. code-block:: bash
 
-    source test_compass_1.0.0_anvil_intel18_mvapich.sh
+    source load_dev_compass_1.0.0_anvil_intel18_mvapich.sh
 
 Then, you can build the MPAS model with
 
@@ -26,7 +26,7 @@ If you've set things up for this compiler, you should be able to:
 
 .. code-block:: bash
 
-    source test_compass_1.0.0_anvil_gnu_mvapich.sh
+    source load_dev_compass_1.0.0_anvil_gnu_mvapich.sh
 
 Then, you can build the MPAS model with
 

--- a/docs/developers_guide/machines/badger.rst
+++ b/docs/developers_guide/machines/badger.rst
@@ -27,7 +27,7 @@ been set up properly (see :ref:`dev_conda_env`), you should be able to source:
 
 .. code-block:: bash
 
-    source test_compass_1.0.0_badger_intel_impi.sh
+    source load_dev_compass_1.0.0_badger_intel_impi.sh
 
 Then, you can build the MPAS model with
 
@@ -42,7 +42,7 @@ If you've set things up for this compiler, you should be able to:
 
 .. code-block:: bash
 
-    source test_compass_1.0.0_badger_gnu_mvapich.sh
+    source load_dev_compass_1.0.0_badger_gnu_mvapich.sh
 
 Then, you can build the MPAS model with
 

--- a/docs/developers_guide/machines/chrysalis.rst
+++ b/docs/developers_guide/machines/chrysalis.rst
@@ -11,7 +11,7 @@ been set up properly (see :ref:`dev_conda_env`), you should be able to source:
 
 .. code-block:: bash
 
-    source test_compass_1.0.0_chrysalis_intel_impi.sh
+    source load_dev_compass_1.0.0_chrysalis_intel_impi.sh
 
 Then, you can build the MPAS model with
 
@@ -26,7 +26,7 @@ If you've set things up for this compiler, you should be able to:
 
 .. code-block:: bash
 
-    source test_compass_1.0.0_chrysalis_gnu_openmpi.sh
+    source load_dev_compass_1.0.0_chrysalis_gnu_openmpi.sh
 
 Then, you can build the MPAS model with
 

--- a/docs/developers_guide/machines/compy.rst
+++ b/docs/developers_guide/machines/compy.rst
@@ -15,7 +15,7 @@ able to source:
 
 .. code-block:: bash
 
-    source test_compass_1.0.0_compy_intel_impi.sh
+    source load_dev_compass_1.0.0_compy_intel_impi.sh
 
 Then, you can build the MPAS model with
 

--- a/docs/developers_guide/machines/cori.rst
+++ b/docs/developers_guide/machines/cori.rst
@@ -10,7 +10,7 @@ able to source:
 
 .. code-block:: bash
 
-    source test_compass_1.0.0_cori-haswell_intel_mpt.sh
+    source load_dev_compass_1.0.0_cori-haswell_intel_mpt.sh
 
 Then, you can build the MPAS model with
 
@@ -25,7 +25,7 @@ If you've set things up for this compiler, you should be able to:
 
 .. code-block:: bash
 
-    source test_compass_1.0.0_cori-haswell_gnu_mpt.sh
+    source load_dev_compass_1.0.0_cori-haswell_gnu_mpt.sh
 
 Then, you can build the MPAS model with
 
@@ -41,7 +41,7 @@ been set up properly (see :ref:`dev_conda_env`), you should be able to source:
 
 .. code-block:: bash
 
-    source test_compass_1.0.0_cori-knl_intel_mpt.sh
+    source load_dev_compass_1.0.0_cori-knl_intel_mpt.sh
 
 Then, you can build the MPAS model with
 
@@ -57,7 +57,7 @@ If you've set things up for this compiler, you should be able to:
 
 .. code-block:: bash
 
-    source test_compass_1.0.0_cori-knl_gnu_mpt.sh
+    source load_dev_compass_1.0.0_cori-knl_gnu_mpt.sh
 
 Then, you can build the MPAS model with
 

--- a/docs/developers_guide/machines/grizzly.rst
+++ b/docs/developers_guide/machines/grizzly.rst
@@ -28,7 +28,7 @@ been set up properly (see :ref:`dev_conda_env`), you should be able to source:
 
 .. code-block:: bash
 
-    source test_compass_1.0.0_brizzly_intel_impi.sh
+    source load_dev_compass_1.0.0_brizzly_intel_impi.sh
 
 Then, you can build the MPAS model with
 
@@ -43,7 +43,7 @@ If you've set things up for this compiler, you should be able to:
 
 .. code-block:: bash
 
-    source test_compass_1.0.0_grizzly_gnu_mvapich.sh
+    source load_dev_compass_1.0.0_grizzly_gnu_mvapich.sh
 
 Then, you can build the MPAS model with
 

--- a/docs/developers_guide/machines/index.rst
+++ b/docs/developers_guide/machines/index.rst
@@ -24,7 +24,7 @@ the base of your compass branch, e.g.:
 
 .. code-block:: bash
 
-    source test_compass_1.0.0_anvil_intel18_mvapich.sh
+    source load_dev_compass_1.0.0_anvil_intel18_mvapich.sh
 
 After loading this environment, you can set up test cases or test suites, and
 a link ``load_compass_env.sh`` will be included in each suite or test case
@@ -103,7 +103,7 @@ and on OSX run:
 You may use ``openmpi`` instead of ``mpich`` but we have had better experiences
 with the latter.
 
-The result should be an activation script ``test_compass_1.0.0_<compiler>.sh``.
+The result should be an activation script ``load_dev_compass_1.0.0_<compiler>.sh``.
 Source this script to get the appropriate conda environment and environment
 variables.
 

--- a/docs/developers_guide/quick_start.rst
+++ b/docs/developers_guide/quick_start.rst
@@ -70,7 +70,7 @@ this script will also:
   making mapping files.
 
 * make an activation script called
-  ``test_compass_<version>_<machine>_<compiler>_<mpi>.sh``,
+  ``load_dev_compass_<version>_<machine>_<compiler>_<mpi>.sh``,
   where ``<version>`` is the compass version, ``<machine>`` is the name of the
   machine (to prevent confusion when running from the same branch on multiple
   machines), ``<compiler>`` is the compiler name (e.g. ``intel`` or ``gnu``),
@@ -83,7 +83,7 @@ Each time you want to work with compass, you will need to run:
 
 .. code-block:: bash
 
-    source ./test_compass_<version>_<machine>_<compiler>_<mpi>.sh
+    source ./load_dev_compass_<version>_<machine>_<compiler>_<mpi>.sh
 
 This will load the appropriate conda environment, load system modules for
 compilers, MPI and libraries needed to build and run MPAS components, and
@@ -135,7 +135,7 @@ scratch.  This takes just a little extra time.
 You can check to make sure expected commands are present with ``--check``, you
 can select a particular python version with ``--python``, you can set the name
 of the environment (and the prefix for the activation script) something other
-than the default (``test_compass<version>``) with ``--env-name``.
+than the default (``load_dev_compass_<version>``) with ``--env-name``.
 
 If you are not on a supported machine, you need to choose your MPI type
 (``mpich`` or ``openmpi``) with the ``--mpi`` flag.  The compilers are
@@ -160,7 +160,7 @@ Each time you want to work with compass, you will need to run:
 
 .. code-block:: bash
 
-    source ./test_compass_<version>.sh
+    source ./load_dev_compass_<version>.sh
 
 This will load the appropriate conda environment for ``compass``.  It will also
 set an environment variable ``LOAD_COMPASS_ENV`` that points to the activation
@@ -235,7 +235,7 @@ case), log onto a compute node (if on an HPC machine) and run:
     compass run
 
 The first command will source the same activation script
-(``test_compass_<version>_<machine>_<compiler>_<mpi>.sh``) that you used to set
+(``load_dev_compass_<version>_<machine>_<compiler>_<mpi>.sh``) that you used to set
 up the suite or test case (``load_compass_env.sh`` is just a symlink to that
 activation script you sourced before setting up the suite or test case).
 
@@ -247,7 +247,7 @@ compile MPAS-Ocean:
 
 .. code-block:: bash
 
-    source ./test_compass_<version>_<machine>_<compiler>_<mpi>.sh
+    source ./load_dev_compass_<version>_<machine>_<compiler>_<mpi>.sh
     cd E3SM-Project/components/mpas-ocean/
     make <mpas_compiler>
 
@@ -255,7 +255,7 @@ For MALI:
 
 .. code-block:: bash
 
-    source ./test_compass_<version>_<machine>_<compiler>_<mpi>.sh
+    source ./load_dev_compass_<version>_<machine>_<compiler>_<mpi>.sh
     cd MALI-Dev/components/mpas-albany-landice
     make <mpas_compiler>
 


### PR DESCRIPTION
The conda environment is now called `dev_compass_1.0.0` (possibly with the MPI version if using the conda package for MPI) and the activation script starts with `load_dev_compass_1.0.0`.

The documentation has been updated accordingly.