### PR TITLE
Skip steps not run by default in validation

### DIFF
--- a/compass/landice/tests/dome/decomposition_test/__init__.py
+++ b/compass/landice/tests/dome/decomposition_test/__init__.py
@@ -64,43 +64,41 @@ class DecompositionTest(TestCase):
         Test cases can override this method to perform validation of variables
         and timers
         """
-        steps = self.steps_to_run
-        if '1proc_run' in steps and '4proc_run' in steps:
-            if self.velo_solver == 'sia':
-                compare_variables(test_case=self,
-                                  variables=['thickness', 'normalVelocity'],
-                                  filename1='1proc_run/output.nc',
-                                  filename2='4proc_run/output.nc')
+        if self.velo_solver == 'sia':
+            compare_variables(test_case=self,
+                              variables=['thickness', 'normalVelocity'],
+                              filename1='1proc_run/output.nc',
+                              filename2='4proc_run/output.nc')
 
-            elif self.velo_solver == 'FO':
-                # validate thickness
-                variable = ['thickness', ]
-                if self.mesh_type == 'variable_resolution':
-                    l1_norm = 1.0e-11
-                    l2_norm = 1.0e-12
-                    linf_norm = 1.0e-12
-                elif self.mesh_type == '2000m':
-                    l1_norm = 1.0e-9
-                    l2_norm = 1.0e-11
-                    linf_norm = 1.0e-11
-                compare_variables(test_case=self, variables=variable,
-                                  filename1='1proc_run/output.nc',
-                                  filename2='4proc_run/output.nc',
-                                  l1_norm=l1_norm, l2_norm=l2_norm,
-                                  linf_norm=linf_norm, quiet=False)
+        elif self.velo_solver == 'FO':
+            # validate thickness
+            variable = ['thickness', ]
+            if self.mesh_type == 'variable_resolution':
+                l1_norm = 1.0e-11
+                l2_norm = 1.0e-12
+                linf_norm = 1.0e-12
+            elif self.mesh_type == '2000m':
+                l1_norm = 1.0e-9
+                l2_norm = 1.0e-11
+                linf_norm = 1.0e-11
+            compare_variables(test_case=self, variables=variable,
+                              filename1='1proc_run/output.nc',
+                              filename2='4proc_run/output.nc',
+                              l1_norm=l1_norm, l2_norm=l2_norm,
+                              linf_norm=linf_norm, quiet=False)
 
-                # validate normalVelocity
-                variable = ['normalVelocity', ]
-                if self.mesh_type == 'variable_resolution':
-                    l1_norm = 1.0e-17
-                    l2_norm = 1.0e-18
-                    linf_norm = 1.0e-19
-                elif self.mesh_type == '2000m':
-                    l1_norm = 1.0e-15
-                    l2_norm = 1.0e-16
-                    linf_norm = 1.0e-18
-                compare_variables(test_case=self, variables=variable,
-                                  filename1='1proc_run/output.nc',
-                                  filename2='4proc_run/output.nc',
-                                  l1_norm=l1_norm, l2_norm=l2_norm,
-                                  linf_norm=linf_norm, quiet=False)
+            # validate normalVelocity
+            variable = ['normalVelocity', ]
+            if self.mesh_type == 'variable_resolution':
+                l1_norm = 1.0e-17
+                l2_norm = 1.0e-18
+                linf_norm = 1.0e-19
+            elif self.mesh_type == '2000m':
+                l1_norm = 1.0e-15
+                l2_norm = 1.0e-16
+                linf_norm = 1.0e-18
+            compare_variables(test_case=self, variables=variable,
+                              filename1='1proc_run/output.nc',
+                              filename2='4proc_run/output.nc',
+                              l1_norm=l1_norm, l2_norm=l2_norm,
+                              linf_norm=linf_norm, quiet=False)

--- a/compass/landice/tests/dome/restart_test/__init__.py
+++ b/compass/landice/tests/dome/restart_test/__init__.py
@@ -99,8 +99,6 @@ class RestartTest(TestCase):
         and timers
         """
         variables = ['thickness', 'normalVelocity']
-        steps = self.steps_to_run
-        if 'full_run' in steps and 'restart_run' in steps:
-            compare_variables(test_case=self, variables=variables,
-                              filename1='full_run/output.nc',
-                              filename2='restart_run/output.nc')
+        compare_variables(test_case=self, variables=variables,
+                          filename1='full_run/output.nc',
+                          filename2='restart_run/output.nc')

--- a/compass/landice/tests/eismint2/decomposition_test/__init__.py
+++ b/compass/landice/tests/eismint2/decomposition_test/__init__.py
@@ -61,8 +61,6 @@ class DecompositionTest(TestCase):
         """
         variables = ['thickness', 'temperature', 'basalTemperature',
                      'heatDissipation']
-        steps = self.steps_to_run
-        if '1proc_run' in steps and '4proc_run' in steps:
-            compare_variables(test_case=self, variables=variables,
-                              filename1='1proc_run/output.nc',
-                              filename2='4proc_run/output.nc')
+        compare_variables(test_case=self, variables=variables,
+                          filename1='1proc_run/output.nc',
+                          filename2='4proc_run/output.nc')

--- a/compass/landice/tests/eismint2/restart_test/__init__.py
+++ b/compass/landice/tests/eismint2/restart_test/__init__.py
@@ -87,8 +87,6 @@ class RestartTest(TestCase):
         """
         variables = ['thickness', 'temperature', 'basalTemperature',
                      'heatDissipation']
