### PR TITLE
Make conda path dummy name more verbose

### DIFF
--- a/docs/developers_guide/quick_start.rst
+++ b/docs/developers_guide/quick_start.rst
@@ -61,13 +61,14 @@ If you are on one of the :ref:`dev_supported_machines`, run:
 
 .. code-block:: bash
 
-  ./conda/configure_compass_env.py --conda <conda_path> -c <compiler>
+    ./conda/configure_compass_env.py --conda <base_path_to_install_or_update_conda> \
+        -c <compiler>
 
-The ``<conda_path>`` is typically ``~/miniconda3``.  This is the location
-where you would like to install Miniconda3 or where it is already installed.
-If you have limited space in your home directory, you may want to give another
-path.  If you already have it installed, that path will be used to add
-(or update) the compass test environment.
+The ``<base_path_to_install_or_update_conda>`` is typically ``~/miniconda3``.
+This is the location where you would like to install Miniconda3 or where it is
+already installed. If you have limited space in your home directory, you may
+want to give another path.  If you already have it installed, that path will
+be used to add (or update) the compass test environment.
 
 See the machine under :ref:`dev_supported_machines` for a list of available
 compilers to pass to ``-c``.  If you don't supply a compiler, you will get


### PR DESCRIPTION
This merge makes the dummy path name for the `--conda` flag in the deployment script more verbose: `conda_path` --> `base_path_to_install_or_update_conda`.  The hope is that this makes clear what is stated in the text immediately below, that the path is not just for an existing Miniconda3 installation but also for a new installation if Miniconda3 is not yet installed.