### PR TITLE
Switch Linux and OSX environments to use SCORPIO conda package

### DIFF
--- a/conda/compass_env/spec-file-mpich.txt
+++ b/conda/compass_env/spec-file-mpich.txt
@@ -34,8 +34,9 @@ cmake
 cxx-compiler
 flake8
 fortran-compiler
-libnetcdf=4.7.4=mpi_mpich*
-libpnetcdf=*=mpi_mpich*
+libnetcdf=4.7.4=mpi_mpich_*
+libpnetcdf=1.12.2=mpi_mpich_*
+scorpio=1.1.6=mpi_mpich_*
 m4
 make
 mpich

--- a/conda/compass_env/spec-file-mpich.txt
+++ b/conda/compass_env/spec-file-mpich.txt
@@ -34,7 +34,7 @@ cmake
 cxx-compiler
 flake8
 fortran-compiler
-libnetcdf=4.7.4=mpi_mpich_*
+libnetcdf=4.8.0=mpi_mpich_*
 libpnetcdf=1.12.2=mpi_mpich_*
 scorpio=1.1.6=mpi_mpich_*
 m4

--- a/conda/compass_env/spec-file-mpich.txt
+++ b/conda/compass_env/spec-file-mpich.txt
@@ -34,6 +34,7 @@ cmake
 cxx-compiler
 flake8
 fortran-compiler
+libnetcdf=4.7.4=mpi_mpich*
 libpnetcdf=*=mpi_mpich*
 m4
 make

--- a/conda/compass_env/spec-file-openmpi.txt
+++ b/conda/compass_env/spec-file-openmpi.txt
@@ -34,8 +34,9 @@ cmake
 cxx-compiler
 flake8
 fortran-compiler
-libnetcdf=4.7.4=mpi_mpich*
-libpnetcdf=*=mpi_openmpi*
+libnetcdf=4.7.4=mpi_openmpi_*
+libpnetcdf=1.12.2=mpi_openmpi_*
+scorpio=1.1.6=mpi_openmpi_*
 m4
 make
 openmpi

--- a/conda/compass_env/spec-file-openmpi.txt
+++ b/conda/compass_env/spec-file-openmpi.txt
@@ -34,6 +34,7 @@ cmake
 cxx-compiler
 flake8
 fortran-compiler
+libnetcdf=4.7.4=mpi_mpich*
 libpnetcdf=*=mpi_openmpi*
 m4
 make

--- a/conda/compass_env/spec-file-openmpi.txt
+++ b/conda/compass_env/spec-file-openmpi.txt
@@ -34,7 +34,7 @@ cmake
 cxx-compiler
 flake8
 fortran-compiler
-libnetcdf=4.7.4=mpi_openmpi_*
+libnetcdf=4.8.0=mpi_openmpi_*
 libpnetcdf=1.12.2=mpi_openmpi_*
 scorpio=1.1.6=mpi_openmpi_*
 m4