-        steps = self.steps_to_run
-        if 'full_run' in steps and 'restart_run' in steps:
-            compare_variables(test_case=self, variables=variables,
-                              filename1='full_run/output.nc',
-                              filename2='restart_run/output.nc')
+        compare_variables(test_case=self, variables=variables,
+                          filename1='full_run/output.nc',
+                          filename2='restart_run/output.nc')

--- a/compass/landice/tests/greenland/decomposition_test/__init__.py
+++ b/compass/landice/tests/greenland/decomposition_test/__init__.py
@@ -52,30 +52,29 @@ class DecompositionTest(TestCase):
         """
         name1 = '{}proc_run'.format(self.cores_set[0])
         name2 = '{}proc_run'.format(self.cores_set[1])
-        if name1 in self.steps_to_run and name2 in self.steps_to_run:
-            if self.velo_solver == 'sia':
-                compare_variables(test_case=self,
-                                  variables=['thickness', 'normalVelocity'],
-                                  filename1='{}/output.nc'.format(name1),
-                                  filename2='{}/output.nc'.format(name2))
+        if self.velo_solver == 'sia':
+            compare_variables(test_case=self,
+                              variables=['thickness', 'normalVelocity'],
+                              filename1='{}/output.nc'.format(name1),
+                              filename2='{}/output.nc'.format(name2))
 
-            elif self.velo_solver == 'FO':
-                # validate thickness
-                compare_variables(test_case=self,
-                                  variables=['thickness', ],
-                                  filename1='{}/output.nc'.format(name1),
-                                  filename2='{}/output.nc'.format(name2),
-                                  l1_norm=1.0e-11,
-                                  l2_norm=1.0e-11,
-                                  linf_norm=1.0e-11,
-                                  quiet=False)
+        elif self.velo_solver == 'FO':
+            # validate thickness
+            compare_variables(test_case=self,
+                              variables=['thickness', ],
+                              filename1='{}/output.nc'.format(name1),
+                              filename2='{}/output.nc'.format(name2),
+                              l1_norm=1.0e-11,
+                              l2_norm=1.0e-11,
+                              linf_norm=1.0e-11,
+                              quiet=False)
 
-                # validate normalVelocity
-                compare_variables(test_case=self,
-                                  variables=['normalVelocity', ],
-                                  filename1='{}/output.nc'.format(name1),
-                                  filename2='{}/output.nc'.format(name2),
-                                  l1_norm=1.0e-13,
-                                  l2_norm=1.0e-15,
-                                  linf_norm=1.0e-16,
-                                  quiet=False)
+            # validate normalVelocity
+            compare_variables(test_case=self,
+                              variables=['normalVelocity', ],
+                              filename1='{}/output.nc'.format(name1),
+                              filename2='{}/output.nc'.format(name2),
+                              l1_norm=1.0e-13,
+                              l2_norm=1.0e-15,
+                              linf_norm=1.0e-16,
+                              quiet=False)

--- a/compass/landice/tests/greenland/restart_test/__init__.py
+++ b/compass/landice/tests/greenland/restart_test/__init__.py
@@ -79,8 +79,6 @@ class RestartTest(TestCase):
         and timers
         """
         variables = ['thickness', 'normalVelocity']
-        steps = self.steps_to_run
-        if 'full_run' in steps and 'restart_run' in steps:
-            compare_variables(test_case=self, variables=variables,
-                              filename1='full_run/output.nc',
-                              filename2='restart_run/output.nc')
+        compare_variables(test_case=self, variables=variables,
+                          filename1='full_run/output.nc',
+                          filename2='restart_run/output.nc')

--- a/compass/landice/tests/hydro_radial/decomposition_test/__init__.py
+++ b/compass/landice/tests/hydro_radial/decomposition_test/__init__.py
@@ -48,8 +48,6 @@ class DecompositionTest(TestCase):
         and timers
         """
         variables = ['waterThickness', 'waterPressure']
-        steps = self.steps_to_run
-        if '1proc_run' in steps and '3proc_run' in steps:
-            compare_variables(test_case=self, variables=variables,
-                              filename1='1proc_run/output.nc',
-                              filename2='3proc_run/output.nc')
+        compare_variables(test_case=self, variables=variables,
+                          filename1='1proc_run/output.nc',
+                          filename2='3proc_run/output.nc')

--- a/compass/landice/tests/hydro_radial/restart_test/__init__.py
+++ b/compass/landice/tests/hydro_radial/restart_test/__init__.py
@@ -82,8 +82,6 @@ class RestartTest(TestCase):
         and timers
         """
         variables = ['waterThickness', 'waterPressure']
