### PR TITLE
Check that files to validate are step output

### DIFF
--- a/compass/setup.py
+++ b/compass/setup.py
@@ -224,6 +224,10 @@ def setup_case(path, test_case, config_file, machine, work_dir, baseline_dir,
         # process input, output, namelist and streams files
         step.process_inputs_and_outputs()
 
+    # wait until we've set up all the steps before pickling because steps may
+    # need other steps to be set up
+    for step in test_case.steps.values():
+
         # pickle the test case and step for use at runtime
         pickle_filename = os.path.join(step.work_dir, 'step.pickle')
         with open(pickle_filename, 'wb') as handle:

--- a/docs/developers_guide/framework.rst
+++ b/docs/developers_guide/framework.rst
@@ -355,7 +355,7 @@ compared with those in the corresponding files in the baseline.
 In any of these cases, if comparison fails, a ``ValueError`` is raised and
 execution of the test case is terminated.
 
-Typical output will look like this:
+If ``quiet=False``, typical output will look like this:
 
 .. code-block:: none
 
@@ -400,6 +400,14 @@ Typical output will look like this:
      ** PASS Comparison of normalVelocity between /home/xylar/data/mpas/test_nightly_latest/ocean/baroclinic_channel/10km/threads_test/1thread/output.nc and
         /home/xylar/data/mpas/test_nightly_latest/ocean/baroclinic_channel/10km/threads_test/2thread/output.nc
 
+If ``quiet=True`` (the default), there is only an indication that the
+comparison passed for each variable.
+
+By default, the function checks to make sure ``filename1`` and, if provided,
+``filename2`` are output of one of the steps in the test case.  In general,
+validation should be performed on outputs of the steps this test case that are
+explicitly added with :py:meth:`compass.Step.add_output_file()`.  This check
+can be disabled by setting ``check_outputs=False``.
 
 Norms
 ^^^^^


### PR DESCRIPTION
In `compass.validate.compare_variables()`, optionally check to make sure the files being compared are output of one of the steps in the test case.

The new behavior (and the keyword argument for disabling it) are now in the documentation.