### PR TITLE
Fix None check of norms in validate package

### DIFF
--- a/compass/validate.py
+++ b/compass/validate.py
@@ -298,17 +298,17 @@ def _compute_norms(da1, da2, quiet, max_l1_norm, max_l2_norm, max_linf_norm,
     else:
         diff_str = '{:d}: '.format(time_index)
 
-    if l1_norm is not None:
+    if max_l1_norm is not None:
         if max_l1_norm < l1_norm:
             result = False
     diff_str = '{} l1: {:16.14e} '.format(diff_str, l1_norm)
 
-    if l2_norm is not None:
+    if max_l2_norm is not None:
         if max_l2_norm < l2_norm:
             result = False
     diff_str = '{} l2: {:16.14e} '.format(diff_str, l2_norm)
 
-    if linf_norm is not None:
+    if max_linf_norm is not None:
         if max_linf_norm < linf_norm:
             result = False
     diff_str = '{} linf: {:16.14e} '.format(diff_str, linf_norm)


### PR DESCRIPTION
This merge fixes a bug in the validate package that was not properly
checking if None was passed to the validation function.  This corrects
the following error:
```
  File
"/turquoise/usr/projects/climate/mhoffman/mpas/compass/compass/validate.py",
line 124, in compare_variables
    internal_pass = _compare_variables(
  File
"/turquoise/usr/projects/climate/mhoffman/mpas/compass/compass/validate.py",
line 254, in _compare_variables
    result = _compute_norms(slice1, slice2, quiet, l1_norm,
  File
"/turquoise/usr/projects/climate/mhoffman/mpas/compass/compass/validate.py",
line 302, in _compute_norms
    if max_l1_norm < l1_norm:
TypeError: '>' not supported between instances of 'float' and 'NoneType'
```

After the fix, the validate package works as expected when passing None
for an norm value (the comparison is skipped).