--- a/conda/configure_compass_env.py
+++ b/conda/configure_compass_env.py
@@ -222,9 +222,9 @@ def build_env(is_test, recreate, machine, compiler, mpi, conda_mpi, version,
         mpi_prefix = 'mpi_{}'.format(mpi)
 
     channels = '--override-channels -c conda-forge -c defaults'
-    if machine is None:
-        # we need libpnetcdf from the e3sm channel for now
-        channels = '{} -c e3sm'.format(channels)
+    if machine is None or not is_test:
+        # we need libpnetcdf and scorpio from the e3sm channel, compass label
+        channels = '{} -c e3sm/label/compass'.format(channels)
     packages = 'python={}'.format(python)
 
     base_activation_script = os.path.abspath(
@@ -251,7 +251,6 @@ def build_env(is_test, recreate, machine, compiler, mpi, conda_mpi, version,
             check_call(commands)
 
         else:
-            channels = '{} -c e3sm'.format(channels)
             packages = '{} "compass={}={}_*"'.format(
                 packages, version, mpi_prefix)
             commands = '{}; mamba create -y -n {} {} {}'.format(
@@ -458,11 +457,11 @@ def build_system_libraries(config, machine, compiler, mpi, version,
 
     if machine is not None:
         esmf = config.get('deploy', 'esmf')
+        scorpio = config.get('deploy', 'scorpio')
     else:
-        # stick with the conda-forge ESMF
+        # stick with the conda-forge ESMF and e3sm/label/compass SCORPIO
         esmf = 'None'
-
-    scorpio = config.get('deploy', 'scorpio')
+        scorpio = 'None'
 
     if esmf != 'None':
         # remove conda-forge esmf because we will use the system build

--- a/conda/configure_compass_env.py
+++ b/conda/configure_compass_env.py
@@ -494,8 +494,7 @@ def build_system_libraries(config, machine, compiler, mpi, version,
             'export LD_LIBRARY_PATH={}:$LD_LIBRARY_PATH'.format(
                 os.path.join(esmf_path, 'lib')))
 
-    if scorpio != 'None':
-        sys_info['env_vars'].append('export PIO={}'.format(scorpio_path))
+    sys_info['env_vars'].append('export PIO={}'.format(scorpio_path))
 
     build_esmf = 'False'
     if esmf == 'None':

--- a/conda/pnetcdf/ci/linux_mpi_mpich.yaml
+++ b/conda/pnetcdf/ci/linux_mpi_mpich.yaml
@@ -1,0 +1,25 @@
+c_compiler:
+- gcc
+c_compiler_version:
+- '9'
+cdt_name:
+- cos6
+channel_sources:
+- conda-forge,defaults
+channel_targets:
+- e3sm main
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '9'
+hdf5:
+- 1.10.6
+libnetcdf:
+- 4.7.4
+mpi:
+- mpich
+target_platform:
+- linux-64
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version

--- a/conda/pnetcdf/ci/linux_mpi_mpich.yaml
+++ b/conda/pnetcdf/ci/linux_mpi_mpich.yaml
@@ -15,7 +15,7 @@ cxx_compiler_version:
 hdf5:
 - 1.10.6
 libnetcdf:
-- 4.7.4
+- 4.8.0
 mpi:
 - mpich
 target_platform:

--- a/conda/pnetcdf/ci/linux_mpi_openmpi.yaml
+++ b/conda/pnetcdf/ci/linux_mpi_openmpi.yaml
@@ -1,0 +1,25 @@
+c_compiler:
+- gcc
+c_compiler_version:
+- '9'
+cdt_name:
+- cos6
+channel_sources:
+- conda-forge,defaults
+channel_targets:
+- e3sm main
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '9'
+hdf5:
+- 1.10.6
+libnetcdf:
+- 4.7.4
+mpi:
+- openmpi
+target_platform:
+- linux-64
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version

--- a/conda/pnetcdf/ci/linux_mpi_openmpi.yaml
+++ b/conda/pnetcdf/ci/linux_mpi_openmpi.yaml
@@ -15,7 +15,7 @@ cxx_compiler_version:
 hdf5:
 - 1.10.6
 libnetcdf:
-- 4.7.4
+- 4.8.0
 mpi:
 - openmpi
 target_platform:

--- a/conda/pnetcdf/ci/osx_mpi_mpich.yaml
+++ b/conda/pnetcdf/ci/osx_mpi_mpich.yaml
@@ -1,0 +1,23 @@
+c_compiler:
+- clang
+c_compiler_version:
+- '11'
+channel_sources:
+- conda-forge,defaults
+channel_targets:
+- e3sm main
+cxx_compiler:
+- clangxx
+cxx_compiler_version:
+- '11'
+hdf5:
+- 1.10.6
+libnetcdf:
+- 4.7.4
+mpi:
+- mpich
+target_platform:
+- osx-64
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version

--- a/conda/pnetcdf/ci/osx_mpi_mpich.yaml
+++ b/conda/pnetcdf/ci/osx_mpi_mpich.yaml
@@ -13,7 +13,7 @@ cxx_compiler_version:
 hdf5:
 - 1.10.6
 libnetcdf:
-- 4.7.4
+- 4.8.0
 mpi:
 - mpich
 target_platform:

--- a/conda/pnetcdf/ci/osx_mpi_openmpi.yaml
+++ b/conda/pnetcdf/ci/osx_mpi_openmpi.yaml
@@ -1,0 +1,23 @@
+c_compiler:
+- clang
+c_compiler_version:
+- '11'
+channel_sources:
+- conda-forge,defaults
+channel_targets:
+- e3sm main
+cxx_compiler:
+- clangxx
+cxx_compiler_version:
+- '11'
+hdf5:
+- 1.10.6
+libnetcdf:
+- 4.7.4
+mpi:
+- openmpi
+target_platform:
+- osx-64
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version

--- a/conda/pnetcdf/ci/osx_mpi_openmpi.yaml
+++ b/conda/pnetcdf/ci/osx_mpi_openmpi.yaml
@@ -13,7 +13,7 @@ cxx_compiler_version:
 hdf5:
 - 1.10.6
 libnetcdf:
-- 4.7.4
+- 4.8.0
 mpi:
 - openmpi
 target_platform:

--- a/conda/pnetcdf/recipe/build.sh
+++ b/conda/pnetcdf/recipe/build.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+export MPICC=mpicc
+export MPICXX=mpicxx
+export MPIF77=mpifort
+export MPIF90=mpifort
+
+./configure --prefix=${PREFIX} \
+    --with-netcdf4=${PREFIX}
+
+make
+# serial tests
+# make check
+# lighter weight parallel tests (4 MPI tasks)
+# make ptest
+
+make install

--- a/conda/pnetcdf/recipe/conda_build_config.yaml
+++ b/conda/pnetcdf/recipe/conda_build_config.yaml
@@ -1,0 +1,8 @@
+mpi:
+  - openmpi
+  - mpich
+
+pin_run_as_build:
+  openmpi: x.x
+  mpich: x.x
+

--- a/conda/pnetcdf/recipe/meta.yaml
+++ b/conda/pnetcdf/recipe/meta.yaml
@@ -1,0 +1,79 @@
+{% set version = "1.12.2" %}
+{% set build = 2 %}
+
+# recipe-lint fails if mpi is undefined
+{% set mpi = mpi or 'mpich' %}
+{% if mpi == "mpich" %}
+# prioritize mpich via build number
+{% set build = build + 100 %}
+{% endif %}
+
+package:
+  name: libpnetcdf
+  version: {{ version }}
+
+source:
+  url: https://parallel-netcdf.github.io/Release/pnetcdf-{{ version }}.tar.gz
+  sha256: 3ef1411875b07955f519a5b03278c31e566976357ddfc74c2493a1076e7d7c74
+
+build:
+  number: {{ build }}
+  skip: True  # [win]
+  {% set mpi_prefix = "mpi_" + mpi %}
+  # add build string so packages can depend on
+  # mpi variants
+  # dependencies:
+  # `PKG_NAME * mpi_mpich_*` for mpich
+  # `PKG_NAME * mpi_*` for any mpi
+  string: "{{ mpi_prefix }}_h{{ PKG_HASH }}_{{ build }}"
+
+  # mpi builds require the right mpi
+  {% set build_pin = mpi_prefix + '_*' %}
+
+  run_exports:
+    - {{ pin_subpackage('libpnetcdf', max_pin='x.x.x.x') }} {{ build_pin }}
+
+requirements:
+  build:
+    - cmake
+    - make
+    - m4
+    - {{ compiler('c') }}
+    - {{ compiler('cxx') }}
+    - {{ compiler('fortran') }}
+    - llvm-openmp  # [osx]
+    - libgomp      # [linux]
+  host:
+    - {{ mpi }}
+    # these need to be listed twice so conda build picks up the pins
+    - hdf5
+    - hdf5 * {{ mpi_prefix }}_*
+    - libnetcdf
+    - libnetcdf * {{ mpi_prefix }}_*
+    - netcdf-fortran
+    - netcdf-fortran * {{ mpi_prefix }}_*
+  run:
+    - {{ mpi }}
+    - hdf5 * {{ mpi_prefix }}_*
+    - libnetcdf * {{ mpi_prefix }}_*
+    - netcdf-fortran * {{ mpi_prefix }}_*
+
+test:
+  commands:
+    - pnetcdf-config --all
+    - test -f ${PREFIX}/lib/libpnetcdf.a
+    #- test -f ${PREFIX}/lib/libpnetcdf${SHLIB_EXT}
+
+about:
+  home: https://parallel-netcdf.github.io/
+  license: custom
+  license_file: COPYRIGHT
+  summary: |
+    PnetCDF is a high-performance parallel I/O library for accessing Unidata's
+    NetCDF, files in classic formats, specifically the formats of CDF-1, 2, and
+    5.
+  dev_url: https://github.com/Parallel-NetCDF/PnetCDF
+
+extra:
+  recipe-maintainers:
+    - xylar

--- a/conda/pnetcdf/recipe/meta.yaml
+++ b/conda/pnetcdf/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set version = "1.12.2" %}
-{% set build = 2 %}
+{% set build = 3 %}
 
 # recipe-lint fails if mpi is undefined
 {% set mpi = mpi or 'mpich' %}

--- a/conda/pnetcdf/recipe/run_test.sh
+++ b/conda/pnetcdf/recipe/run_test.sh
@@ -1,0 +1,3 @@
+pnetcdf-config --has-c++      | grep -q yes
+pnetcdf-config --has-fortran  | grep -q yes
+pnetcdf-config --netcdf4      | grep -q enabled

--- a/conda/scorpio/ci/linux_mpi_mpich.yaml
+++ b/conda/scorpio/ci/linux_mpi_mpich.yaml
@@ -15,7 +15,7 @@ cxx_compiler_version:
 hdf5:
 - 1.10.6
 libnetcdf:
-- 4.7.4
+- 4.8.0
 libpnetcdf:
 - 1.12.2
 mpi:

--- a/conda/scorpio/ci/linux_mpi_mpich.yaml
+++ b/conda/scorpio/ci/linux_mpi_mpich.yaml
@@ -1,0 +1,27 @@
+c_compiler:
+- gcc
+c_compiler_version:
+- '9'
+cdt_name:
+- cos6
+channel_sources:
+- conda-forge,defaults,e3sm
+channel_targets:
+- e3sm main
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '9'
+hdf5:
+- 1.10.6
+libnetcdf:
+- 4.7.4
+libpnetcdf:
+- 1.12.2
+mpi:
+- mpich
+target_platform:
+- linux-64
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version

--- a/conda/scorpio/ci/linux_mpi_openmpi.yaml
+++ b/conda/scorpio/ci/linux_mpi_openmpi.yaml
@@ -15,7 +15,7 @@ cxx_compiler_version:
 hdf5:
 - 1.10.6
 libnetcdf:
-- 4.7.4
+- 4.8.0
 libpnetcdf:
 - 1.12.2
 mpi:

--- a/conda/scorpio/ci/linux_mpi_openmpi.yaml
+++ b/conda/scorpio/ci/linux_mpi_openmpi.yaml
@@ -1,0 +1,27 @@
+c_compiler:
+- gcc
+c_compiler_version:
+- '9'
+cdt_name:
+- cos6
+channel_sources:
+- conda-forge,defaults,e3sm
+channel_targets:
+- e3sm main
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '9'
+hdf5:
+- 1.10.6
+libnetcdf:
+- 4.7.4
+libpnetcdf:
+- 1.12.2
+mpi:
+- openmpi
+target_platform:
+- linux-64
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version

--- a/conda/scorpio/ci/osx_mpi_mpich.yaml
+++ b/conda/scorpio/ci/osx_mpi_mpich.yaml
@@ -13,7 +13,7 @@ cxx_compiler_version:
 hdf5:
 - 1.10.6
 libnetcdf:
-- 4.7.4
+- 4.8.0
 libpnetcdf:
 - 1.12.2
 mpi:

--- a/conda/scorpio/ci/osx_mpi_mpich.yaml
+++ b/conda/scorpio/ci/osx_mpi_mpich.yaml
@@ -1,0 +1,25 @@
+c_compiler:
+- clang
+c_compiler_version:
+- '11'
+channel_sources:
+- conda-forge,defaults
+channel_targets:
+- e3sm main
+cxx_compiler:
+- clangxx
+cxx_compiler_version:
+- '11'
+hdf5:
+- 1.10.6
+libnetcdf:
+- 4.7.4
+libpnetcdf:
+- 1.12.2
+mpi:
+- mpich
+target_platform:
+- osx-64
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version

--- a/conda/scorpio/ci/osx_mpi_openmpi.yaml
+++ b/conda/scorpio/ci/osx_mpi_openmpi.yaml
@@ -13,7 +13,7 @@ cxx_compiler_version:
 hdf5:
 - 1.10.6
 libnetcdf:
-- 4.7.4
+- 4.8.0
 libpnetcdf:
 - 1.12.2
 mpi:

--- a/conda/scorpio/ci/osx_mpi_openmpi.yaml
+++ b/conda/scorpio/ci/osx_mpi_openmpi.yaml
@@ -1,0 +1,25 @@
+c_compiler:
+- clang
+c_compiler_version:
+- '11'
+channel_sources:
+- conda-forge,defaults
+channel_targets:
+- e3sm main
+cxx_compiler:
+- clangxx
+cxx_compiler_version:
+- '11'
+hdf5:
+- 1.10.6
+libnetcdf:
+- 4.7.4
+libpnetcdf:
+- 1.12.2
+mpi:
+- openmpi
+target_platform:
+- osx-64
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version

--- a/conda/scorpio/recipe/COPYRIGHT
+++ b/conda/scorpio/recipe/COPYRIGHT
@@ -1,0 +1,16 @@
+/******************************************************************************
+ *
+ *
+ *
+ * Copyright (C) 2009-2019
+ *
+ * Permission to use, copy, modify, and distribute this software and its
+ * documentation under the terms of the GNU General Public License is hereby
+ * granted. No representations are made about the suitability of this software
+ * for any purpose. It is provided "as is" without express or implied warranty.
+ * See the GNU General Public License for more details.
+ *
+ * Documents produced by Doxygen are derivative works derived from the
+ * input used in their production; they are not affected by this license.
+ *
+ */

--- a/conda/scorpio/recipe/build.sh
+++ b/conda/scorpio/recipe/build.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+export NETCDF_C_PATH=$(dirname $(dirname $(which nc-config)))
+export NETCDF_FORTRAN_PATH=$(dirname $(dirname $(which nf-config)))
+export PNETCDF_PATH=$(dirname $(dirname $(which pnetcdf-config)))
+
+mkdir build
+cd build
+FC=mpifort CC=mpicc CXX=mpicxx cmake \
+    -DCMAKE_INSTALL_PREFIX=$PREFIX \
+    -DPIO_USE_MALLOC=ON \
+    -DPIO_ENABLE_TOOLS=OFF \
+    -DPIO_ENABLE_TESTS=ON \
+    -DPIO_ENABLE_TIMING=OFF \
+    -DPIO_ENABLE_INTERNAL_TIMING=ON \
+    -DNetCDF_C_PATH=$NETCDF_C_PATH \
+    -DNetCDF_Fortran_PATH=$NETCDF_FORTRAN_PATH \
+    -DPnetCDF_PATH=$PNETCDF_PATH ..
+
+make
+
+# make tests
+# ctest
+
+make install

--- a/conda/scorpio/recipe/conda_build_config.yaml
+++ b/conda/scorpio/recipe/conda_build_config.yaml
@@ -1,0 +1,8 @@
+mpi:
+  - openmpi
+  - mpich
+
+pin_run_as_build:
+  openmpi: x.x
+  mpich: x.x
+

--- a/conda/scorpio/recipe/meta.yaml
+++ b/conda/scorpio/recipe/meta.yaml
@@ -1,0 +1,79 @@
+{% set version = "1.1.6" %}
+{% set build = 0 %}
+
+# recipe-lint fails if mpi is undefined
+{% set mpi = mpi or 'mpich' %}
+{% if mpi == "mpich" %}
+# prioritize mpich via build number
+{% set build = build + 100 %}
+{% endif %}
+
+package:
+  name: scorpio
+  version: {{ version }}
+
+source:
+  url: https://github.com/E3SM-Project/scorpio/archive/refs/tags/scorpio-v{{ version }}.tar.gz
+  sha256: 31bb75d30ce05deba952470f0132ed89d13d198c2c5d66b1921c6468f57390d4
+
+build:
+  number: {{ build }}
+  skip: True  # [win]
+  {% set mpi_prefix = "mpi_" + mpi %}
+  # add build string so packages can depend on
+  # mpi variants
+  # dependencies:
+  # `PKG_NAME * mpi_mpich_*` for mpich
+  # `PKG_NAME * mpi_*` for any mpi
+  string: "{{ mpi_prefix }}_h{{ PKG_HASH }}_{{ build }}"
+
+  # mpi builds require the right mpi
+  {% set build_pin = mpi_prefix + '_*' %}
+
+  run_exports:
+    - {{ pin_subpackage('scorpio', max_pin='x.x.x.x') }} {{ build_pin }}
+
+requirements:
+  build:
+    - cmake
+    - make
+    - {{ compiler('c') }}
+    - {{ compiler('cxx') }}
+    - {{ compiler('fortran') }}
+  host:
+    - {{ mpi }}
+    # these need to be listed twice so conda build picks up the pins
+    - hdf5
+    - hdf5 * {{ mpi_prefix }}_*
+    - libnetcdf
+    - libnetcdf * {{ mpi_prefix }}_*
+    - netcdf-fortran
+    - netcdf-fortran * {{ mpi_prefix }}_*
+    - libpnetcdf
+    - libpnetcdf * {{ mpi_prefix }}_*
+  run:
+    - {{ mpi }}
+    - hdf5 * {{ mpi_prefix }}_*
+    - libnetcdf * {{ mpi_prefix }}_*
+    - netcdf-fortran * {{ mpi_prefix }}_*
+    - libpnetcdf * {{ mpi_prefix }}_*
+
+test:
+  commands:
+    - test -f ${PREFIX}/lib/libpioc.a
+    - test -f ${PREFIX}/lib/libpiof.a
+
+about:
+  home: https://github.com/E3SM-Project/scorpio
+  license: GPL
+  license_file: COPYRIGHT
+  summary: |
+    Software for Caching Output and Reads for Parallel I/O (SCORPIO)
+    A high-level Parallel I/O Library for structured grid applications.
+    This library was derived from the Parallel I/O library
+    https://github.com/NCAR/ParallelIO.
+  dev_url: https://github.com/E3SM-Project/scorpio
+
+extra:
+  recipe-maintainers:
+    - xylar

--- a/conda/scorpio/recipe/meta.yaml
+++ b/conda/scorpio/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set version = "1.1.6" %}
-{% set build = 0 %}
+{% set build = 1 %}
 
 # recipe-lint fails if mpi is undefined
 {% set mpi = mpi or 'mpich' %}


### PR DESCRIPTION
Like PNetCDF, SCORPIO can be built as a conda package.  This merge adds the conda recipes for `libpnetcdf` and `scorpio`.  Both packages have been built for OSX and Linux with `mpich` and `openmp`, and uploaded to the `e3sm/label/compass` anaconda channel.

The script for building the compass development conda environment has been updated to use these packages on unknown machines.  For now, I'm using the latest `libnetcdf` (4.8.0) but SCORPIO developers suggested that a slightly older version (4.7.4) might be safer since the newest version hasn't been tested.  I uploaded packages built with this older version (and also rebuilt `mpas_tools` 0.7.0 with that version).  So we have that as a fallback if problems emerge.  I haven't seen any so far.

This work is critical for supporting compass development on OSX.