### PR TITLE
Update mpas_tools to 0.7.0

### DIFF
--- a/conda/compass_env/spec-file-mpich.txt
+++ b/conda/compass_env/spec-file-mpich.txt
@@ -18,7 +18,7 @@ jupyter
 lxml
 matplotlib-base
 metis
-mpas_tools=0.6.0
+mpas_tools=0.7.0
 nco
 netcdf4=*=nompi_*
 numpy

--- a/conda/compass_env/spec-file-mpich.txt
+++ b/conda/compass_env/spec-file-mpich.txt
@@ -3,7 +3,6 @@
 
 # Base
 python>=3.6
-affine
 cartopy
 cartopy_offlinedata
 cmocean
@@ -25,7 +24,6 @@ numpy
 progressbar2
 pyamg
 pyremap>=0.0.13,<0.1.0
-rasterio
 requests
 scipy
 xarray

--- a/conda/compass_env/spec-file-nompi.txt
+++ b/conda/compass_env/spec-file-nompi.txt
@@ -18,7 +18,7 @@ jupyter
 lxml
 matplotlib-base
 metis
-mpas_tools=0.6.0
+mpas_tools=0.7.0
 nco
 netcdf4=*=nompi_*
 numpy

--- a/conda/compass_env/spec-file-nompi.txt
+++ b/conda/compass_env/spec-file-nompi.txt
@@ -3,7 +3,6 @@
 
 # Base
 python>=3.6
-affine
 cartopy
 cartopy_offlinedata
 cmocean
@@ -25,7 +24,6 @@ numpy
 progressbar2
 pyamg
 pyremap>=0.0.13,<0.1.0
-rasterio
 requests
 scipy
 xarray

--- a/conda/compass_env/spec-file-openmpi.txt
+++ b/conda/compass_env/spec-file-openmpi.txt
@@ -18,7 +18,7 @@ jupyter
 lxml
 matplotlib-base
 metis
-mpas_tools=0.6.0
+mpas_tools=0.7.0
 nco
 netcdf4=*=nompi_*
 numpy

--- a/conda/compass_env/spec-file-openmpi.txt
+++ b/conda/compass_env/spec-file-openmpi.txt
@@ -3,7 +3,6 @@
 
 # Base
 python>=3.6
-affine
 cartopy
 cartopy_offlinedata
 cmocean
@@ -25,7 +24,6 @@ numpy
 progressbar2
 pyamg
 pyremap>=0.0.13,<0.1.0
-rasterio
 requests
 scipy
 xarray

--- a/conda/recipe/meta.yaml
+++ b/conda/recipe/meta.yaml
@@ -40,7 +40,6 @@ requirements:
     - setuptools
   run:
     - python >=3.6
-    - affine
     - cartopy
     - cartopy_offlinedata
     - cmocean
@@ -63,7 +62,6 @@ requirements:
     - progressbar2
     - pyamg
     - pyremap >=0.0.13,<0.1.0
-    - rasterio
     - requests
     - scipy
     - xarray

--- a/conda/recipe/meta.yaml
+++ b/conda/recipe/meta.yaml
@@ -55,7 +55,7 @@ requirements:
     - lxml
     - matplotlib-base
     - metis
-    - mpas_tools 0.6.0
+    - mpas_tools 0.7.0
     - {{ mpi }}  # [mpi != 'nompi']
     - nco
     - netcdf4 * nompi_*

--- a/setup.py
+++ b/setup.py
@@ -19,8 +19,7 @@ def package_files(directory, prefixes, extensions):
 
 
 install_requires = \
-    ['affine',
-     'cartopy',
+    ['cartopy',
      'cmocean',
      'ipython',
      'jigsawpy==0.3.3',
@@ -31,7 +30,6 @@ install_requires = \
      'numpy',
      'progressbar2',
      'pyamg',
-     'rasterio',
      'requests',
      'scipy',
      'xarray']


### PR DESCRIPTION
This brings in https://github.com/MPAS-Dev/MPAS-Tools/pull/426

Remove unused rasterio and affine dependencies.  These are not needed in compass (they aren't currently used).  Rasterio was removed from MPAS-Tools, and now conflicts with the latest version of that package because they have not been built with the same version of `libnetcdf`.