### PR TITLE
Fix EC30to60 dynamical adjustment

### DIFF
--- a/compass/ocean/tests/global_ocean/mesh/ec30to60/dynamic_adjustment/__init__.py
+++ b/compass/ocean/tests/global_ocean/mesh/ec30to60/dynamic_adjustment/__init__.py
@@ -36,7 +36,8 @@ class EC30to60DynamicAdjustment(DynamicAdjustment):
             raise ValueError('{} dynamic adjustment not defined for {}'.format(
                 mesh.mesh_name, time_integrator))
 
-        restart_times = ['0001-01-11_00:00:00', '0001-01-21_00:00:00']
+        restart_times = ['0001-01-11_00:00:00', '0001-01-31_00:00:00',
+                         '0001-02-10_00:00:00']
         restart_filenames = [
             'restarts/rst.{}.nc'.format(restart_time.replace(':', '.'))
             for restart_time in restart_times]
@@ -59,7 +60,7 @@ class EC30to60DynamicAdjustment(DynamicAdjustment):
 
         namelist_options = {
             'config_run_duration': "'00-00-10_00:00:00'",
-            'config_dt': "'00:20:00'",
+            'config_dt': "'00:15:00'",
             'config_Rayleigh_friction': '.true.',
             'config_Rayleigh_damping_coeff': '1.0e-4'}
         namelist_options.update(global_stats)
@@ -74,14 +75,15 @@ class EC30to60DynamicAdjustment(DynamicAdjustment):
         step.add_output_file(filename='../{}'.format(restart_filenames[0]))
         self.add_step(step)
 
-        # final step
-        step_name = 'simulation'
+        # second step
+        step_name = 'damped_adjustment_2'
         step = ForwardStep(test_case=self, mesh=mesh, init=init,
                            time_integrator=time_integrator, name=step_name,
                            subdir=step_name)
 
         namelist_options = {
-            'config_run_duration': "'00-00-10_00:00:00'",
+            'config_run_duration': "'00-00-20_00:00:00'",
+            'config_dt': "'00:15:00'",
             'config_do_restart': '.true.',
             'config_start_time': "'{}'".format(restart_times[0])}
         namelist_options.update(global_stats)
@@ -95,6 +97,29 @@ class EC30to60DynamicAdjustment(DynamicAdjustment):
 
         step.add_input_file(filename='../{}'.format(restart_filenames[0]))
         step.add_output_file(filename='../{}'.format(restart_filenames[1]))
+        self.add_step(step)
+
+        # final step
+        step_name = 'simulation'
+        step = ForwardStep(test_case=self, mesh=mesh, init=init,
+                           time_integrator=time_integrator, name=step_name,
+                           subdir=step_name)
+
+        namelist_options = {
+            'config_run_duration': "'00-00-10_00:00:00'",
+            'config_do_restart': '.true.',
+            'config_start_time': "'{}'".format(restart_times[1])}
+        namelist_options.update(global_stats)
+        step.add_namelist_options(namelist_options)
+
+        stream_replacements = {
+            'output_interval': '00-00-10_00:00:00',
+            'restart_interval': '00-00-10_00:00:00'}
+        step.add_streams_file(module, 'streams.template',
+                              template_replacements=stream_replacements)
+
+        step.add_input_file(filename='../{}'.format(restart_filenames[1]))
+        step.add_output_file(filename='../{}'.format(restart_filenames[2]))
         self.add_step(step)
 
         self.restart_filenames = restart_filenames

--- a/compass/ocean/tests/global_ocean/mesh/ec30to60/dynamic_adjustment/__init__.py
+++ b/compass/ocean/tests/global_ocean/mesh/ec30to60/dynamic_adjustment/__init__.py
@@ -47,6 +47,10 @@ class EC30to60DynamicAdjustment(DynamicAdjustment):
 
         module = self.__module__
 
+        global_stats = {'config_AM_globalStats_enable': '.true.',
+                        'config_AM_globalStats_compute_on_startup': '.true.',
+                        'config_AM_globalStats_write_on_startup': '.true.'}
+
         # first step
         step_name = 'damped_adjustment_1'
         step = ForwardStep(test_case=self, mesh=mesh, init=init,
@@ -58,6 +62,7 @@ class EC30to60DynamicAdjustment(DynamicAdjustment):
             'config_dt': "'00:20:00'",
             'config_Rayleigh_friction': '.true.',
             'config_Rayleigh_damping_coeff': '1.0e-4'}
+        namelist_options.update(global_stats)
         step.add_namelist_options(namelist_options)
 
         stream_replacements = {
@@ -79,6 +84,7 @@ class EC30to60DynamicAdjustment(DynamicAdjustment):
             'config_run_duration': "'00-00-10_00:00:00'",
             'config_do_restart': '.true.',
             'config_start_time': "'{}'".format(restart_times[0])}
