### PR TITLE
Add global ocean test case with Lagrangian particles

### DIFF
--- a/compass/ocean/tests/global_ocean/__init__.py
+++ b/compass/ocean/tests/global_ocean/__init__.py
@@ -16,6 +16,7 @@ from compass.ocean.tests.global_ocean.decomp_test import DecompTest
 from compass.ocean.tests.global_ocean.threads_test import ThreadsTest
 from compass.ocean.tests.global_ocean.analysis_test import AnalysisTest
 from compass.ocean.tests.global_ocean.daily_output_test import DailyOutputTest
+from compass.ocean.tests.global_ocean.lagrangian_particles import LagrangianParticles
 from compass.ocean.tests.global_ocean.files_for_e3sm import FilesForE3SM
 from compass.ocean.tests.global_ocean.make_diagnostics_files import \
     MakeDiagnosticsFiles
@@ -68,6 +69,10 @@ class GlobalOcean(TestGroup):
                 DailyOutputTest(
                     test_group=self, mesh=mesh, init=init,
                     time_integrator=time_integrator))
+            self.add_test_case(
+                LagrangianParticles(
+                    test_group=self, mesh=mesh, init=init,
+                    time_integrator=time_integrator))
 
             dynamic_adjustment = QU240DynamicAdjustment(
                 test_group=self, mesh=mesh, init=init,
@@ -95,6 +100,10 @@ class GlobalOcean(TestGroup):
                 ThreadsTest(
                     test_group=self, mesh=mesh, init=init,
                     time_integrator=time_integrator))
+            #self.add_test_case(
+            #    LagrangianParticles(
+            #        test_group=self, mesh=mesh, init=init,
+            #        time_integrator=time_integrator))
 
             # EN4_1900 tests
             time_integrator = 'split_explicit'
@@ -171,6 +180,10 @@ class GlobalOcean(TestGroup):
                 FilesForE3SM(
                     test_group=self, mesh=mesh, init=init,
                     dynamic_adjustment=dynamic_adjustment))
+            #self.add_test_case(
+            #    LagrangianParticles(
+            #        test_group=self, mesh=mesh, init=init,
+            #        time_integrator=time_integrator))
 
         # WC14: just the version without cavities
         for mesh_name in ['WC14']:
@@ -194,6 +207,10 @@ class GlobalOcean(TestGroup):
                 FilesForE3SM(
                     test_group=self, mesh=mesh, init=init,
                     dynamic_adjustment=dynamic_adjustment))
+            #self.add_test_case(
+            #    LagrangianParticles(
+            #        test_group=self, mesh=mesh, init=init,
+            #        time_integrator=time_integrator))
 
         # A test case for making diagnostics files from an existing mesh
         self.add_test_case(MakeDiagnosticsFiles(test_group=self))

--- a/compass/ocean/tests/global_ocean/forward.py
+++ b/compass/ocean/tests/global_ocean/forward.py
@@ -116,6 +116,10 @@ class ForwardStep(Step):
         self.add_input_file(
             filename='graph.info',
             work_dir_target='{}/culled_graph.info'.format(mesh_path))
+        self.add_input_file(
+            filename='particles.nc',
+            work_dir_target='{}/initial_state/particles.nc'
+                            ''.format(init.path))
 
         self.add_model_as_input()
 

--- a/compass/ocean/tests/global_ocean/init/initial_state.py
+++ b/compass/ocean/tests/global_ocean/init/initial_state.py
@@ -1,8 +1,9 @@
 from compass.ocean.tests.global_ocean.metadata import \
     add_mesh_and_init_metadata
-from compass.model import run_model
+from compass.model import partition, run_model
 from compass.ocean.vertical.grid_1d import generate_1d_grid, write_1d_grid
 from compass.ocean.plot import plot_vertical_grid, plot_initial_state
+from compass.ocean import particles
 from compass.step import Step
 
 
@@ -162,6 +163,12 @@ class InitialState(Step):
 
         add_mesh_and_init_metadata(self.outputs, config,
                                    init_filename='initial_state.nc')
+
+        cores = self.cores
+        partition(cores, self.config, self.logger)
+        particles.write(init_filename='initial_state.nc', particle_filename='particles.nc',
+                        graph_filename='graph.info.part.{}'.format(cores),
+                        types='buoyancy')
 
         plot_initial_state(input_file_name='initial_state.nc',
                            output_file_name='initial_state.png')

