### PR TITLE
Better document and configure conda envs. on Linux and Mac OS

### DIFF
--- a/conda/configure_compass_env.py
+++ b/conda/configure_compass_env.py
@@ -883,6 +883,11 @@ def main():
         activ_path = get_env_setup(args, config, machine, is_test, source_path,
                                    conda_base)
 
+    if machine is None and not args.env_only and args.mpi is None:
+        raise ValueError('Your machine wasn\'t recognized by compass but you '
+                         'didn\'t specify the MPI version. Please provide '
+                         'either the --mpi or --env_only flag.')
+
     if machine is None:
         if args.env_only:
             compiler = None

--- a/docs/developers_guide/machines/index.rst
+++ b/docs/developers_guide/machines/index.rst
@@ -101,7 +101,7 @@ and on OSX run:
 You may use ``openmpi`` instead of ``mpich`` but we have had better experiences
 with the latter.
 
-The result should be an activation script ``load_dev_compass_1.0.0_<compiler>.sh``.
+The result should be an activation script ``load_dev_compass_1.0.0_<mpi>.sh``.
 Source this script to get the appropriate conda environment and environment
 variables.
 

--- a/docs/developers_guide/quick_start.rst
+++ b/docs/developers_guide/quick_start.rst
@@ -37,6 +37,17 @@ run:
 
   ./conda/configure_compass_env.py --conda <conda_path> -c <compiler>
 
+If your are on an "unknown" machine, typically a Mac or Linux laptop or
+workstation, you will need to specify which flavor of MPI you want to use
+(``mpich`` or ``openmpi``):
+
+.. code-block:: bash
+
+  ./conda/configure_compass_env.py --conda <conda_path> --mpi <mpi>
+
+We only support one set of compilers for Mac and Linux, so there is no need to
+specify them.  See :ref:`dev_other_machines` for more details.
+
 If you don't have `Miniconda3 <https://docs.conda.io/en/latest/miniconda.html>`_
 installed in ``<conda_path>``, it will be downloaded and installed for you in
 this location. If you already have it installed, that path will be used to add


### PR DESCRIPTION
First, this merge adds an error that is raised when the `--mpi` flag is missing (and `--env_only` was not specified) on an "unknown" machine (Linux or Mac).  The hope is to avoid unexpectedly creating an environment without MPI support.

Second, it adds what is hopefully better documentation that clarifies the need to specify the ``--mpi`` flag when installing on an Linux and Mac OS.