### PR TITLE
Make `compass setup` create a custom test suite

### DIFF
--- a/compass/clean.py
+++ b/compass/clean.py
@@ -7,7 +7,7 @@ from compass.mpas_cores import get_mpas_cores
 from compass import provenance
 
 
-def clean_cases(tests=None, numbers=None, work_dir=None):
+def clean_cases(tests=None, numbers=None, work_dir=None, suite_name='custom'):
     """
     Set up one or more test cases
 
@@ -21,6 +21,10 @@ def clean_cases(tests=None, numbers=None, work_dir=None):
 
     work_dir : str, optional
         A directory that will serve as the base for creating case directories
+
+    suite_name : str, optional
+        The name of the test suite if tests are being set up through a test
+        suite or ``'custom'`` if not
     """
 
     if tests is None and numbers is None:
@@ -28,6 +32,7 @@ def clean_cases(tests=None, numbers=None, work_dir=None):
 
     if work_dir is None:
         work_dir = os.getcwd()
+    work_dir = os.path.abspath(work_dir)
 
     mpas_cores = get_mpas_cores()
     all_test_cases = dict()
@@ -64,6 +69,14 @@ def clean_cases(tests=None, numbers=None, work_dir=None):
             shutil.rmtree(test_case_dir)
         except OSError:
             pass
+
+    # delete the pickle file for the test suite (if any)
+    pickle_file = os.path.join(work_dir, '{}.pickle'.format(suite_name))
+
+    try:
+        os.remove(pickle_file)
+    except OSError:
+        pass
 
 
 def main():

--- a/docs/developers_guide/command_line.rst
+++ b/docs/developers_guide/command_line.rst
@@ -95,7 +95,7 @@ The command-line options are:
 .. code-block:: none
 
     compass setup [-h] [-t PATH] [-n NUM [NUM ...]] [-f FILE] [-m MACH]
-                  [-w PATH] [-b PATH] [-p PATH]
+                  [-w PATH] [-b PATH] [-p PATH] [--suite_name SUITE]
 
 The ``-h`` or ``--help`` options will display the help message describing the
 command-line options.
@@ -142,8 +142,18 @@ previous run.  Many test cases validate variables to make sure they are
 identical between runs, compare timers to see how much performance has changed,
 or both.  See :ref:`dev_validation`.
 
-See :ref:`dev_setup` for more about the underlying framework.
+The test cases will be included in a "custom" test suite in the order they are
+named or numbered.  You can give this suite a name with ``--suite_name`` or
+leave it with the default name ``custom``.  You can run this test suite with
+``compass run [suite_name]`` as with the predefined test suites (see
+:ref:`dev_compass_suite`).
 
+Test cases within the custom suite are run in the order they are supplied to
+``compass setup``, so keep this in mind when providing the list.  Any test
+cases that depend on the output of other test cases must run afther their
+dependencies.
+
+See :ref:`dev_setup` for more about the underlying framework.
 
 .. _dev_compass_clean:
 
@@ -228,9 +238,10 @@ Whereas other ``compass`` commands are typically run in the local clone of the
 compass repo, ``compass run`` needs to be run in the appropriate work
 directory. If you are running a test suite, you may need to provide the name
 of the test suite if more than one suite has been set up in the same work
-directory (with or without the ``.pickle`` suffix that exists on the suite's
-file in the working directory).  If you are in the work directory for a test
-case or step, you do not need to provide any arguments.
+directory.  You can provide either just the suite name or
+``<suite_name>.pickle`` (the latter is convenient for tab completion).  If you
+are in the work directory for a test case or step, you do not need to provide
+any arguments.
 
 If you want to explicitly select which steps in a test case you want to run,
 you have two options.  You can either edit the ``steps_to_run`` config options

--- a/docs/users_guide/quick_start.rst
+++ b/docs/users_guide/quick_start.rst
@@ -79,8 +79,8 @@ Each time you want to work with compass, you will need to run:
 
 .. _setup_overview:
 
-Setting up a test case
-----------------------
+Setting up test cases
+---------------------
 
 Before you set up a test case with ``compass``, you will need to build the
 MPAS component you wish to test with.  Since the instructions for building
@@ -213,6 +213,11 @@ in the repository.
 In order to run a bit-for-bit test with a previous test case, use
 ``-b $PREVIOUS_WORKDIR`` to specify a "baseline".
 
+When you set up one or more test cases, they will also be included in a custom
+test suite, which is called ``custom`` by default.  (You can give it another
+name with the ``--suite_name`` flag.)  You can run all the test cases in
+sequence with one command as described in :ref:`suite_overview` or run them
+one at a time as follows.
 
 Running a test case
 -------------------


### PR DESCRIPTION
This is convenient for running several test cases in one command even if they aren't part of a predefined test suite.  Test cases are run in the order they are supplied to `compass setup`.

Some functionality has been moved from the `suite` module into `setup` and `clean` to facilitate setting up and cleaning up custom test suites in the same way as predefined ones.

A small bug has been fixed in determining the number of cores that a suite requires.  Previously, all steps were used.  With the fix, only `steps_to_run` are used.

The docs have been updated to include new custom suites.