+        namelist_options.update(global_stats)
         step.add_namelist_options(namelist_options)
 
         stream_replacements = {

--- a/compass/ocean/tests/global_ocean/mesh/ec30to60/dynamic_adjustment/streams.template
+++ b/compass/ocean/tests/global_ocean/mesh/ec30to60/dynamic_adjustment/streams.template
@@ -6,4 +6,7 @@
                   filename_template="../restarts/rst.$Y-$M-$D_$h.$m.$s.nc"
                   output_interval="{{ restart_interval }}"/>
 
+<stream name="globalStatsOutput"
+        output_interval="0000_00:00:01"/>
+
 </streams>

--- a/compass/ocean/tests/global_ocean/mesh/qu240/dynamic_adjustment/__init__.py
+++ b/compass/ocean/tests/global_ocean/mesh/qu240/dynamic_adjustment/__init__.py
@@ -38,6 +38,10 @@ class QU240DynamicAdjustment(DynamicAdjustment):
 
         module = self.__module__
 
+        global_stats = {'config_AM_globalStats_enable': '.true.',
+                        'config_AM_globalStats_compute_on_startup': '.true.',
+                        'config_AM_globalStats_write_on_startup': '.true.'}
+
         # first step
         step_name = 'damped_adjustment_1'
         step = ForwardStep(test_case=self, mesh=mesh, init=init,
@@ -48,6 +52,7 @@ class QU240DynamicAdjustment(DynamicAdjustment):
             'config_run_duration': "'00-00-01_00:00:00'",
             'config_Rayleigh_friction': '.true.',
             'config_Rayleigh_damping_coeff': '1.0e-4'}
+        namelist_options.update(global_stats)
         step.add_namelist_options(namelist_options)
 
         stream_replacements = {
@@ -69,6 +74,7 @@ class QU240DynamicAdjustment(DynamicAdjustment):
             'config_run_duration': "'00-00-01_00:00:00'",
             'config_do_restart': '.true.',
             'config_start_time': "'{}'".format(restart_times[0])}
+        namelist_options.update(global_stats)
         step.add_namelist_options(namelist_options)
 
         stream_replacements = {

--- a/compass/ocean/tests/global_ocean/mesh/qu240/dynamic_adjustment/streams.template
+++ b/compass/ocean/tests/global_ocean/mesh/qu240/dynamic_adjustment/streams.template
@@ -6,4 +6,7 @@
                   filename_template="../restarts/rst.$Y-$M-$D_$h.$m.$s.nc"
                   output_interval="{{ restart_interval }}"/>
 
+<stream name="globalStatsOutput"
+        output_interval="0000_00:00:01"/>
+
 </streams>

--- a/compass/ocean/tests/global_ocean/mesh/so12to60/dynamic_adjustment/__init__.py
+++ b/compass/ocean/tests/global_ocean/mesh/so12to60/dynamic_adjustment/__init__.py
@@ -48,6 +48,10 @@ class SO12to60DynamicAdjustment(DynamicAdjustment):
 
         module = self.__module__
 
+        global_stats = {'config_AM_globalStats_enable': '.true.',
+                        'config_AM_globalStats_compute_on_startup': '.true.',
+                        'config_AM_globalStats_write_on_startup': '.true.'}
+
         # first step
         step_name = 'damped_adjustment_1'
         step = ForwardStep(test_case=self, mesh=mesh, init=init,
@@ -60,6 +64,7 @@ class SO12to60DynamicAdjustment(DynamicAdjustment):
             'config_btr_dt': "'00:00:20'",
             'config_Rayleigh_friction': '.true.',
             'config_Rayleigh_damping_coeff': '1.0e-4'}
+        namelist_options.update(global_stats)
         step.add_namelist_options(namelist_options)
 
         stream_replacements = {
@@ -85,6 +90,7 @@ class SO12to60DynamicAdjustment(DynamicAdjustment):
             'config_Rayleigh_damping_coeff': '4.0e-5',
             'config_do_restart': '.true.',
             'config_start_time': "'{}'".format(restart_times[0])}
+        namelist_options.update(global_stats)
         step.add_namelist_options(namelist_options)
 
         stream_replacements = {
@@ -111,6 +117,7 @@ class SO12to60DynamicAdjustment(DynamicAdjustment):
             'config_Rayleigh_damping_coeff': '1.0e-5',
             'config_do_restart': '.true.',
             'config_start_time': "'{}'".format(restart_times[1])}
+        namelist_options.update(global_stats)
         step.add_namelist_options(namelist_options)
 
         stream_replacements = {
@@ -133,6 +140,7 @@ class SO12to60DynamicAdjustment(DynamicAdjustment):
             'config_run_duration': "'00-00-10_00:00:00'",
             'config_do_restart': '.true.',
             'config_start_time': "'{}'".format(restart_times[2])}
+        namelist_options.update(global_stats)
         step.add_namelist_options(namelist_options)
 
         stream_replacements = {

--- a/compass/ocean/tests/global_ocean/mesh/so12to60/dynamic_adjustment/streams.template
+++ b/compass/ocean/tests/global_ocean/mesh/so12to60/dynamic_adjustment/streams.template
@@ -6,4 +6,7 @@
                   filename_template="../restarts/rst.$Y-$M-$D_$h.$m.$s.nc"
                   output_interval="{{ restart_interval }}"/>
 
+<stream name="globalStatsOutput"
+        output_interval="0000_00:00:01"/>
+
 </streams>

--- a/compass/ocean/tests/global_ocean/mesh/wc14/dynamic_adjustment/__init__.py
+++ b/compass/ocean/tests/global_ocean/mesh/wc14/dynamic_adjustment/__init__.py
@@ -50,6 +50,10 @@ class WC14DynamicAdjustment(DynamicAdjustment):
 
         module = self.__module__
 
+        global_stats = {'config_AM_globalStats_enable': '.true.',
+                        'config_AM_globalStats_compute_on_startup': '.true.',
+                        'config_AM_globalStats_write_on_startup': '.true.'}
+
         # first step
         step_name = 'damped_adjustment_1'
         step = ForwardStep(test_case=self, mesh=mesh, init=init,
@@ -62,6 +66,7 @@ class WC14DynamicAdjustment(DynamicAdjustment):
             'config_btr_dt': "'00:00:01.5'",
             'config_Rayleigh_friction': '.true.',
             'config_Rayleigh_damping_coeff': '1.0e-3'}
+        namelist_options.update(global_stats)
         step.add_namelist_options(namelist_options)
 
         stream_replacements = {
@@ -87,6 +92,7 @@ class WC14DynamicAdjustment(DynamicAdjustment):
             'config_Rayleigh_damping_coeff': '4.0e-4',
             'config_do_restart': '.true.',
             'config_start_time': "'{}'".format(restart_times[0])}
+        namelist_options.update(global_stats)
         step.add_namelist_options(namelist_options)
 
         stream_replacements = {
@@ -113,6 +119,7 @@ class WC14DynamicAdjustment(DynamicAdjustment):
             'config_Rayleigh_damping_coeff': '1.0e-4',
             'config_do_restart': '.true.',
             'config_start_time': "'{}'".format(restart_times[1])}
+        namelist_options.update(global_stats)
         step.add_namelist_options(namelist_options)
 
         stream_replacements = {
@@ -139,6 +146,7 @@ class WC14DynamicAdjustment(DynamicAdjustment):
             'config_Rayleigh_damping_coeff': '4.0e-5',
             'config_do_restart': '.true.',
             'config_start_time': "'{}'".format(restart_times[2])}
+        namelist_options.update(global_stats)
         step.add_namelist_options(namelist_options)
 
         stream_replacements = {
@@ -165,6 +173,7 @@ class WC14DynamicAdjustment(DynamicAdjustment):
             'config_Rayleigh_damping_coeff': '2.0e-5',
             'config_do_restart': '.true.',
             'config_start_time': "'{}'".format(restart_times[3])}
+        namelist_options.update(global_stats)
         step.add_namelist_options(namelist_options)
 
         stream_replacements = {
@@ -189,6 +198,7 @@ class WC14DynamicAdjustment(DynamicAdjustment):
             'config_btr_dt': "'00:00:15'",
             'config_do_restart': '.true.',
             'config_start_time': "'{}'".format(restart_times[4])}
+        namelist_options.update(global_stats)
         step.add_namelist_options(namelist_options)
 
         stream_replacements = {
@@ -211,6 +221,7 @@ class WC14DynamicAdjustment(DynamicAdjustment):
             'config_run_duration': "'00-00-24_00:00:00'",
             'config_do_restart': '.true.',
             'config_start_time': "'{}'".format(restart_times[5])}
+        namelist_options.update(global_stats)
         step.add_namelist_options(namelist_options)
 
         stream_replacements = {

--- a/compass/ocean/tests/global_ocean/mesh/wc14/dynamic_adjustment/streams.template
+++ b/compass/ocean/tests/global_ocean/mesh/wc14/dynamic_adjustment/streams.template
@@ -6,4 +6,7 @@
                   filename_template="../restarts/rst.$Y-$M-$D_$h.$m.$s.nc"
                   output_interval="{{ restart_interval }}"/>
 
+<stream name="globalStatsOutput"
+        output_interval="0000_00:00:01"/>
+
 </streams>


### PR DESCRIPTION
This merge turns on global stats in dynamical adjustment test cases.  This is very useful for debugging spin-up issues, particularly with the mean KE and the global CFL.

This merge also adds one step to the EC30to60 dynamic adjustment with the intention of fixing NaNs that were seen in the final `simulation` step before this merge.  This new step has smaller time steps than the final `simulation` step and also has no Rayleigh damping.

partially addresses #208 