### PR TITLE
Add a new ocean "pr" test suite

### DIFF
--- a/compass/ocean/suites/pr.txt
+++ b/compass/ocean/suites/pr.txt
@@ -1,0 +1,50 @@
+ocean/baroclinic_channel/10km/default
+ocean/baroclinic_channel/10km/threads_test
+ocean/baroclinic_channel/10km/decomp_test
+ocean/baroclinic_channel/10km/restart_test
+
+ocean/global_convergence/cosine_bell
+  cached: QU60_mesh QU60_init QU90_mesh QU90_init QU120_mesh QU120_init
+  cached: QU150_mesh QU150_init QU180_mesh QU180_init QU210_mesh QU210_init
+  cached: QU240_mesh QU240_init
+
+ocean/global_ocean/QU240/mesh
+ocean/global_ocean/QU240/PHC/init
+ocean/global_ocean/QU240/PHC/performance_test
+ocean/global_ocean/QU240/PHC/restart_test
+ocean/global_ocean/QU240/PHC/decomp_test
+ocean/global_ocean/QU240/PHC/threads_test
+ocean/global_ocean/QU240/PHC/analysis_test
+ocean/global_ocean/QU240/PHC/dynamic_adjustment
+ocean/global_ocean/QU240/PHC/files_for_e3sm
+
+ocean/global_ocean/QU240/PHC/RK4/performance_test
+ocean/global_ocean/QU240/PHC/RK4/restart_test
+ocean/global_ocean/QU240/PHC/RK4/decomp_test
+ocean/global_ocean/QU240/PHC/RK4/threads_test
+
+ocean/global_ocean/QUwISC240/mesh
+  cached
+ocean/global_ocean/QUwISC240/PHC/init
+  cached
+ocean/global_ocean/QUwISC240/PHC/performance_test
+
+ocean/global_ocean/EC30to60/mesh
+  cached
+ocean/global_ocean/EC30to60/PHC/init
+  cached
+ocean/global_ocean/EC30to60/PHC/performance_test
+
+ocean/global_ocean/ECwISC30to60/mesh
+  cached
+ocean/global_ocean/ECwISC30to60/PHC/init
+  cached
+ocean/global_ocean/ECwISC30to60/PHC/performance_test
+
+ocean/ice_shelf_2d/5km/z-star/restart_test
+ocean/ice_shelf_2d/5km/z-level/restart_test
+
+ocean/isomip_plus/2km/z-star/Ocean0
+
+ocean/ziso/20km/default
+ocean/ziso/20km/with_frazil


### PR DESCRIPTION
This test suite is heavier than the `nightly` suite and it intended to be run to test E3SM PRs that change MPAS-Ocean to more robustly test for unexpected changes.

See some discussion here https://github.com/MPAS-Dev/compass/discussions/188#discussioncomment-1086525