### PR TITLE
A bit of cleanup to the docs

### DIFF
--- a/docs/design_docs/cached_outputs.rst
+++ b/docs/design_docs/cached_outputs.rst
@@ -219,7 +219,7 @@ Each MPAS core in ``compass`` will optionally include a file
 names of output files in the work directory and those in the ``compass_cache``
 database for that MPAS core on the LCRC server.  For example:
 
-.. code-block:: json
+.. code-block:: none
 
     {
         "ocean/global_ocean/QU240/mesh/mesh/culled_mesh.nc": "global_ocean/QU240/mesh/mesh/culled_mesh.210803.nc",
@@ -357,7 +357,7 @@ As an example, yesterday (8/3/2021) when I made the following call:
 
 the result was a cache file ``ocean_cached_files.json`` like this:
 
-.. code-block:: json
+.. code-block:: none
 
     {
         "ocean/global_convergence/cosine_bell/QU60/mesh/mesh.nc": "global_convergence/cosine_bell/QU60/mesh/mesh.210803.nc",

--- a/docs/developers_guide/framework.rst
+++ b/docs/developers_guide/framework.rst
@@ -263,7 +263,7 @@ directly if need be.
 .. _dev_io_symlink:
 
 Symlinks
-^^^^^^^^
+~~~~~~~~
 
 You can create your own symlinks that aren't input files (e.g. for a
 README file that the user might want to have available) using
@@ -293,7 +293,7 @@ know if the test case will be set up at all (or in what work directory) during
 .. _dev_io_download:
 
 Download
-^^^^^^^^
+~~~~~~~~
 
 You can download files more directly if you need to using
 :py:func:`compass.io.download()`, though we recommend using
@@ -337,7 +337,7 @@ Model
 -----
 
 Running MPAS
-^^^^^^^^^^^^
+~~~~~~~~~~~~
 
 Steps that run the MPAS model should call the
 :py:meth:`compass.Step.add_model_as_input()` method from
@@ -355,7 +355,7 @@ constructor or :ref:`dev_step_setup` method (i.e. before calling
 required resources are available.
 
 Partitioning the mesh
-^^^^^^^^^^^^^^^^^^^^^
+~~~~~~~~~~~~~~~~~~~~~
 
 The function :py:func:`compass.model.partition()` calls the graph partitioning
 executable (`gpmetis <https://arc.vt.edu/userguide/metis/>`_ by default) to
@@ -371,7 +371,7 @@ creating the same partition over and over.  For such cases, you can call
 to later calls to :py:func:`compass.model.run_model()`.
 
 Updating PIO namelist options
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 You can use :py:func:`compass.model.update_namelist_pio()` to automatically set
 the MPAS namelist options ``config_pio_num_iotasks`` and ``config_pio_stride``
@@ -394,7 +394,7 @@ use ``update_pio=False`` when calling ``run_model()``.
 
 
 Making a graph file
-^^^^^^^^^^^^^^^^^^^
+~~~~~~~~~~~~~~~~~~~
 
 Some ``compass`` test cases take advantage of the fact that the
 `MPAS-Tools cell culler <http://mpas-dev.github.io/MPAS-Tools/stable/mesh_conversion.html#cell-culler>`_
@@ -415,7 +415,7 @@ This validation is a critical part of running test suites and comparing them
 to baselines.
 
 Validating variables
-^^^^^^^^^^^^^^^^^^^^
+~~~~~~~~~~~~~~~~~~~~
 
 The function :py:func:`compass.validate.compare_variables()` can be used to
 compare variables in a file with a given relative path (``filename1``) with
@@ -581,7 +581,7 @@ are explicitly added with :py:meth:`compass.Step.add_output_file()`.  This
 check can be disabled by setting ``check_outputs=False``.
 
 Norms
-^^^^^
+~~~~~
 
 In the unlikely circumstance that you would like to allow comparison to pass
 with non-zero differences between variables, you can supply keyword arguments
@@ -603,7 +603,7 @@ argument.
 
 
 Validating timers
-^^^^^^^^^^^^^^^^^
+~~~~~~~~~~~~~~~~~
 
 Timer validation is qualitatively similar to variable validation except that
 no errors are raised, meaning that the user must manually look at the

--- a/docs/developers_guide/quick_start.rst
+++ b/docs/developers_guide/quick_start.rst
@@ -3,6 +3,18 @@
 Quick Start for Developers
 ==========================
 
+.. _dev_shell:
+
+Unix Shell
+----------
+
+Currently, compass only supports ``bash`` and related unix shells (such as
+``ksh`` on the Mac).  We do not support ``csh``, ``tcsh`` or other variants of
+``csh``.  An activation script for those shells will not be created.
+
+If you normally use ``csh``, ``tcsh`` or similar, you will need to temporarily
+switch to bash by calling ``/bin/bash`` each time you want to use compass.
+
 .. _dev_compass_repo:
 
 Set up a compass repository: for beginners


### PR DESCRIPTION
1. State that only `bash` is supported in the developer's guide. We don't create activation scripts for `csh` or equivalent.
2. Remove `json` code tags in a design doc.  Sphinx doesn't recognize them.
3. Make section symbols consistent in framework section of the developer's guide.  Recent changes used tildes (`~`) instead of carrots (`^`).  Now using tildes for all subsections.