--- a/compass/ocean/tests/global_ocean/lagrangian_particles/__init__.py
+++ b/compass/ocean/tests/global_ocean/lagrangian_particles/__init__.py
@@ -1,0 +1,83 @@
+from compass.validate import compare_variables, compare_timers
+from compass.ocean.tests.global_ocean.forward import ForwardTestCase, \
+    ForwardStep
+
+
+class LagrangianParticles(ForwardTestCase):
+    """
+    A test case for performing a short forward run with an MPAS-Ocean global
+    initial condition assess lagrangian particles and compare with previous results
+    """
+
+    def __init__(self, test_group, mesh, init, time_integrator):
+        """
+        Create test case
+
+        Parameters
+        ----------
+        test_group : compass.ocean.tests.global_ocean.GlobalOcean
+            The global ocean test group that this test case belongs to
+
+        mesh : compass.ocean.tests.global_ocean.mesh.Mesh
+            The test case that produces the mesh for this run
+
+        init : compass.ocean.tests.global_ocean.init.Init
+            The test case that produces the initial condition for this run
+
+        time_integrator : {'split_explicit', 'RK4'}
+            The time integrator to use for the forward run
+        """
+        super().__init__(test_group=test_group, mesh=mesh, init=init,
+                         time_integrator=time_integrator,
+                         name='lagrangian_particles')
+
+        step = ForwardStep(test_case=self, mesh=mesh, init=init,
+                           time_integrator=time_integrator)
+
+        module = self.__module__
+        step.add_namelist_file(module, 'namelist.lagrPart')
+        step.add_streams_file(module, 'streams.lagrPart')
+
+        if mesh.with_ice_shelf_cavities:
+            module = self.__module__
+            step.add_namelist_file(module, 'namelist.wisc')
+            step.add_streams_file(module, 'streams.wisc')
+            step.add_output_file(filename='land_ice_fluxes.nc')
+        self.add_step(step)
+
+    # no run() method is needed
+
+    def validate(self):
+        """
+        Test cases can override this method to perform validation of variables
+        and timers
+        """
+        variables = ['temperature', 'salinity', 'layerThickness',
+                     'normalVelocity']
+        if self.init.with_bgc:
+            variables.extend(
+                ['PO4', 'NO3', 'SiO3', 'NH4', 'Fe', 'O2', 'DIC', 'DIC_ALT_CO2',
+                 'ALK', 'DOC', 'DON', 'DOFe', 'DOP', 'DOPr', 'DONr', 'zooC',
+                 'spChl', 'spC', 'spFe', 'spCaCO3', 'diatChl', 'diatC',
+                 'diatFe', 'diatSi', 'diazChl', 'diazC', 'diazFe', 'phaeoChl',
+                 'phaeoC', 'phaeoFe'])
+
+        compare_variables(test_case=self, variables=variables,
+                          filename1='forward/output.nc')
+
+        if self.mesh.with_ice_shelf_cavities:
+            variables = [
+                'ssh', 'landIcePressure', 'landIceDraft', 'landIceFraction',
+                'landIceMask', 'landIceFrictionVelocity', 'topDrag',
+                'topDragMagnitude', 'landIceFreshwaterFlux', 'landIceHeatFlux',
+                'heatFluxToLandIce', 'landIceBoundaryLayerTemperature',
+                'landIceBoundaryLayerSalinity', 'landIceHeatTransferVelocity',
+                'landIceSaltTransferVelocity', 'landIceInterfaceTemperature',
+                'landIceInterfaceSalinity', 'accumulatedLandIceMass',
+                'accumulatedLandIceHeat']
+
+            compare_variables(test_case=self, variables=variables,
+                              filename1='forward/land_ice_fluxes.nc')
+
+        timers = ['time integration']
+        compare_timers(timers, self.config, self.work_dir, rundir1='forward')

--- a/compass/ocean/tests/global_ocean/lagrangian_particles/namelist.lagrPart
+++ b/compass/ocean/tests/global_ocean/lagrangian_particles/namelist.lagrPart
@@ -1,0 +1,5 @@
+config_AM_lagrPartTrack_enable = .true.
+config_AM_lagrPartTrack_sample_temperature = .true.
+config_AM_lagrPartTrack_sample_salinity = .true.
+config_AM_lagrPartTrack_reset_criteria = 'none'
+config_AM_lagrPartTrack_reset_global_timestamp = '0000_00:00:00'

--- a/compass/ocean/tests/global_ocean/lagrangian_particles/namelist.wisc
+++ b/compass/ocean/tests/global_ocean/lagrangian_particles/namelist.wisc
@@ -1,0 +1,2 @@
+config_check_ssh_consistency = .false.
+config_land_ice_flux_mode = 'standalone'

--- a/compass/ocean/tests/global_ocean/lagrangian_particles/streams.lagrPart
+++ b/compass/ocean/tests/global_ocean/lagrangian_particles/streams.lagrPart
@@ -1,0 +1,12 @@
+<streams>
+
+<stream name="lagrPartTrackInput"
+        filename_template="particles.nc">
+
+</stream>
+
+<stream name="lagrPartTrackOutput"/>
+
+<stream name="lagrPartTrackRestart"/>
+
+</streams>

--- a/compass/ocean/tests/global_ocean/lagrangian_particles/streams.wisc
+++ b/compass/ocean/tests/global_ocean/lagrangian_particles/streams.wisc
@@ -1,0 +1,33 @@
+<streams>
+
+<stream name="land_ice_fluxes"
+        type="output"
+        filename_template="land_ice_fluxes.nc"
+        output_interval="0000_00:00:01"
+		reference_time="0001-01-01_00:00:00"
+        clobber_mode="truncate">
+
+    <stream name="mesh"/>
+    <var name="xtime"/>
+    <var name="daysSinceStartOfSim"/>
+    <var name="ssh"/>
+    <var name="landIcePressure"/>
+    <var name="landIceDraft"/>
+    <var name="landIceFraction"/>
+    <var name="landIceMask"/>
+    <var name="landIceFrictionVelocity"/>
+    <var name="topDrag"/>
+    <var name="topDragMagnitude"/>
+    <var name="landIceFreshwaterFlux"/>
+    <var name="landIceHeatFlux"/>
+    <var name="heatFluxToLandIce"/>
+    <var name="effectiveDensityInLandIce"/>
+    <var_array name="landIceBoundaryLayerTracers"/>
+    <var_array name="landIceTracerTransferVelocities"/>
+    <var_array name="landIceInterfaceTracers"/>
+    <var name="accumulatedLandIceMass"/>
+    <var name="accumulatedLandIceHeat"/>
+
+</stream>
+
+</streams>


### PR DESCRIPTION
Add a test that creates an initial condition particle file, then runs LIGHT for the forward global ocean run.