### PR TITLE
Allow `compass run suitename` to include or not the .pickle suffix

### DIFF
--- a/compass/run.py
+++ b/compass/run.py
@@ -31,7 +31,7 @@ def run_suite(suite_name):
     # Allow a suite name to either include or not the .pickle suffix
     if suite_name.endswith('.pickle'):
         # code below assumes no suffix, so remove it
-        suite_name = suite_name.replace('.pickle', '')
+        suite_name = suite_name[:-len('.pickle')]
     # Now open the the suite's pickle file
     if not os.path.exists('{}.pickle'.format(suite_name)):
         raise ValueError('The suite "{}" doesn\'t appear to have been set up '

--- a/compass/run.py
+++ b/compass/run.py
@@ -28,6 +28,11 @@ def run_suite(suite_name):
     fail_str = '{}FAIL{}'.format(start_fail, end)
     error_str = '{}ERROR{}'.format(start_fail, end)
 
+    # Allow a suite name to either include or not the .pickle suffix
+    if suite_name.endswith('.pickle'):
+        # code below assumes no suffix, so remove it
+        suite_name = suite_name.replace('.pickle', '')
+    # Now open the the suite's pickle file
     if not os.path.exists('{}.pickle'.format(suite_name)):
         raise ValueError('The suite "{}" doesn\'t appear to have been set up '
                          'here.'.format(suite_name))

--- a/compass/run.py
+++ b/compass/run.py
@@ -249,7 +249,8 @@ def main():
         description='Run a test suite, test case or step',
         prog='compass run')
     parser.add_argument("suite", nargs='?', default=None,
-                        help="The name of a test suite to run")
+                        help="The name of a test suite to run. Can exclude "
+                        "or include the .pickle filename suffix.")
     parser.add_argument("--steps", dest="steps", nargs='+', default=None,
                         help="The steps of a test case to run")
     parser.add_argument("--no-steps", dest="no_steps", nargs='+', default=None,

--- a/docs/developers_guide/command_line.rst
+++ b/docs/developers_guide/command_line.rst
@@ -220,8 +220,9 @@ Whereas other ``compass`` commands are typically run in the local clone of the
 compass repo, ``compass run`` needs to be run in the appropriate work
 directory. If you are running a test suite, you may need to provide the name
 of the test suite if more than one suite has been set up in the same work
-directory.  If you are in the work directory for a test case or step, you do
-not need to provide any arguments.
+directory (with or without the ``.pickle`` suffix that exists on the suite's
+file in the working directory).  If you are in the work directory for a test
+case or step, you do not need to provide any arguments.
 
 If you want to explicitly select which steps in a test case you want to run,
 you have two options.  You can either edit the ``steps_to_run`` config options

--- a/docs/users_guide/quick_start.rst
+++ b/docs/users_guide/quick_start.rst
@@ -265,4 +265,6 @@ and
     compass run [nightly]
 
 In this case, you can specify the name of the suite to run.  This is required
-if there are multiple suites in the same ``$WORKDIR``.
+if there are multiple suites in the same ``$WORKDIR``.  You can optionally
+specify a suite like ``compass run [suitename].pickle``, which is convenient
+for tab completion on the command line.


### PR DESCRIPTION
Allowing the .pickle suffix in the `compass run` command is a convenience
change to support command-line tab completion.