### PR TITLE
Make `conda_base` an absolute path

### DIFF
--- a/conda/configure_compass_env.py
+++ b/conda/configure_compass_env.py
@@ -112,9 +112,8 @@ def get_conda_base(conda_base, is_test, config):
                                  'none could be inferred.')
         else:
             conda_base = config.get('paths', 'compass_envs')
-        conda_base = os.path.abspath(conda_base)
     # handle "~" in the path
-    conda_base = os.path.expanduser(conda_base)
+    conda_base = os.path.abspath(os.path.expanduser(conda_base))
     return conda_base
 
 


### PR DESCRIPTION
In the script for setting up the compass conda environment, make sure the `conda_base` path (passed in from `--conda` or supplied as a config option) is an absolute path.  Recent tests showed that a relative path resulted in failures when trying to activate the environment.