### PR TITLE
Fix use of "~" in conda base location

### DIFF
--- a/conda/configure_compass_env.py
+++ b/conda/configure_compass_env.py
@@ -113,6 +113,8 @@ def get_conda_base(conda_base, is_test, config):
         else:
             conda_base = config.get('paths', 'compass_envs')
         conda_base = os.path.abspath(conda_base)
+    # handle "~" in the path
+    conda_base = os.path.expanduser(conda_base)
     return conda_base
 
 


### PR DESCRIPTION
With this change, when a developer calls `configure_conda_env.sh` with `--conda`, they can safely use `~` in the path.  This was not working as expected on Chrysalis.