### PR TITLE
Add support for specifying the NetCDF output engine

### DIFF
--- a/compass/default.cfg
+++ b/compass/default.cfg
@@ -31,6 +31,20 @@ verify = True
 partition_executable = gpmetis
 
 
+# The io section describes options related to file i/o
+[io]
+
+# the NetCDF file format: NETCDF4, NETCDF4_CLASSIC, NETCDF3_64BIT, or
+# NETCDF3_CLASSIC
+format = NETCDF3_64BIT
+
+# the NetCDF output engine: netcdf4 or scipy
+# the netcdf4 engine is not performing well on Chrysalis and Anvil, so we will
+# try scipy for now.  If we can switch to NETCDF4 format, netcdf4 will be
+# required
+engine = scipy
+
+
 # Options related to deploying a compass conda environment on supported
 # machines
 [deploy]

--- a/compass/ocean/tests/global_ocean/files_for_e3sm/diagnostics_files.py
+++ b/compass/ocean/tests/global_ocean/files_for_e3sm/diagnostics_files.py
@@ -9,6 +9,7 @@ from geometric_features.aggregation import get_aggregator_by_name
 from mpas_tools.logging import check_call
 from mpas_tools.ocean.moc import add_moc_southern_boundary_transects
 from mpas_tools.io import write_netcdf
+import mpas_tools.io
 
 from compass.io import symlink
 from compass.step import Step
@@ -148,12 +149,19 @@ def _make_region_masks(mesh_name, suffix, fcMask, logger, cores):
 
     fcMask.to_geojson(geojson_filename)
 
+    # these defaults may have been updated from config options -- pass them
+    # along to the subprocess
+    netcdf_format = mpas_tools.io.default_format
+    netcdf_engine = mpas_tools.io.default_engine
+
     args = ['compute_mpas_region_masks',
             '-m', mesh_filename,
             '-g', geojson_filename,
             '-o', mask_filename,
             '-t', 'cell',
-            '--process_count', '{}'.format(cores)]
+            '--process_count', '{}'.format(cores),
+            '--format', netcdf_format,
+            '--engine', netcdf_engine]
     check_call(args, logger=logger)
 
     # make links in output directory
@@ -172,6 +180,11 @@ def _make_transect_masks(mesh_name, suffix, fcMask, logger, cores,
 
     fcMask.to_geojson(geojson_filename)
 
+    # these defaults may have been updated from config options -- pass them
+    # along to the subprocess
+    netcdf_format = mpas_tools.io.default_format
+    netcdf_engine = mpas_tools.io.default_engine
+
     args = ['compute_mpas_transect_masks',
             '-m', mesh_filename,
             '-g', geojson_filename,
@@ -179,7 +192,9 @@ def _make_transect_masks(mesh_name, suffix, fcMask, logger, cores,
             '-t', 'edge',
             '-s', '{}'.format(subdivision_threshold),
             '--process_count', '{}'.format(cores),
-            '--add_edge_sign']
+            '--add_edge_sign',
+            '--format', netcdf_format,
+            '--engine', netcdf_engine]
     check_call(args, logger=logger)
 
     # make links in output directory
@@ -263,12 +278,19 @@ def _make_moc_masks(mesh_short_name, logger, cores):
 
     fcMask.to_geojson(geojson_filename)
 
+    # these defaults may have been updated from config options -- pass them
+    # along to the subprocess
+    netcdf_format = mpas_tools.io.default_format
+    netcdf_engine = mpas_tools.io.default_engine
+
     args = ['compute_mpas_region_masks',
             '-m', mesh_filename,
             '-g', geojson_filename,
             '-o', mask_filename,
             '-t', 'cell',
-            '--process_count', '{}'.format(cores)]
+            '--process_count', '{}'.format(cores),
+            '--format', netcdf_format,
+            '--engine', netcdf_engine]
     check_call(args, logger=logger)
 
     mask_and_transect_filename = '{}_mocBasinsAndTransects{}.nc'.format(

--- a/compass/run.py
+++ b/compass/run.py
@@ -4,10 +4,10 @@ import os
 import pickle
 import configparser
 import time
-import numpy
 import glob
 
 from mpas_tools.logging import LoggingContext
+import mpas_tools.io
 
 
 def run_suite(suite_name):
@@ -73,6 +73,9 @@ def run_suite(suite_name):
                     interpolation=configparser.ExtendedInterpolation())
                 config.read(test_case.config_filename)
                 test_case.config = config
+
+                mpas_tools.io.default_format = config.get('io', 'format')
+                mpas_tools.io.default_engine = config.get('io', 'engine')
 
                 test_case.steps_to_run = config.get(
                     'test_case', 'steps_to_run').replace(',', ' ').split()
@@ -188,6 +191,9 @@ def run_test_case(steps_to_run=None, steps_not_to_run=None):
     config.read(test_case.config_filename)
     test_case.config = config
 
+    mpas_tools.io.default_format = config.get('io', 'format')
+    mpas_tools.io.default_engine = config.get('io', 'engine')
+
     if steps_to_run is None:
         steps_to_run = config.get('test_case',
                                   'steps_to_run').replace(',', ' ').split()
@@ -235,6 +241,9 @@ def run_step():
         interpolation=configparser.ExtendedInterpolation())
     config.read(step.config_filename)
     test_case.config = config
+
+    mpas_tools.io.default_format = config.get('io', 'format')
+    mpas_tools.io.default_engine = config.get('io', 'engine')
 
     # start logging to stdout/stderr
     test_name = step.path.replace('/', '_')

--- a/conda/compass_env/spec-file.template
+++ b/conda/compass_env/spec-file.template
@@ -17,7 +17,7 @@ jupyter
 lxml
 matplotlib-base
 metis
-mpas_tools=0.8.0
+mpas_tools=0.9.0
 nco
 netcdf4=*=nompi_*
 numpy

--- a/conda/recipe/meta.yaml
+++ b/conda/recipe/meta.yaml
@@ -54,7 +54,7 @@ requirements:
     - lxml
     - matplotlib-base
     - metis
-    - mpas_tools 0.8.0
+    - mpas_tools 0.9.0
     - {{ mpi }}  # [mpi != 'nompi']
     - nco
     - netcdf4 * nompi_*


### PR DESCRIPTION
This is useful because the `scipy` engine seems to perform well on Anvil and Chrysalis, whereas the `netcdf4` engine seems to be hanging.

This merge also updates subprocess calls in `global_ocean` to specify the NetCDF engine.

This requires https://github.com/MPAS-Dev/MPAS-Tools/pull/434

closes #185 