### PR TITLE
Make 'compass list --suites -v' print the contents of a suite

### DIFF
--- a/compass/list.py
+++ b/compass/list.py
@@ -100,12 +100,15 @@ def list_suites(cores=None, verbose=False):
             if suite.endswith('.txt'):
                 print('  -c {} -t {}'.format(core, os.path.splitext(suite)[0]))
                 if verbose:
-                   text = resources.read_text('compass.{}.suites'.format(core), suite)
-                   tests = list()
-                   for test in text.split('\n'):
-                      test = test.strip()
-                      if len(test) > 0 and test not in tests and not test.startswith('#'):
-                         print("\t* {}".format(test))
+                    text = resources.read_text(
+                        'compass.{}.suites'.format(core), suite)
+                    tests = list()
+                    for test in text.split('\n'):
+                        test = test.strip()
+                        if (len(test) > 0 and test not in tests
+                                and not test.startswith('#')):
+                            print("\t* {}".format(test))
+
 
 def main():
     parser = argparse.ArgumentParser(

--- a/compass/list.py
+++ b/compass/list.py
@@ -21,8 +21,8 @@ def list_cases(test_expr=None, number=None, verbose=False):
         The number of the test to list
 
     verbose : bool, optional
-        Whether to print details of each test or just the subdirectories
-        When applied to suites, verbose will list the tests in the suite
+        Whether to print details of each test or just the subdirectories.
+        When applied to suites, verbose will list the tests in the suite.
     """
     mpas_cores = get_mpas_cores()
 
@@ -126,7 +126,8 @@ def main():
                         help="List test suites (instead of test cases)")
     parser.add_argument("-v", "--verbose", dest="verbose", action="store_true",
                         help="List details of each test case, not just the "
-                             "path")
+                             "path.  When applied to suites, verbose lists "
+                             "the tests contained in each suite.")
     args = parser.parse_args(sys.argv[2:])
     if args.machines:
         list_machines()

--- a/compass/suite.py
+++ b/compass/suite.py
@@ -54,7 +54,8 @@ def setup_suite(mpas_core, suite_name, config_file=None, machine=None,
     tests = list()
     for test in text.split('\n'):
         test = test.strip()
-        if len(test) > 0 and test not in tests:
+        if (len(test) > 0 and test not in tests
+                and not test.startswith('#')):
             tests.append(test)
 
     if work_dir is None:
@@ -108,7 +109,7 @@ def clean_suite(mpas_core, suite_name, work_dir=None):
     text = resources.read_text('compass.{}.suites'.format(mpas_core),
                                '{}.txt'.format(suite_name))
     tests = [test.strip() for test in text.split('\n') if
-             len(test.strip()) > 0]
+             len(test.strip()) > 0 and not test.startswith('#')]
 
     if work_dir is None:
         work_dir = os.getcwd()

--- a/docs/developers_guide/organization.rst
+++ b/docs/developers_guide/organization.rst
@@ -1718,3 +1718,16 @@ forgotten to compile the model, this will be obvious by the broken symlink and
 the step will immediately fail because of the missing input.  The path to the
 executable is automatically detected based on the work directory for the step
 and the config options.
+
+.. _dev_suites:
+
+Test Suites
+-----------
+
+As described in the :ref:`user_testsuites` section of the User's Guide, COMPASS
+test cases can be organized into test suites.  Each core has separate regression
+suites, and a core can have multiple independent regression suites.  A developer
+defines a test suite by creating a `.txt` file within the `compass/CORE/suites`
+directory.  The format of the `.txt` file is a list of the paths to the tests
+desired to be part of the suite.  A line starting with `#` will be treated as a
+comment line.

--- a/docs/developers_guide/organization.rst
+++ b/docs/developers_guide/organization.rst
@@ -1728,6 +1728,6 @@ As described in the :ref:`user_testsuites` section of the User's Guide, COMPASS
 test cases can be organized into test suites.  Each core has separate regression
 suites, and a core can have multiple independent regression suites.  A developer
 defines a test suite by creating a `.txt` file within the `compass/CORE/suites`
-directory.  The format of the `.txt` file is a list of the paths to the tests
-desired to be part of the suite.  A line starting with `#` will be treated as a
-comment line.
+directory.  The format of the `.txt` file is a list of the work directories to
+the tests desired to be part of the suite.  A line starting with `#` will be
+treated as a comment line.

--- a/docs/users_guide/test_suites.rst
+++ b/docs/users_guide/test_suites.rst
@@ -59,3 +59,6 @@ for regression testing of MPAS-Ocean.  Here are the tests included:
     ocean/ice_shelf_2d/5km/restart_test
     ocean/ziso/20km/default
     ocean/ziso/20km/with_frazil
+
+Including the ``-v`` verbose argument to ``compass list --suites`` will
+print the tests belonging to each given suite.


### PR DESCRIPTION
This merge also updates the documentation for this change and adds a
short section to the Developer's Guide about developing suites.