-        steps = self.steps_to_run
-        if 'full_run' in steps and 'restart_run' in steps:
-            compare_variables(test_case=self, variables=variables,
-                              filename1='full_run/output.nc',
-                              filename2='restart_run/output.nc')
+        compare_variables(test_case=self, variables=variables,
+                          filename1='full_run/output.nc',
+                          filename2='restart_run/output.nc')

--- a/compass/landice/tests/thwaites/decomposition_test/__init__.py
+++ b/compass/landice/tests/thwaites/decomposition_test/__init__.py
@@ -16,7 +16,7 @@ class DecompositionTest(TestCase):
 
         Parameters
         ----------
-        test_group : compass.landice.tests.thwaites
+        test_group : compass.landice.tests.thwaites.Thwaites
             The test group that this test case belongs to
 
         """
@@ -42,23 +42,22 @@ class DecompositionTest(TestCase):
         """
         name1 = '{}proc_run'.format(self.cores_set[0])
         name2 = '{}proc_run'.format(self.cores_set[1])
-        if name1 in self.steps_to_run and name2 in self.steps_to_run:
-            # validate thickness
-            compare_variables(test_case=self,
-                              variables=['thickness', ],
-                              filename1='{}/output.nc'.format(name1),
-                              filename2='{}/output.nc'.format(name2),
-                              l1_norm=1.0e-11,
-                              l2_norm=1.0e-11,
-                              linf_norm=1.0e-12,
-                              quiet=False)
+        # validate thickness
+        compare_variables(test_case=self,
+                          variables=['thickness', ],
+                          filename1='{}/output.nc'.format(name1),
+                          filename2='{}/output.nc'.format(name2),
+                          l1_norm=1.0e-11,
+                          l2_norm=1.0e-11,
+                          linf_norm=1.0e-12,
+                          quiet=False)
 
-            # validate surfaceSpeed
-            compare_variables(test_case=self,
-                              variables=['surfaceSpeed', ],
-                              filename1='{}/output.nc'.format(name1),
-                              filename2='{}/output.nc'.format(name2),
-                              l1_norm=1.0e-13,
-                              l2_norm=1.0e-14,
-                              linf_norm=1.0e-15,
-                              quiet=False)
+        # validate surfaceSpeed
+        compare_variables(test_case=self,
+                          variables=['surfaceSpeed', ],
+                          filename1='{}/output.nc'.format(name1),
+                          filename2='{}/output.nc'.format(name2),
+                          l1_norm=1.0e-13,
+                          l2_norm=1.0e-14,
+                          linf_norm=1.0e-15,
+                          quiet=False)

--- a/compass/landice/tests/thwaites/restart_test/__init__.py
+++ b/compass/landice/tests/thwaites/restart_test/__init__.py
@@ -16,7 +16,7 @@ class RestartTest(TestCase):
 
         Parameters
         ----------
-        test_group : compass.landice.tests.thwaites
+        test_group : compass.landice.tests.thwaites.Thwaites
             The test group that this test case belongs to
 
         """
@@ -70,8 +70,6 @@ class RestartTest(TestCase):
         and timers
         """
         variables = ['thickness', 'surfaceSpeed']
-        steps = self.steps_to_run
-        if 'full_run' in steps and 'restart_run' in steps:
-            compare_variables(test_case=self, variables=variables,
-                              filename1='full_run/output.nc',
-                              filename2='restart_run/output.nc')
+        compare_variables(test_case=self, variables=variables,
+                          filename1='full_run/output.nc',
+                          filename2='restart_run/output.nc')

--- a/compass/ocean/tests/baroclinic_channel/decomp_test/__init__.py
+++ b/compass/ocean/tests/baroclinic_channel/decomp_test/__init__.py
@@ -58,8 +58,6 @@ class DecompTest(TestCase):
         """
         variables = ['temperature', 'salinity', 'layerThickness',
                      'normalVelocity']
-        steps = self.steps_to_run
-        if '4proc' in steps and '8proc' in steps:
-            compare_variables(test_case=self, variables=variables,
-                              filename1='4proc/output.nc',
-                              filename2='8proc/output.nc')
+        compare_variables(test_case=self, variables=variables,
+                          filename1='4proc/output.nc',
+                          filename2='8proc/output.nc')

--- a/compass/ocean/tests/baroclinic_channel/restart_test/__init__.py
+++ b/compass/ocean/tests/baroclinic_channel/restart_test/__init__.py
@@ -66,8 +66,6 @@ class RestartTest(TestCase):
         """
         variables = ['temperature', 'salinity', 'layerThickness',
                      'normalVelocity']
-        steps = self.steps_to_run
-        if 'full_run' in steps and 'restart_run' in steps:
-            compare_variables(test_case=self, variables=variables,
-                              filename1='full_run/output.nc',
-                              filename2='restart_run/output.nc')
+        compare_variables(test_case=self, variables=variables,
+                          filename1='full_run/output.nc',
+                          filename2='restart_run/output.nc')

