### PR TITLE
Clarify error when git username or email not set

### DIFF
--- a/compass/ocean/tests/global_ocean/metadata.py
+++ b/compass/ocean/tests/global_ocean/metadata.py
@@ -88,14 +88,26 @@ def _get_metadata(dsInit, config):
 
     author = config.get('global_ocean', 'author')
     if author == 'autodetect':
-        author = subprocess.check_output(
-            ['git', 'config', 'user.name']).decode("utf-8").strip()
+        try:
+            author = subprocess.check_output(
+                ['git', 'config', 'user.name']).decode("utf-8").strip()
+        except subprocess.CalledProcessError:
+            raise ValueError('It appears you have not set up a git username '
+                             'yet.  Please do so or provide a config file '
+                             'that sets config option "author" in '
+                             '[global_ocean].')
         config.set('global_ocean', 'author', author)
 
     email = config.get('global_ocean', 'email')
     if email == 'autodetect':
-        email = subprocess.check_output(
-            ['git', 'config', 'user.email']).decode("utf-8").strip()
+        try:
+            email = subprocess.check_output(
+                ['git', 'config', 'user.email']).decode("utf-8").strip()
+        except subprocess.CalledProcessError:
+            raise ValueError('It appears you have not set your email in git '
+                             'yet.  Please do so or provide a config file '
+                             'that sets config option "email" in '
+                             '[global_ocean].')
         config.set('global_ocean', 'email', email)
 
     creation_date = config.get('global_ocean', 'creation_date')


### PR DESCRIPTION
In the global ocean test group, we use the name and email address from `git` by default.  If these are not provided, the error message:
```
subprocess.CalledProcessError: Command '['git', 'config', 'user.name']' returned non-zero exit status 1.
```
isn't very helpful.  This merge provides what is hopefully a more helpful error message.