### PR TITLE
Global ocean forward steps explicitly add output.nc

### DIFF
--- a/compass/ocean/tests/global_ocean/daily_output_test/__init__.py
+++ b/compass/ocean/tests/global_ocean/daily_output_test/__init__.py
@@ -37,6 +37,7 @@ class DailyOutputTest(ForwardTestCase):
                            threads=1)
 
         module = self.__module__
+        step.add_output_file(filename='output.nc')
         step.add_namelist_file(module, 'namelist.forward')
         step.add_streams_file(module, 'streams.forward')
         self.add_step(step)

--- a/compass/ocean/tests/global_ocean/decomp_test/__init__.py
+++ b/compass/ocean/tests/global_ocean/decomp_test/__init__.py
@@ -32,10 +32,11 @@ class DecompTest(ForwardTestCase):
                          name='decomp_test')
         for procs in [4, 8]:
             name = '{}proc'.format(procs)
-            self.add_step(
-                ForwardStep(test_case=self, mesh=mesh, init=init,
-                            time_integrator=time_integrator, name=name,
-                            subdir=name, cores=procs, threads=1))
+            step = ForwardStep(test_case=self, mesh=mesh, init=init,
+                               time_integrator=time_integrator, name=name,
+                               subdir=name, cores=procs, threads=1)
+            step.add_output_file(filename='output.nc')
+            self.add_step(step)
 
     # no run() method is needed
 

--- a/compass/ocean/tests/global_ocean/forward.py
+++ b/compass/ocean/tests/global_ocean/forward.py
@@ -117,8 +117,6 @@ class ForwardStep(Step):
 
         self.add_model_as_input()
 
-        self.add_output_file(filename='output.nc')
-
     def setup(self):
         """
         Set up the test case in the work directory, including downloading any

--- a/compass/ocean/tests/global_ocean/mesh/ec30to60/dynamic_adjustment/__init__.py
+++ b/compass/ocean/tests/global_ocean/mesh/ec30to60/dynamic_adjustment/__init__.py
@@ -89,6 +89,7 @@ class EC30to60DynamicAdjustment(DynamicAdjustment):
 
         step.add_input_file(filename='../{}'.format(restart_filenames[0]))
         step.add_output_file(filename='../{}'.format(restart_filenames[1]))
+        step.add_output_file(filename='output.nc')
         self.add_step(step)
 
         self.restart_filenames = restart_filenames

--- a/compass/ocean/tests/global_ocean/mesh/qu240/dynamic_adjustment/__init__.py
+++ b/compass/ocean/tests/global_ocean/mesh/qu240/dynamic_adjustment/__init__.py
@@ -79,4 +79,5 @@ class QU240DynamicAdjustment(DynamicAdjustment):
 
         step.add_input_file(filename='../{}'.format(restart_filenames[0]))
         step.add_output_file(filename='../{}'.format(restart_filenames[1]))
+        step.add_output_file(filename='output.nc')
         self.add_step(step)

--- a/compass/ocean/tests/global_ocean/mesh/so12to60/dynamic_adjustment/__init__.py
+++ b/compass/ocean/tests/global_ocean/mesh/so12to60/dynamic_adjustment/__init__.py
@@ -143,6 +143,7 @@ class SO12to60DynamicAdjustment(DynamicAdjustment):
 
         step.add_input_file(filename='../{}'.format(restart_filenames[2]))
         step.add_output_file(filename='../{}'.format(restart_filenames[3]))
+        step.add_output_file(filename='output.nc')
         self.add_step(step)
 
         self.restart_filenames = restart_filenames

--- a/compass/ocean/tests/global_ocean/mesh/wc14/dynamic_adjustment/__init__.py
+++ b/compass/ocean/tests/global_ocean/mesh/wc14/dynamic_adjustment/__init__.py
@@ -221,6 +221,7 @@ class WC14DynamicAdjustment(DynamicAdjustment):
 
         step.add_input_file(filename='../{}'.format(restart_filenames[5]))
         step.add_output_file(filename='../{}'.format(restart_filenames[6]))
+        step.add_output_file(filename='output.nc')
         self.add_step(step)
 
         self.restart_filenames = restart_filenames

--- a/compass/ocean/tests/global_ocean/performance_test/__init__.py
+++ b/compass/ocean/tests/global_ocean/performance_test/__init__.py
@@ -34,6 +34,7 @@ class PerformanceTest(ForwardTestCase):
         step = ForwardStep(test_case=self, mesh=mesh, init=init,
                            time_integrator=time_integrator)
 
+        step.add_output_file(filename='output.nc')
         if mesh.with_ice_shelf_cavities:
             module = self.__module__
             step.add_namelist_file(module, 'namelist.wisc')

--- a/compass/ocean/tests/global_ocean/restart_test/__init__.py
+++ b/compass/ocean/tests/global_ocean/restart_test/__init__.py
@@ -51,6 +51,7 @@ class RestartTest(ForwardTestCase):
                 step.add_input_file(filename=input_file[part])
             if part in output_file:
                 step.add_output_file(filename=output_file[part])
+            step.add_output_file(filename='output.nc')
             self.add_step(step)
 
     # no run() method is needed

--- a/compass/ocean/tests/global_ocean/threads_test/__init__.py
+++ b/compass/ocean/tests/global_ocean/threads_test/__init__.py
@@ -32,10 +32,11 @@ class ThreadsTest(ForwardTestCase):
                          name='threads_test')
         for threads in [1, 2]:
             name = '{}thread'.format(threads)
-            self.add_step(
-                ForwardStep(test_case=self, mesh=mesh, init=init,
-                            time_integrator=time_integrator, name=name,
-                            subdir=name, cores=4, threads=threads))
+            step = ForwardStep(test_case=self, mesh=mesh, init=init,
+                               time_integrator=time_integrator, name=name,
+                               subdir=name, cores=4, threads=threads)
+            step.add_output_file(filename='output.nc')
+            self.add_step(step)
 
     # no run() method is needed
 


### PR DESCRIPTION
Rather than assuming that every forward step has an output called `output.nc`, this merge adds that output explicitly when it is needed (which is true for most steps).  The only steps that currently don't produce this output are the shorter dynamic adjustment steps.

closes #205 