### PR TITLE
Fix timer comparison with baseline

### DIFF
--- a/compass/ocean/tests/global_ocean/analysis_test/__init__.py
+++ b/compass/ocean/tests/global_ocean/analysis_test/__init__.py
@@ -134,7 +134,7 @@ class AnalysisTest(ForwardTestCase):
                   'compute_eddyProductVariables', 'write_eddyProductVariables',
                   'compute_oceanHeatContent', 'write_oceanHeatContent',
                   'compute_mixedLayerHeatBudget', 'write_mixedLayerHeatBudget']
-        compare_timers(timers, config, work_dir, rundir1='forward')
+        compare_timers(self, timers, rundir1='forward')
 
         variables = ['temperature', 'salinity', 'layerThickness',
                      'normalVelocity']
@@ -150,4 +150,4 @@ class AnalysisTest(ForwardTestCase):
                           filename1='forward/output.nc')
 
         timers = ['time integration']
-        compare_timers(timers, self.config, self.work_dir, rundir1='forward')
+        compare_timers(self, timers, rundir1='forward')

--- a/compass/ocean/tests/global_ocean/performance_test/__init__.py
+++ b/compass/ocean/tests/global_ocean/performance_test/__init__.py
@@ -76,4 +76,4 @@ class PerformanceTest(ForwardTestCase):
                               filename1='forward/land_ice_fluxes.nc')
 
         timers = ['time integration']
-        compare_timers(timers, self.config, self.work_dir, rundir1='forward')
+        compare_timers(self, timers, rundir1='forward')

--- a/compass/ocean/tests/ziso/default/__init__.py
+++ b/compass/ocean/tests/ziso/default/__init__.py
@@ -96,4 +96,4 @@ class Default(TestCase):
         timers = ['init_lagrPartTrack', 'compute_lagrPartTrack',
                   'write_lagrPartTrack', 'restart_lagrPartTrack',
                   'finalize_lagrPartTrack']
-        compare_timers(timers, config, work_dir, rundir1='forward')
+        compare_timers(self, timers, rundir1='forward')

--- a/compass/validate.py
+++ b/compass/validate.py
@@ -156,21 +156,18 @@ def compare_variables(test_case, variables, filename1, filename2=None,
     test_case.validation = validation
 
 
-def compare_timers(timers, config, work_dir, rundir1, rundir2=None):
+def compare_timers(test_case, timers, rundir1, rundir2=None):
     """
     Compare variables between files in the current test case and/or with the
     baseline results.
 
     Parameters
     ----------
+    test_case : compass.TestCase
+        An object describing a test case to validate
+
     timers : list
         A list of timer names to compare
-
-    config : configparser.ConfigParser
-        Configuration options for the test case
-
-    work_dir : str
-        The work directory for the test case
 
     rundir1 : str
         The relative path to a directory within the ``work_dir``. If
@@ -186,13 +183,14 @@ def compare_timers(timers, config, work_dir, rundir1, rundir2=None):
         those in the corresponding baseline directory.
     """
 
+    work_dir = test_case.work_dir
+    baseline_root = test_case.baseline_dir
+
     if rundir2 is not None:
         _compute_timers(os.path.join(work_dir, rundir1),
                         os.path.join(work_dir, rundir2), timers)
 
-    if config.has_option('paths', 'baseline_dir'):
-        baseline_root = config.get('paths', 'baseline_dir')
-
+    if baseline_root is not None:
         _compute_timers(os.path.join(baseline_root, rundir1),
                         os.path.join(work_dir, rundir1), timers)
 


### PR DESCRIPTION
The method for finding the baseline path for the test case has been updated.  It should come from the `test_case` object, not from a config option.

The API of the `compare_timers()` function needed to change to accommodate change to where the baseline directory is stored.  The 3 test cases that use timers have been updated with the new API.