### PR TITLE
Remove `critical_passages` stream from `initial_state` in `global_ocean` test group

### DIFF
--- a/compass/ocean/tests/global_ocean/init/initial_state.py
+++ b/compass/ocean/tests/global_ocean/init/initial_state.py
@@ -117,10 +117,6 @@ class InitialState(Step):
             work_dir_target=f'{mesh_path}/culled_mesh.nc')
 
         self.add_input_file(
-            filename='critical_passages.nc',
-            work_dir_target=f'{mesh_path}/critical_passages_mask_final.nc')
-
-        self.add_input_file(
             filename='graph.info',
             work_dir_target=f'{mesh_path}/culled_graph.info')
 

--- a/compass/ocean/tests/global_ocean/init/streams.init
+++ b/compass/ocean/tests/global_ocean/init/streams.init
@@ -77,13 +77,4 @@
     <var name="xtime"/>
 </stream>
 
-<stream name="critical_passages"
-        filename_template="critical_passages.nc"
-        input_interval="initial_only"
-        type="input">
-
-    <var name="transectCellMasks"/>
-    <var name="depthTransects"/>
-</stream>
-
 </streams>


### PR DESCRIPTION
We do not deepen critical passages in any mesh configuration, so the critical_passages mask is not needed during init. Requiring the file in `stream.ocean` makes it difficult to swap the mesh used in `initial_state` for another mesh (e.g. one generated on a different machine or with a previous version of compass).

closes #204 