--- a/compass/ocean/tests/baroclinic_channel/threads_test/__init__.py
+++ b/compass/ocean/tests/baroclinic_channel/threads_test/__init__.py
@@ -58,8 +58,6 @@ class ThreadsTest(TestCase):
         """
         variables = ['temperature', 'salinity', 'layerThickness',
                      'normalVelocity']
-        steps = self.steps_to_run
-        if '1thread' in steps and '2thread' in steps:
-            compare_variables(test_case=self, variables=variables,
-                              filename1='1thread/output.nc',
-                              filename2='2thread/output.nc')
+        compare_variables(test_case=self, variables=variables,
+                          filename1='1thread/output.nc',
+                          filename2='2thread/output.nc')

--- a/compass/ocean/tests/global_ocean/decomp_test/__init__.py
+++ b/compass/ocean/tests/global_ocean/decomp_test/__init__.py
@@ -46,8 +46,6 @@ class DecompTest(ForwardTestCase):
         """
         variables = ['temperature', 'salinity', 'layerThickness',
                      'normalVelocity']
-        steps = self.steps_to_run
-        if '4proc' in steps and '8proc' in steps:
-            compare_variables(test_case=self, variables=variables,
-                              filename1='4proc/output.nc',
-                              filename2='8proc/output.nc')
+        compare_variables(test_case=self, variables=variables,
+                          filename1='4proc/output.nc',
+                          filename2='8proc/output.nc')

--- a/compass/ocean/tests/global_ocean/init/__init__.py
+++ b/compass/ocean/tests/global_ocean/init/__init__.py
@@ -101,26 +101,23 @@ class Init(TestCase):
         Test cases can override this method to perform validation of variables
         and timers
         """
-        steps = self.steps_to_run
+        variables = ['temperature', 'salinity', 'layerThickness']
+        compare_variables(test_case=self, variables=variables,
+                          filename1='initial_state/initial_state.nc')
 
-        if 'initial_state' in steps:
-            variables = ['temperature', 'salinity', 'layerThickness']
+        if self.with_bgc:
+            variables = [
+                'temperature', 'salinity', 'layerThickness', 'PO4', 'NO3',
+                'SiO3', 'NH4', 'Fe', 'O2', 'DIC', 'DIC_ALT_CO2', 'ALK',
+                'DOC', 'DON', 'DOFe', 'DOP', 'DOPr', 'DONr', 'zooC',
+                'spChl', 'spC', 'spFe', 'spCaCO3', 'diatChl', 'diatC',
+                'diatFe', 'diatSi', 'diazChl', 'diazC', 'diazFe',
+                'phaeoChl', 'phaeoC', 'phaeoFe', 'DMS', 'DMSP', 'PROT',
+                'POLY', 'LIP']
             compare_variables(test_case=self, variables=variables,
                               filename1='initial_state/initial_state.nc')
 
-            if self.with_bgc:
-                variables = [
-                    'temperature', 'salinity', 'layerThickness', 'PO4', 'NO3',
-                    'SiO3', 'NH4', 'Fe', 'O2', 'DIC', 'DIC_ALT_CO2', 'ALK',
-                    'DOC', 'DON', 'DOFe', 'DOP', 'DOPr', 'DONr', 'zooC',
-                    'spChl', 'spC', 'spFe', 'spCaCO3', 'diatChl', 'diatC',
-                    'diatFe', 'diatSi', 'diazChl', 'diazC', 'diazFe',
-                    'phaeoChl', 'phaeoC', 'phaeoFe', 'DMS', 'DMSP', 'PROT',
-                    'POLY', 'LIP']
-                compare_variables(test_case=self, variables=variables,
-                                  filename1='initial_state/initial_state.nc')
-
-        if 'ssh_adjustment' in steps:
+        if self.mesh.with_ice_shelf_cavities:
             variables = ['ssh', 'landIcePressure']
             compare_variables(test_case=self, variables=variables,
                               filename1='ssh_adjustment/adjusted_init.nc')

--- a/compass/ocean/tests/global_ocean/restart_test/__init__.py
+++ b/compass/ocean/tests/global_ocean/restart_test/__init__.py
@@ -62,8 +62,6 @@ class RestartTest(ForwardTestCase):
         """
         variables = ['temperature', 'salinity', 'layerThickness',
                      'normalVelocity']
-        steps = self.steps_to_run
-        if 'full_run' in steps and 'restart_run' in steps:
-            compare_variables(test_case=self, variables=variables,
-                              filename1='full_run/output.nc',
-                              filename2='restart_run/output.nc')
+        compare_variables(test_case=self, variables=variables,
+                          filename1='full_run/output.nc',
+                          filename2='restart_run/output.nc')

