### PR TITLE
Add ISOMIP+ Ocean1 and Ocean2 test cases

### DIFF
--- a/compass/ocean/tests/isomip_plus/__init__.py
+++ b/compass/ocean/tests/isomip_plus/__init__.py
@@ -15,7 +15,7 @@ class IsomipPlus(TestGroup):
         super().__init__(mpas_core=mpas_core, name='isomip_plus')
 
         for resolution in [2., 5.]:
-            for experiment in ['Ocean0']:
+            for experiment in ['Ocean0', 'Ocean1', 'Ocean2']:
                 for vertical_coordinate in ['z-star']:
                     self.add_test_case(
                         OceanTest(test_group=self, resolution=resolution,

--- a/compass/ocean/tests/isomip_plus/ocean_test/__init__.py
+++ b/compass/ocean/tests/isomip_plus/ocean_test/__init__.py
@@ -96,10 +96,37 @@ class OceanTest(TestCase):
         resolution = self.resolution
         vertical_coordinate = self.vertical_coordinate
         config = self.config
+        experiment = self.experiment
 
         nx = round(800 / resolution)
         ny = round(100 / resolution)
         dc = 1e3 * resolution
+
+        if experiment in ['Ocean0', 'Ocean2', 'Ocean3']:
+            # warm initial conditions
+            config.set('isomip_plus', 'init_top_temp', '-1.9')
+            config.set('isomip_plus', 'init_bot_temp', '1.0')
+            config.set('isomip_plus', 'init_top_sal', '33.8')
+            config.set('isomip_plus', 'init_bot_sal', '34.7')
+        else:
+            # cold initial conditions
+            config.set('isomip_plus', 'init_top_temp', '-1.9')
+            config.set('isomip_plus', 'init_bot_temp', '-1.9')
+            config.set('isomip_plus', 'init_top_sal', '33.8')
+            config.set('isomip_plus', 'init_bot_sal', '34.55')
+
+        if experiment in ['Ocean0', 'Ocean1', 'Ocean3']:
+            # warm restoring
+            config.set('isomip_plus', 'restore_top_temp', '-1.9')
+            config.set('isomip_plus', 'restore_bot_temp', '1.0')
+            config.set('isomip_plus', 'restore_top_sal', '33.8')
+            config.set('isomip_plus', 'restore_bot_sal', '34.7')
+        else:
+            # cold restoring
+            config.set('isomip_plus', 'restore_top_temp', '-1.9')
+            config.set('isomip_plus', 'restore_bot_temp', '-1.9')
+            config.set('isomip_plus', 'restore_top_sal', '33.8')
+            config.set('isomip_plus', 'restore_bot_sal', '34.55')
 
         config.set('isomip_plus', 'nx', '{}'.format(nx))
         config.set('isomip_plus', 'ny', '{}'.format(ny))

--- a/docs/developers_guide/ocean/test_groups/isomip_plus.rst
+++ b/docs/developers_guide/ocean/test_groups/isomip_plus.rst
@@ -6,8 +6,8 @@ isomip_plus
 The ``isomip_plus`` test group
 (:py:class:`compass.ocean.tests.isomip_plus.IsomipPlus`) implements variants
 of the ISOMIP+ experiments (see :ref:`ocean_isomip_plus` in the User's Guide).
-Here, we describe the shared framework for this test group and 1 test case
-(Ocean0) that has currently been implemented.
+Here, we describe the shared framework for this test group and 3 test case
+(Ocean0, Ocean1 and Ocean2) that have currently been implemented.
 
 framework
 ---------
@@ -146,19 +146,22 @@ out the results in the format expected by MISOMIP.
     There is currently an issue with fill values not being handled correctly
     that needs to be resolved before this step is fully useful.
 
-.. _dev_ocean_isomip_plus_default:
+.. _dev_ocean_isomip_plus_ocean_test:
 
 ocean_test
 ----------
 
-By default the variants of the
-:py:class:`compass.ocean.tests.isomip_plus.ocean_test.OceanTest` test case
-create and mesh and initial condition, perform 10 iterations of
-SSH adjustment to make sure the SSH is as close as possible to being in
-dynamic balance with the land-ice pressure.  Then, they perform a 1-hour
-(15-time-step) forward simulation. If a baseline is provided when calling
-:ref:`dev_compass_setup`, a large number of variables (both prognostic and
-related to land-ice fluxes) are checked to make sure they match the baseline.
+The same class,
+:py:class:`compass.ocean.tests.isomip_plus.ocean_test.OceanTest`, defines
+the Ocean0, Ocean1 and Ocean2 test cases at various resolutions and with
+various vertical coordinates.  By default, these test cases only run 3 of the
+7 available steps: ``initial_state`` to create and mesh and initial condition,
+``ssh_adjustment`` to perform 10 1-hour simulations used to balance the
+land-ice pressure with the sea surface height, and ``performance`` to run a
+final 1-hour (15-time-step) forward simulation. If a baseline is provided when
+calling :ref:`dev_compass_setup`, a large number of variables (both prognostic
+and related to land-ice fluxes) are checked to make sure they match the
+baseline.
 
 The optional ``simulation``, ``streamfunction``, ``viz`` and ``misomip`` steps,
 described above, are used to perform longer simulations and perform analysis

--- a/docs/users_guide/ocean/test_groups/isomip_plus.rst
+++ b/docs/users_guide/ocean/test_groups/isomip_plus.rst
@@ -198,7 +198,43 @@ continental shelf in the Amundsen and Bellingshausen Seas.  At the northern
 boundary, the temperature is restored to the same warm profile, leading to a
 vigorous circulation under the ice shelf that continually supplies heat and
 produces relatively high melt rates.  Because of the rigorous flow, the
-simulation reaches a quasi-steady state in 1-2 years.
+simulation reaches a quasi-steady state in 2-3 years.
+
+Ocean1
+------
+
+``ocean/isomip_plus/2km/z-star/Ocean1`` and
+``ocean/isomip_plus/5km/z-star/Ocean1``
+
+This test case is initialized with "cold" ocean conditions: -1.9 degree C
+throughout the water column.  These conditions are similar to cold-shelf
+regions such as the Antarctic continental shelf in the Weddell and Ross Seas.
+At the northern boundary, the temperature is restored to the same warm profile
+as in Ocean0.  The initially cold cavity has low melt rates and a weak flow, so
+that warm water from the northern boundary may take about a decade to reach the
+ice-shelf base.  At this point, the melting and flow rapidly increase,
+eventually (in the coarse of ~20 years) leading to the same quasi-steady-state
+as in Ocean0.  The ISOMIP+ protocol suggests running this simulation for 20
+years.
+
+Ocean2
+------
+
+``ocean/isomip_plus/2km/z-star/Ocean2`` and
+``ocean/isomip_plus/5km/z-star/Ocean2``
+
+This test case is initialized with "warm" ocean conditions as in Ocean0.  At
+the northern boundary, the temperature is restored to the cold profile used for
+the initial condition in Ocean1: -1.9 degree C throughout the water column.
+Thus, where Ocean1 transitions from cold to warm cavity conditions, Ocean2
+makes the opposite transition from warm to cold.  The geometry is also taken
+from a different stage of the BISICLES MISIMP+ run than Ocean0 and Ocean1 in
+which the ice shelf has undergone significant thinning and retreat.  The
+initially warm cavity has high melt rates and a strong flow, so that cold water
+water from the northern boundary will reach the ice-shelf base within a few
+years.  At this point, the melting and flow exponentially decrease, approaching
+a new quasi-steady state.  The ISOMIP+ protocol suggests running this
+simulation for 20 years, which is not long enough to reach quasi-steady state.
 
 Performance run
 ---------------


### PR DESCRIPTION
These are the remaining test cases for the `isomip_plus` test group that MPAS-Ocean can currently support (without moving grounding lines).