### PR TITLE
List default steps in cosine_bell test case

### DIFF
--- a/compass/ocean/tests/global_convergence/cosine_bell/__init__.py
+++ b/compass/ocean/tests/global_convergence/cosine_bell/__init__.py
@@ -1,3 +1,6 @@
+import configparser
+
+from compass.config import add_config
 from compass.testcase import TestCase
 
 from compass.ocean.tests.global_convergence.cosine_bell.mesh import Mesh
@@ -27,16 +30,19 @@ class CosineBell(TestCase):
         super().__init__(test_group=test_group, name='cosine_bell')
         self.resolutions = None
 
+        # add the steps with default resolutions so they can be listed
+        config = configparser.ConfigParser(
+            interpolation=configparser.ExtendedInterpolation())
+        add_config(config, self.__module__, '{}.cfg'.format(self.name))
+        self._setup_steps(config)
+
     def configure(self):
         """
         Set config options for the test case
         """
         config = self.config
-        resolutions = config.get('cosine_bell', 'resolutions')
-        resolutions = [int(resolution) for resolution in
-                       resolutions.replace(',', ' ').split()]
-
-        self.resolutions = resolutions
+        # set up the steps again in case a user has provided new resolutions
+        self._setup_steps(config)
 
         init_options = dict()
         for option in ['temperature', 'salinity', 'lat_center', 'lon_center',
@@ -44,16 +50,9 @@ class CosineBell(TestCase):
             init_options['config_cosine_bell_{}'.format(option)] = \
                 config.get('cosine_bell', option)
 
-        for resolution in resolutions:
-            self.add_step(Mesh(test_case=self, resolution=resolution))
-
-            step = Init(test_case=self, resolution=resolution)
-            step.add_namelist_options(options=init_options, mode='init')
-            self.add_step(step)
-
-            self.add_step(Forward(test_case=self, resolution=resolution))
-
-        self.add_step(Analysis(test_case=self, resolutions=resolutions))
+        for step in self.steps.values():
+            if 'init' in step.name:
+                step.add_namelist_options(options=init_options, mode='init')
 
         self.update_cores()
 
@@ -102,3 +101,27 @@ class CosineBell(TestCase):
                        str(cores))
             config.set('cosine_bell', 'QU{}_min_cores'.format(resolution),
                        str(min_cores))
+
+    def _setup_steps(self, config):
+        """ setup steps given resolutions """
+        resolutions = config.get('cosine_bell', 'resolutions')
+        resolutions = [int(resolution) for resolution in
+                       resolutions.replace(',', ' ').split()]
+
+        if self.resolutions is not None and self.resolutions == resolutions:
+            return
+
+        # start fresh with no steps
+        self.steps = dict()
+        self.steps_to_run = list()
+
+        self.resolutions = resolutions
+
+        for resolution in resolutions:
+            self.add_step(Mesh(test_case=self, resolution=resolution))
+
+            self.add_step(Init(test_case=self, resolution=resolution))
+
+            self.add_step(Forward(test_case=self, resolution=resolution))
+
+        self.add_step(Analysis(test_case=self, resolutions=resolutions))


### PR DESCRIPTION
This requires adding the default steps at init, rather than during configure.  If a user provides different resolutions in a config file, the default steps are removed and new ones are added when the configure() method gets called during setup.

closes #199 