--- a/compass/ocean/tests/global_ocean/threads_test/__init__.py
+++ b/compass/ocean/tests/global_ocean/threads_test/__init__.py
@@ -46,8 +46,6 @@ class ThreadsTest(ForwardTestCase):
         """
         variables = ['temperature', 'salinity', 'layerThickness',
                      'normalVelocity']
-        steps = self.steps_to_run
-        if '1thread' in steps and '2thread' in steps:
-            compare_variables(test_case=self, variables=variables,
-                              filename1='1thread/output.nc',
-                              filename2='2thread/output.nc')
+        compare_variables(test_case=self, variables=variables,
+                          filename1='1thread/output.nc',
+                          filename2='2thread/output.nc')

--- a/compass/ocean/tests/gotm/default/__init__.py
+++ b/compass/ocean/tests/gotm/default/__init__.py
@@ -32,7 +32,6 @@ class Default(TestCase):
         """
         Validate variables against a baseline
         """
-        if 'forward' in self.steps_to_run:
-            compare_variables(test_case=self,
-                              variables=['layerThickness', 'normalVelocity'],
-                              filename1='forward/output.nc')
+        compare_variables(test_case=self,
+                          variables=['layerThickness', 'normalVelocity'],
+                          filename1='forward/output.nc')

--- a/compass/ocean/tests/ice_shelf_2d/restart_test/__init__.py
+++ b/compass/ocean/tests/ice_shelf_2d/restart_test/__init__.py
@@ -67,44 +67,40 @@ class RestartTest(TestCase):
         Test cases can override this method to perform validation of variables
         and timers
         """
-        steps = self.steps_to_run
+        variables = ['bottomDepth', 'ssh', 'layerThickness', 'zMid',
+                     'maxLevelCell', 'temperature', 'salinity']
+        compare_variables(
+            test_case=self, variables=variables,
+            filename1='initial_state/initial_state.nc')
 
-        if 'initial_state' in steps:
-            variables = ['bottomDepth', 'ssh', 'layerThickness', 'zMid',
-                         'maxLevelCell', 'temperature', 'salinity']
-            compare_variables(
-                test_case=self, variables=variables,
-                filename1='initial_state/initial_state.nc')
+        variables = ['temperature', 'salinity', 'layerThickness',
+                     'normalVelocity']
+        compare_variables(test_case=self, variables=variables,
+                          filename1='full_run/output.nc',
+                          filename2='restart_run/output.nc')
 
-        if 'full_run' in steps and 'restart_run' in steps:
-            variables = ['temperature', 'salinity', 'layerThickness',
-                         'normalVelocity']
-            compare_variables(test_case=self, variables=variables,
-                              filename1='full_run/output.nc',
-                              filename2='restart_run/output.nc')
+        variables = ['ssh', 'landIcePressure', 'landIceDraft',
+                     'landIceFraction',
+                     'landIceMask', 'landIceFrictionVelocity', 'topDrag',
+                     'topDragMagnitude', 'landIceFreshwaterFlux',
+                     'landIceHeatFlux', 'heatFluxToLandIce',
+                     'landIceBoundaryLayerTemperature',
+                     'landIceBoundaryLayerSalinity',
+                     'landIceHeatTransferVelocity',
+                     'landIceSaltTransferVelocity',
+                     'landIceInterfaceTemperature',
+                     'landIceInterfaceSalinity', 'accumulatedLandIceMass',
+                     'accumulatedLandIceHeat']
+        compare_variables(test_case=self, variables=variables,
+                          filename1='full_run/land_ice_fluxes.nc',
+                          filename2='restart_run/land_ice_fluxes.nc')
 
-            variables = ['ssh', 'landIcePressure', 'landIceDraft',
-                         'landIceFraction',
-                         'landIceMask', 'landIceFrictionVelocity', 'topDrag',
-                         'topDragMagnitude', 'landIceFreshwaterFlux',
-                         'landIceHeatFlux', 'heatFluxToLandIce',
-                         'landIceBoundaryLayerTemperature',
-                         'landIceBoundaryLayerSalinity',
-                         'landIceHeatTransferVelocity',
-                         'landIceSaltTransferVelocity',
-                         'landIceInterfaceTemperature',
-                         'landIceInterfaceSalinity', 'accumulatedLandIceMass',
-                         'accumulatedLandIceHeat']
-            compare_variables(test_case=self, variables=variables,
-                              filename1='full_run/land_ice_fluxes.nc',
-                              filename2='restart_run/land_ice_fluxes.nc')
-
-            variables = ['accumulatedFrazilIceMass',
-                         'accumulatedFrazilIceSalinity',
-                         'seaIceEnergy', 'frazilLayerThicknessTendency',
-                         'frazilTemperatureTendency', 'frazilSalinityTendency',
-                         'frazilSurfacePressure',
-                         'accumulatedLandIceFrazilMass']
-            compare_variables(test_case=self, variables=variables,
-                              filename1='full_run/frazil.nc',
-                              filename2='restart_run/frazil.nc')
+        variables = ['accumulatedFrazilIceMass',
+                     'accumulatedFrazilIceSalinity',
+                     'seaIceEnergy', 'frazilLayerThicknessTendency',
+                     'frazilTemperatureTendency', 'frazilSalinityTendency',
+                     'frazilSurfacePressure',
+                     'accumulatedLandIceFrazilMass']
+        compare_variables(test_case=self, variables=variables,
+                          filename1='full_run/frazil.nc',
+                          filename2='restart_run/frazil.nc')

