### PR TITLE
Switch global ocean forward steps to use graph.info from initial state, not mesh

### DIFF
--- a/compass/ocean/tests/global_ocean/forward.py
+++ b/compass/ocean/tests/global_ocean/forward.py
@@ -88,34 +88,32 @@ class ForwardStep(Step):
         mesh_package = mesh.mesh_step.package
         mesh_package_contents = list(contents(mesh_package))
         mesh_namelists = ['namelist.forward',
-                          'namelist.{}'.format(time_integrator.lower())]
+                          f'namelist.{time_integrator.lower()}']
         for mesh_namelist in mesh_namelists:
             if mesh_namelist in mesh_package_contents:
                 self.add_namelist_file(mesh_package, mesh_namelist)
 
         mesh_streams = ['streams.forward',
-                        'streams.{}'.format(time_integrator.lower())]
+                        f'streams.{time_integrator.lower()}']
         for mesh_stream in mesh_streams:
             if mesh_stream in mesh_package_contents:
                 self.add_streams_file(mesh_package, mesh_stream)
 
-        mesh_path = mesh.mesh_step.path
-
         if mesh.with_ice_shelf_cavities:
-            initial_state_target = '{}/ssh_adjustment/adjusted_init.nc'.format(
-                init.path)
+            initial_state_target = \
+                f'{init.path}/ssh_adjustment/adjusted_init.nc'
         else:
-            initial_state_target = '{}/initial_state/initial_state.nc'.format(
-                init.path)
+            initial_state_target = \
+                f'{init.path}/initial_state/initial_state.nc'
         self.add_input_file(filename='init.nc',
                             work_dir_target=initial_state_target)
         self.add_input_file(
             filename='forcing_data.nc',
-            work_dir_target='{}/initial_state/init_mode_forcing_data.nc'
-                            ''.format(init.path))
+            work_dir_target=f'{init.path}/initial_state/'
+                            f'init_mode_forcing_data.nc')
         self.add_input_file(
             filename='graph.info',
-            work_dir_target='{}/culled_graph.info'.format(mesh_path))
+            work_dir_target=f'{init.path}/initial_state/graph.info')
 
         self.add_model_as_input()
 
@@ -223,7 +221,6 @@ def get_forward_subdir(init_subdir, time_integrator, name):
     elif time_integrator == 'RK4':
         subdir = os.path.join(init_subdir, time_integrator, name)
     else:
-        raise ValueError('Unexpected time integrator {}'.format(
-            time_integrator))
+        raise ValueError(f'Unexpected time integrator {time_integrator}')
 
     return subdir

--- a/compass/ocean/tests/global_ocean/init/initial_state.py
+++ b/compass/ocean/tests/global_ocean/init/initial_state.py
@@ -38,8 +38,7 @@ class InitialState(Step):
             Whether to include biogeochemistry (BGC) in the initial condition
         """
         if initial_condition not in ['PHC', 'EN4_1900']:
-            raise ValueError('Unknown initial_condition {}'.format(
-                initial_condition))
+            raise ValueError(f'Unknown initial_condition {initial_condition}')
 
         super().__init__(test_case=test_case, name='initial_state')
         self.mesh = mesh
@@ -51,7 +50,7 @@ class InitialState(Step):
         # generate the namelist, replacing a few default options
         self.add_namelist_file(package, 'namelist.init', mode='init')
         self.add_namelist_file(
-            package, 'namelist.{}'.format(initial_condition.lower()),
+            package, f'namelist.{initial_condition.lower()}',
             mode='init')
         if mesh.with_ice_shelf_cavities:
             self.add_namelist_file(package, 'namelist.wisc', mode='init')
@@ -115,25 +114,25 @@ class InitialState(Step):
 
         self.add_input_file(
             filename='mesh.nc',
-            work_dir_target='{}/culled_mesh.nc'.format(mesh_path))
+            work_dir_target=f'{mesh_path}/culled_mesh.nc')
 
         self.add_input_file(
             filename='critical_passages.nc',
-            work_dir_target='{}/critical_passages_mask_final.nc'.format(
-                mesh_path))
+            work_dir_target=f'{mesh_path}/critical_passages_mask_final.nc')
 
         self.add_input_file(
             filename='graph.info',
-            work_dir_target='{}/culled_graph.info'.format(mesh_path))
+            work_dir_target=f'{mesh_path}/culled_graph.info')
 
         if mesh.with_ice_shelf_cavities:
             self.add_input_file(
                 filename='land_ice_mask.nc',
-                work_dir_target='{}/land_ice_mask.nc'.format(mesh_path))
+                work_dir_target=f'{mesh_path}/land_ice_mask.nc')
 
         self.add_model_as_input()
 
-        for file in ['initial_state.nc', 'init_mode_forcing_data.nc']:
+        for file in ['initial_state.nc', 'init_mode_forcing_data.nc',
+                     'graph.info']:
             self.add_output_file(filename=file)
 
     def setup(self):


### PR DESCRIPTION
This merge also adds `graph.info` as an output in the `initial_state` step so it is available to subsequent test cases and steps.

This change means that forward steps depend only in steps from the init test case, not the mesh test case, which should decrease dependencies when running cached versions of each test case (#184).

Various strings have also been switched from the less readable `.format()` syntax to the more readable f-string syntax.