### PR TITLE
Add missing output files to 3 ocean test groups

### DIFF
--- a/compass/ocean/tests/global_ocean/analysis_test/__init__.py
+++ b/compass/ocean/tests/global_ocean/analysis_test/__init__.py
@@ -1,4 +1,6 @@
 import traceback
+import os
+
 from compass.validate import compare_variables, compare_timers
 from compass.ocean.tests.global_ocean.forward import ForwardTestCase, \
     ForwardStep
@@ -10,6 +12,11 @@ class AnalysisTest(ForwardTestCase):
     initial condition and check nearly all MPAS-Ocean analysis members to make
     sure they run successfully and output is identical to a baseline (if one
     is provided).
+
+    Attributes
+    ----------
+    variables : dict
+        A dictionary of output files and the variables in each to validate
     """
 
     def __init__(self, test_group, mesh, init, time_integrator):
@@ -38,6 +45,50 @@ class AnalysisTest(ForwardTestCase):
                            time_integrator=time_integrator, cores=4,
                            threads=1)
 
+        self.variables = {
+            'output.nc':
+                ['temperature', 'salinity', 'layerThickness',
+                 'normalVelocity'],
+            'analysis_members/globalStats.0001-01-01_00.00.00.nc':
+                ['kineticEnergyCellMax', 'kineticEnergyCellMin',
+                 'kineticEnergyCellAvg', 'temperatureAvg', 'salinityAvg'],
+            'analysis_members/debugDiagnostics.0001-01-01.nc':
+                ['rx1MaxCell'],
+            'analysis_members/highFrequencyOutput.0001-01-01.nc':
+                ['temperatureAt250m'],
+            'analysis_members/mixedLayerDepths.0001-01-01.nc':
+                ['dThreshMLD', 'tThreshMLD'],
+            'analysis_members/waterMassCensus.0001-01-01_00.00.00.nc':
+                ['waterMassCensusTemperatureValues'],
+            'analysis_members/eliassenPalm.0001-01-01.nc':
+                ['EPFT'],
+            'analysis_members/'
+            'layerVolumeWeightedAverage.0001-01-01_00.00.00.nc':
+                ['avgVolumeTemperature', 'avgVolumeRelativeVorticityCell'],
+            'analysis_members/okuboWeiss.0001-01-01_00.00.00.nc':
+                ['okuboWeiss'],
+            'analysis_members/zonalMeans.0001-01-01_00.00.00.nc':
+                ['velocityZonalZonalMean', 'temperatureZonalMean'],
+            'analysis_members/'
+            'meridionalHeatTransport.0001-01-01_00.00.00.nc':
+                ['meridionalHeatTransportLat'],
+            'analysis_members/'
+            'surfaceAreaWeightedAverages.0001-01-01_00.00.00.nc':
+                ['avgSurfaceSalinity', 'avgSeaSurfacePressure'],
+            'analysis_members/'
+            'eddyProductVariables.0001-01-01.nc':
+                ['SSHSquared', 'velocityZonalSquared',
+                 'velocityZonalTimesTemperature'],
+            'analysis_members/oceanHeatContent.0001-01-01.nc':
+                ['oceanHeatContentSfcToBot', 'oceanHeatContentSfcTo700m',
+                 'oceanHeatContent700mTo2000m', 'oceanHeatContent2000mToBot'],
+            'analysis_members/mixedLayerHeatBudget.0001-01-01.nc':
+                ['temperatureHorAdvectionMLTend', 'salinityHorAdvectionMLTend',
+                 'temperatureML', 'salinityML', 'bruntVaisalaFreqML']}
+
+        for output in self.variables:
+            step.add_output_file(output)
+
         module = self.__module__
         step.add_namelist_file(module, 'namelist.forward')
         step.add_streams_file(module, 'streams.forward')
@@ -53,52 +104,11 @@ class AnalysisTest(ForwardTestCase):
         config = self.config
         work_dir = self.work_dir
 
-        variables = {
-            'forward/output.nc':
-                ['temperature', 'salinity', 'layerThickness',
-                 'normalVelocity'],
-            'forward/analysis_members/globalStats.0001-01-01_00.00.00.nc':
-                ['kineticEnergyCellMax', 'kineticEnergyCellMin',
-                 'kineticEnergyCellAvg', 'temperatureAvg', 'salinityAvg'],
-            'forward/analysis_members/debugDiagnostics.0001-01-01.nc':
-                ['rx1MaxCell'],
-            'forward/analysis_members/highFrequencyOutput.0001-01-01.nc':
-                ['temperatureAt250m'],
-            'forward/analysis_members/mixedLayerDepths.0001-01-01.nc':
-                ['dThreshMLD', 'tThreshMLD'],
-            'forward/analysis_members/waterMassCensus.0001-01-01_00.00.00.nc':
-                ['waterMassCensusTemperatureValues'],
-            'forward/analysis_members/eliassenPalm.0001-01-01.nc':
-                ['EPFT'],
-            'forward/analysis_members/'
-            'layerVolumeWeightedAverage.0001-01-01_00.00.00.nc':
-                ['avgVolumeTemperature', 'avgVolumeRelativeVorticityCell'],
-            'forward/analysis_members/okuboWeiss.0001-01-01_00.00.00.nc':
-                ['okuboWeiss'],
-            'forward/analysis_members/zonalMeans.0001-01-01_00.00.00.nc':
-                ['velocityZonalZonalMean', 'temperatureZonalMean'],
-            'forward/analysis_members/'
-            'meridionalHeatTransport.0001-01-01_00.00.00.nc':
-                ['meridionalHeatTransportLat'],
-            'forward/analysis_members/'
-            'surfaceAreaWeightedAverages.0001-01-01_00.00.00.nc':
-                ['avgSurfaceSalinity', 'avgSeaSurfacePressure'],
-            'forward/analysis_members/'
-            'eddyProductVariables.0001-01-01.nc':
-                ['SSHSquared', 'velocityZonalSquared',
-                 'velocityZonalTimesTemperature'],
-            'forward/analysis_members/oceanHeatContent.0001-01-01.nc':
-                ['oceanHeatContentSfcToBot', 'oceanHeatContentSfcTo700m',
-                 'oceanHeatContent700mTo2000m', 'oceanHeatContent2000mToBot'],
-            'forward/analysis_members/mixedLayerHeatBudget.0001-01-01.nc':
-                ['temperatureHorAdvectionMLTend', 'salinityHorAdvectionMLTend',
-                 'temperatureML', 'salinityML', 'bruntVaisalaFreqML']}
-
         failed = list()
-        for filename, variables in variables.items():
+        for filename, variables in self.variables.items():
             try:
                 compare_variables(test_case=self, variables=variables,
-                                  filename1=filename)
+                                  filename1=os.path.join('forward', filename))
             except ValueError:
                 traceback.print_exc()
                 failed.append(filename)

--- a/compass/ocean/tests/ice_shelf_2d/__init__.py
+++ b/compass/ocean/tests/ice_shelf_2d/__init__.py
@@ -1,4 +1,3 @@
-from compass.config import add_config
 from compass.testgroup import TestGroup
 from compass.ocean.tests.ice_shelf_2d.default import Default
 from compass.ocean.tests.ice_shelf_2d.restart_test import RestartTest

--- a/compass/ocean/tests/ice_shelf_2d/forward.py
+++ b/compass/ocean/tests/ice_shelf_2d/forward.py
@@ -59,6 +59,7 @@ class Forward(Step):
                        'config_frazil_maximum_depth': '2000.0'}
             self.add_namelist_options(options)
             self.add_streams_file('compass.ocean.streams', 'streams.frazil')
+            self.add_output_file('frazil.nc')
 
         self.add_streams_file('compass.ocean.streams',
                               'streams.land_ice_fluxes')
@@ -74,6 +75,7 @@ class Forward(Step):
         self.add_model_as_input()
 
         self.add_output_file('output.nc')
+        self.add_output_file('land_ice_fluxes.nc')
 
     # no setup() is needed
 

--- a/compass/ocean/tests/ziso/forward.py
+++ b/compass/ocean/tests/ziso/forward.py
@@ -77,6 +77,7 @@ class Forward(Step):
             self.add_namelist_options(
                 {'config_use_frazil_ice_formation': '.true.'})
             self.add_streams_file('compass.ocean.streams', 'streams.frazil')
+            self.add_output_file('frazil.nc')
 
         self.add_namelist_file('compass.ocean.tests.ziso',
                                'namelist.{}.forward'.format(resolution))


### PR DESCRIPTION
The `global_ocean/analysis_test`, both `ice_shelf_2d` test cases, and the `ziso/frazil_test` are all missing output files that should be added with `add_output_file()`.  This was revealed by #151 