--- a/compass/ocean/tests/ziso/default/__init__.py
+++ b/compass/ocean/tests/ziso/default/__init__.py
@@ -74,28 +74,26 @@ class Default(TestCase):
         config = self.config
         work_dir = self.work_dir
 
-        steps = self.steps_to_run
-        if 'initial_state' in steps:
-            variables = ['bottomDepth', 'layerThickness', 'maxLevelCell',
-                         'temperature', 'salinity']
-            compare_variables(
-                test_case=self, variables=variables,
-                filename1='initial_state/ocean.nc')
-        if 'forward' in steps:
-            variables = ['temperature', 'layerThickness']
-            compare_variables(
-                test_case=self, variables=variables,
-                filename1='forward/output/output.0001-01-01_00.00.00.nc')
+        variables = ['bottomDepth', 'layerThickness', 'maxLevelCell',
+                     'temperature', 'salinity']
+        compare_variables(
+            test_case=self, variables=variables,
+            filename1='initial_state/ocean.nc')
 
-            variables = [
-                'xParticle', 'yParticle', 'zParticle', 'zLevelParticle',
-                'buoyancyParticle', 'indexToParticleID', 'currentCell',
-                'transfered', 'numTimesReset']
-            compare_variables(test_case=self, variables=variables,
-                              filename1='forward/analysis_members/'
-                                        'lagrPartTrack.0001-01-01_00.00.00.nc')
+        variables = ['temperature', 'layerThickness']
+        compare_variables(
+            test_case=self, variables=variables,
+            filename1='forward/output/output.0001-01-01_00.00.00.nc')
 
-            timers = ['init_lagrPartTrack', 'compute_lagrPartTrack',
-                      'write_lagrPartTrack', 'restart_lagrPartTrack',
-                      'finalize_lagrPartTrack']
-            compare_timers(timers, config, work_dir, rundir1='forward')
+        variables = [
+            'xParticle', 'yParticle', 'zParticle', 'zLevelParticle',
+            'buoyancyParticle', 'indexToParticleID', 'currentCell',
+            'transfered', 'numTimesReset']
+        compare_variables(test_case=self, variables=variables,
+                          filename1='forward/analysis_members/'
+                                    'lagrPartTrack.0001-01-01_00.00.00.nc')
+
+        timers = ['init_lagrPartTrack', 'compute_lagrPartTrack',
+                  'write_lagrPartTrack', 'restart_lagrPartTrack',
+                  'finalize_lagrPartTrack']
+        compare_timers(timers, config, work_dir, rundir1='forward')

