### PR TITLE
Fix appending of global ocean metadata

### DIFF
--- a/compass/ocean/tests/global_ocean/metadata.py
+++ b/compass/ocean/tests/global_ocean/metadata.py
@@ -73,7 +73,7 @@ def add_mesh_and_init_metadata(output_filenames, config, init_filename):
 
         for filename in output_filenames:
             if filename.endswith('.nc'):
-                args = ['ncra']
+                args = ['ncks']
                 for key, value in metadata.items():
                     args.extend(['--glb_att_add', '{}={}'.format(key, value)])
                 name, ext = os.path.splitext(filename)


### PR DESCRIPTION
We were using `ncra` but should have been using `ncks` because we only want to add the metadata, not average the files in time.