### PR TITLE
Update `mpas_tools` to 0.8.0 

### DIFF
--- a/conda/compass_env/spec-file.template
+++ b/conda/compass_env/spec-file.template
@@ -17,7 +17,7 @@ jupyter
 lxml
 matplotlib-base
 metis
-mpas_tools=0.7.0
+mpas_tools=0.8.0
 nco
 netcdf4=*=nompi_*
 numpy

--- a/conda/recipe/meta.yaml
+++ b/conda/recipe/meta.yaml
@@ -54,7 +54,7 @@ requirements:
     - lxml
     - matplotlib-base
     - metis
-    - mpas_tools 0.7.0
+    - mpas_tools 0.8.0
     - {{ mpi }}  # [mpi != 'nompi']
     - nco
     - netcdf4 * nompi_*


### PR DESCRIPTION
This should take care of an issue with meshes that are run through `MpasMeshConverter.x` that end up with garbage values in `kiteAreasOnVertex`.  This issue was causing trouble in tests in debug mode, fixed in https://github.com/MPAS-Dev/MPAS-Tools/pull/431