--- a/compass/ocean/tests/ziso/with_frazil/__init__.py
+++ b/compass/ocean/tests/ziso/with_frazil/__init__.py
@@ -66,18 +66,16 @@ class WithFrazil(TestCase):
         Test cases can override this method to perform validation of variables
         and timers
         """
-        steps = self.steps_to_run
-        if 'forward' in steps:
-            variables = ['temperature', 'layerThickness']
-            compare_variables(
-                test_case=self, variables=variables,
-                filename1='forward/output/output.0001-01-01_00.00.00.nc')
+        variables = ['temperature', 'layerThickness']
+        compare_variables(
+            test_case=self, variables=variables,
+            filename1='forward/output/output.0001-01-01_00.00.00.nc')
 
-            variables = ['accumulatedFrazilIceMass',
-                         'accumulatedFrazilIceSalinity',
-                         'seaIceEnergy', 'frazilLayerThicknessTendency',
-                         'frazilTemperatureTendency', 'frazilSalinityTendency',
-                         'frazilSurfacePressure',
-                         'accumulatedLandIceFrazilMass']
-            compare_variables(test_case=self, variables=variables,
-                              filename1='forward/frazil.nc')
+        variables = ['accumulatedFrazilIceMass',
+                     'accumulatedFrazilIceSalinity',
+                     'seaIceEnergy', 'frazilLayerThicknessTendency',
+                     'frazilTemperatureTendency', 'frazilSalinityTendency',
+                     'frazilSurfacePressure',
+                     'accumulatedLandIceFrazilMass']
+        compare_variables(test_case=self, variables=variables,
+                          filename1='forward/frazil.nc')

--- a/docs/developers_guide/framework.rst
+++ b/docs/developers_guide/framework.rst
@@ -339,21 +339,28 @@ Here is a slightly more complex example:
 .. code-block:: python
 
     variables = ['temperature', 'salinity', 'layerThickness', 'normalVelocity']
-    steps = testcase['steps_to_run']
-    if '4proc' in steps and '8proc' in steps:
-        compare_variables(variables, config, work_dir=testcase['work_dir'],
-                          filename1='4proc/output.nc',
-                          filename2='8proc/output.nc')
+    compare_variables(variables, config, work_dir=testcase['work_dir'],
+                      filename1='4proc/output.nc',
+                      filename2='8proc/output.nc')
 
-In this case, we only perform the comparison if both ``4proc`` and ``8proc``
-steps have been run (otherwise, we cannot be sure the data we want will be
-available).  If so, we compare the 4 prognostic variable in ``4proc/output.nc``
+In this case, we compare the 4 prognostic variable in ``4proc/output.nc``
 with the same in ``8proc/output.nc`` to make sure they are identical.  If
 a baseline directory was provided, these 4 variables in each file will also be
 compared with those in the corresponding files in the baseline.
 
-In any of these cases, if comparison fails, a ``ValueError`` is raised and
-execution of the test case is terminated.
+By default, the comparison will only be performed if both the ``4proc`` and
+``8proc`` steps have been run (otherwise, we cannot be sure the data we want
+will be available).  If one of the steps was not run (if the user is running
+steps one at a time or has altered the ``steps_to_run`` config option to remove
+some steps), the function will skip validation, logging a message that
+validation was not performed because of the missing step(s).  You can pass
+the keyword argument ``skip_if_step_not_run=False`` to force validation to run
+(and possibly to fail because the output is not available) even if the user did
+not run the step involved in the validation.
+
+In any of these cases, if comparison fails, the failure is stored in the
+``validation`` attribute of the test case, and a ``ValueError`` will be raised
+later by the framework, terminating execution of the test case.
 
 If ``quiet=False``, typical output will look like this:
 
@@ -401,7 +408,69 @@ If ``quiet=False``, typical output will look like this:
         /home/xylar/data/mpas/test_nightly_latest/ocean/baroclinic_channel/10km/threads_test/2thread/output.nc
 
 If ``quiet=True`` (the default), there is only an indication that the
-comparison passed for each variable.
+comparison passed for each variable:
+
+.. code-block:: none
+
+    temperature          Time index: 0, 1, 2
+      PASS /home/xylar/data/mpas/test_20210616/further_validation/ocean/baroclinic_channel/10km/threads_test/1thread/output.nc
+
+           /home/xylar/data/mpas/test_20210616/further_validation/ocean/baroclinic_channel/10km/threads_test/2thread/output.nc
+
+    salinity             Time index: 0, 1, 2
+      PASS /home/xylar/data/mpas/test_20210616/further_validation/ocean/baroclinic_channel/10km/threads_test/1thread/output.nc
+
+           /home/xylar/data/mpas/test_20210616/further_validation/ocean/baroclinic_channel/10km/threads_test/2thread/output.nc
+
+    layerThickness       Time index: 0, 1, 2
+      PASS /home/xylar/data/mpas/test_20210616/further_validation/ocean/baroclinic_channel/10km/threads_test/1thread/output.nc
+
+           /home/xylar/data/mpas/test_20210616/further_validation/ocean/baroclinic_channel/10km/threads_test/2thread/output.nc
+
+    normalVelocity       Time index: 0, 1, 2
+      PASS /home/xylar/data/mpas/test_20210616/further_validation/ocean/baroclinic_channel/10km/threads_test/1thread/output.nc
+
+           /home/xylar/data/mpas/test_20210616/further_validation/ocean/baroclinic_channel/10km/threads_test/2thread/output.nc
+
+    temperature          Time index: 0, 1, 2
+      PASS /home/xylar/data/mpas/test_20210616/further_validation/ocean/baroclinic_channel/10km/threads_test/1thread/output.nc
+
+           /home/xylar/data/mpas/test_20210616/baseline/ocean/baroclinic_channel/10km/threads_test/1thread/output.nc
+
+    salinity             Time index: 0, 1, 2
+      PASS /home/xylar/data/mpas/test_20210616/further_validation/ocean/baroclinic_channel/10km/threads_test/1thread/output.nc
+
+           /home/xylar/data/mpas/test_20210616/baseline/ocean/baroclinic_channel/10km/threads_test/1thread/output.nc
+
+    layerThickness       Time index: 0, 1, 2
+      PASS /home/xylar/data/mpas/test_20210616/further_validation/ocean/baroclinic_channel/10km/threads_test/1thread/output.nc
+
+           /home/xylar/data/mpas/test_20210616/baseline/ocean/baroclinic_channel/10km/threads_test/1thread/output.nc
+
+    normalVelocity       Time index: 0, 1, 2
+      PASS /home/xylar/data/mpas/test_20210616/further_validation/ocean/baroclinic_channel/10km/threads_test/1thread/output.nc
+
+           /home/xylar/data/mpas/test_20210616/baseline/ocean/baroclinic_channel/10km/threads_test/1thread/output.nc
+
+    temperature          Time index: 0, 1, 2
+      PASS /home/xylar/data/mpas/test_20210616/further_validation/ocean/baroclinic_channel/10km/threads_test/2thread/output.nc
+
+           /home/xylar/data/mpas/test_20210616/baseline/ocean/baroclinic_channel/10km/threads_test/2thread/output.nc
+
+    salinity             Time index: 0, 1, 2
+      PASS /home/xylar/data/mpas/test_20210616/further_validation/ocean/baroclinic_channel/10km/threads_test/2thread/output.nc
+
+           /home/xylar/data/mpas/test_20210616/baseline/ocean/baroclinic_channel/10km/threads_test/2thread/output.nc
+
+    layerThickness       Time index: 0, 1, 2
+      PASS /home/xylar/data/mpas/test_20210616/further_validation/ocean/baroclinic_channel/10km/threads_test/2thread/output.nc
+
+           /home/xylar/data/mpas/test_20210616/baseline/ocean/baroclinic_channel/10km/threads_test/2thread/output.nc
+
+    normalVelocity       Time index: 0, 1, 2
+      PASS /home/xylar/data/mpas/test_20210616/further_validation/ocean/baroclinic_channel/10km/threads_test/2thread/output.nc
+
+           /home/xylar/data/mpas/test_20210616/baseline/ocean/baroclinic_channel/10km/threads_test/2thread/output.nc
 
 By default, the function checks to make sure ``filename1`` and, if provided,
 ``filename2`` are output of one of the steps in the test case.  In general,

--- a/docs/developers_guide/organization.rst
+++ b/docs/developers_guide/organization.rst
@@ -715,35 +715,30 @@ examples of validation of variables from output files:
         """
         steps = self.steps_to_run
 
