### PR TITLE
Remove EN4_1900 and PHC_BGC test from nightly suite

### DIFF
--- a/compass/ocean/suites/nightly.txt
+++ b/compass/ocean/suites/nightly.txt
@@ -16,12 +16,6 @@ ocean/global_ocean/QU240/PHC/RK4/restart_test
 ocean/global_ocean/QU240/PHC/RK4/decomp_test
 ocean/global_ocean/QU240/PHC/RK4/threads_test
 
-ocean/global_ocean/QU240/EN4_1900/init
-ocean/global_ocean/QU240/EN4_1900/performance_test
-
-ocean/global_ocean/QU240/PHC_BGC/init
-ocean/global_ocean/QU240/PHC_BGC/performance_test
-
 ocean/global_ocean/QUwISC240/mesh
   cached
 ocean/global_ocean/QUwISC240/PHC/init


### PR DESCRIPTION
As discussed in https://github.com/MPAS-Dev/compass/discussions/188, we do not plan to use these initial conditions in E3SM runs so it doesn't make sense to test them on a regular basis.