### PR TITLE
Update Atlantic MOC basins to exclude Mediterranean

### DIFF
--- a/conda/compass_env/spec-file-mpich.txt
+++ b/conda/compass_env/spec-file-mpich.txt
@@ -8,7 +8,7 @@ cartopy_offlinedata
 cmocean
 esmf=*=mpi_mpich_*
 ffmpeg
-geometric_features=0.4.0
+geometric_features=0.5.0
 git
 ipython
 jigsaw=0.9.14

--- a/conda/compass_env/spec-file-nompi.txt
+++ b/conda/compass_env/spec-file-nompi.txt
@@ -8,7 +8,7 @@ cartopy_offlinedata
 cmocean
 esmf=*=nompi_*
 ffmpeg
-geometric_features=0.4.0
+geometric_features=0.5.0
 git
 ipython
 jigsaw=0.9.14

--- a/conda/compass_env/spec-file-openmpi.txt
+++ b/conda/compass_env/spec-file-openmpi.txt
@@ -8,7 +8,7 @@ cartopy_offlinedata
 cmocean
 esmf=*=mpi_openmpi_*
 ffmpeg
-geometric_features=0.4.0
+geometric_features=0.5.0
 git
 ipython
 jigsaw=0.9.14

--- a/conda/recipe/meta.yaml
+++ b/conda/recipe/meta.yaml
@@ -45,7 +45,7 @@ requirements:
     - cmocean
     - esmf * {{ mpi_prefix }}_*
     - ffmpeg
-    - geometric_features 0.4.0
+    - geometric_features 0.5.0
     - git
     - ipython
     - jigsaw 0.9.14


### PR DESCRIPTION
This merge updates `geometric_features` to a new version (0.5.0) that excludes the Mediterranean from the Atlantic MOC.  There is also an `AtlanticMed` MOC basin that still includes the Mediterranean.

This requires a release of geometric_features after https://github.com/MPAS-Dev/geometric_features/pull/176 has been merged.