-        if 'initial_state' in steps:
-            variables = ['temperature', 'salinity', 'layerThickness']
+        variables = ['temperature', 'salinity', 'layerThickness']
+        compare_variables(test_case=self, variables=variables,
+                          filename1='initial_state/initial_state.nc')
+
+        if self.with_bgc:
+            variables = [
+                'temperature', 'salinity', 'layerThickness', 'PO4', 'NO3',
+                'SiO3', 'NH4', 'Fe', 'O2', 'DIC', 'DIC_ALT_CO2', 'ALK',
+                'DOC', 'DON', 'DOFe', 'DOP', 'DOPr', 'DONr', 'zooC',
+                'spChl', 'spC', 'spFe', 'spCaCO3', 'diatChl', 'diatC',
+                'diatFe', 'diatSi', 'diazChl', 'diazC', 'diazFe',
+                'phaeoChl', 'phaeoC', 'phaeoFe', 'DMS', 'DMSP', 'PROT',
+                'POLY', 'LIP']
             compare_variables(test_case=self, variables=variables,
                               filename1='initial_state/initial_state.nc')
 
-            if self.with_bgc:
-                variables = [
-                    'temperature', 'salinity', 'layerThickness', 'PO4', 'NO3',
-                    'SiO3', 'NH4', 'Fe', 'O2', 'DIC', 'DIC_ALT_CO2', 'ALK',
-                    'DOC', 'DON', 'DOFe', 'DOP', 'DOPr', 'DONr', 'zooC',
-                    'spChl', 'spC', 'spFe', 'spCaCO3', 'diatChl', 'diatC',
-                    'diatFe', 'diatSi', 'diazChl', 'diazC', 'diazFe',
-                    'phaeoChl', 'phaeoC', 'phaeoFe', 'DMS', 'DMSP', 'PROT',
-                    'POLY', 'LIP']
-                compare_variables(test_case=self, variables=variables,
-                                  filename1='initial_state/initial_state.nc')
-
-        if 'ssh_adjustment' in steps:
+        if self.mesh.with_ice_shelf_cavities:
             variables = ['ssh', 'landIcePressure']
             compare_variables(test_case=self, variables=variables,
                               filename1='ssh_adjustment/adjusted_init.nc')
 
-Again, as mentioned in :ref:`dev_test_case_class`, the ``self.steps_to_run``
-attribute may either be the full list of steps that would typically be run to
-complete the test case (the value given to it at init) or it may be a single
-test case because the user is running the steps manually, one at a time.  For
-this reason, it is important to check if the step was run before running
-validation on its outputs.  Otherwise, the validation may fail merely because
-the user didn't ask for that particular step.
+If you leave the default keyword argument ``skip_if_step_not_run=True``,
+comparison will be skipped (logging a message) if one or more of the steps
+involved in the comparison was not run.
 
 .. _dev_steps:
 

--- a/docs/tutorials/dev_porting_legacy.rst
+++ b/docs/tutorials/dev_porting_legacy.rst
@@ -1244,13 +1244,12 @@ class in ``Default`` as follows:
         """
         Validate variables against a baseline
         """
-        if 'forward' in self.steps_to_run:
-            compare_variables(test_case=self,
-                              variables=['layerThickness', 'normalVelocity'],
-                              filename1='forward/output.nc')
+        compare_variables(test_case=self,
+                          variables=['layerThickness', 'normalVelocity'],
+                          filename1='forward/output.nc')
 
-We will only perform validation if the ``forward`` step was part of the current
-test-case run (otherwise the data might not be available). The call to
+If the user ran the ``forward`` step as part of this test case (sometimes they
+might run only some of the steps), the call to
 :py:func:`from compass.validate.compare_variables()` will check whether
 variables ``layerThickness`` and ``normalVelocity`` are exactly the same in
 this run as they were in a previous run if a baseline run was provided when the


### PR DESCRIPTION
In `compass.validate.compare_variables()`, skip validation if one or more of the steps involved in the variable comparison were not run.  Log a message in such cases saying why validation was skipped.