### PR TITLE
Fix dynamic adjustment test case for SOwISC12to60 mesh

### DIFF
--- a/compass/ocean/tests/global_ocean/mesh/so12to60/dynamic_adjustment/__init__.py
+++ b/compass/ocean/tests/global_ocean/mesh/so12to60/dynamic_adjustment/__init__.py
@@ -37,8 +37,8 @@ class SO12to60DynamicAdjustment(DynamicAdjustment):
                 mesh.mesh_name, time_integrator))
 
         restart_times = ['0001-01-03_00:00:00', '0001-01-11_00:00:00',
-                         '0001-01-21_00:00:00', '0001-01-31_00:00:00',
-                         '0001-02-10_00:00:00']
+                         '0001-01-21_00:00:00', '0001-02-10_00:00:00',
+                         '0001-02-20_00:00:00']
         restart_filenames = [
             'restarts/rst.{}.nc'.format(restart_time.replace(':', '.'))
             for restart_time in restart_times]
@@ -136,7 +136,7 @@ class SO12to60DynamicAdjustment(DynamicAdjustment):
                            subdir=step_name)
 
         namelist_options = {
-            'config_run_duration': "'00-00-10_00:00:00'",
+            'config_run_duration': "'00-00-20_00:00:00'",
             'config_dt': "'00:05:00'",
             'config_do_restart': '.true.',
             'config_start_time': "'{}'".format(restart_times[2])}

--- a/compass/ocean/tests/global_ocean/mesh/so12to60/dynamic_adjustment/__init__.py
+++ b/compass/ocean/tests/global_ocean/mesh/so12to60/dynamic_adjustment/__init__.py
@@ -151,7 +151,6 @@ class SO12to60DynamicAdjustment(DynamicAdjustment):
 
         step.add_input_file(filename='../{}'.format(restart_filenames[2]))
         step.add_output_file(filename='../{}'.format(restart_filenames[3]))
-        step.add_output_file(filename='output.nc')
         self.add_step(step)
 
         # final step
@@ -175,6 +174,7 @@ class SO12to60DynamicAdjustment(DynamicAdjustment):
 
         step.add_input_file(filename='../{}'.format(restart_filenames[3]))
         step.add_output_file(filename='../{}'.format(restart_filenames[4]))
+        step.add_output_file(filename='output.nc')
         self.add_step(step)
 
         self.restart_filenames = restart_filenames

--- a/compass/ocean/tests/global_ocean/mesh/so12to60/dynamic_adjustment/__init__.py
+++ b/compass/ocean/tests/global_ocean/mesh/so12to60/dynamic_adjustment/__init__.py
@@ -36,8 +36,9 @@ class SO12to60DynamicAdjustment(DynamicAdjustment):
             raise ValueError('{} dynamic adjustment not defined for {}'.format(
                 mesh.mesh_name, time_integrator))
 
-        restart_times = ['0001-01-03_00:00:00', '0001-01-07_00:00:00',
-                         '0001-01-11_00:00:00', '0001-01-21_00:00:00']
+        restart_times = ['0001-01-03_00:00:00', '0001-01-11_00:00:00',
+                         '0001-01-21_00:00:00', '0001-01-31_00:00:00',
+                         '0001-02-10_00:00:00']
         restart_filenames = [
             'restarts/rst.{}.nc'.format(restart_time.replace(':', '.'))
             for restart_time in restart_times]
@@ -83,8 +84,8 @@ class SO12to60DynamicAdjustment(DynamicAdjustment):
                            subdir=step_name)
 
         namelist_options = {
-            'config_run_duration': "'00-00-04_00:00:00'",
-            'config_dt': "'00:07:30'",
+            'config_run_duration': "'00-00-08_00:00:00'",
+            'config_dt': "'00:05:00'",
             'config_btr_dt': "'00:00:20'",
             'config_Rayleigh_friction': '.true.',
             'config_Rayleigh_damping_coeff': '4.0e-5',
@@ -110,8 +111,8 @@ class SO12to60DynamicAdjustment(DynamicAdjustment):
                            subdir=step_name)
 
         namelist_options = {
-            'config_run_duration': "'00-00-04_00:00:00'",
-            'config_dt': "'00:10:00'",
+            'config_run_duration': "'00-00-10_00:00:00'",
+            'config_dt': "'00:05:00'",
             'config_btr_dt': "'00:00:20'",
             'config_Rayleigh_friction': '.true.',
             'config_Rayleigh_damping_coeff': '1.0e-5',
@@ -122,7 +123,7 @@ class SO12to60DynamicAdjustment(DynamicAdjustment):
 
         stream_replacements = {
             'output_interval': '00-00-10_00:00:00',
-            'restart_interval': '00-00-02_00:00:00'}
+            'restart_interval': '00-00-10_00:00:00'}
         step.add_streams_file(module, 'streams.template',
                               template_replacements=stream_replacements)
 
@@ -130,14 +131,16 @@ class SO12to60DynamicAdjustment(DynamicAdjustment):
         step.add_output_file(filename='../{}'.format(restart_filenames[2]))
         self.add_step(step)
 
-        # final step
-        step_name = 'simulation'
+        # fourth step
+        step_name = 'damped_adjustment_4'
         step = ForwardStep(test_case=self, mesh=mesh, init=init,
                            time_integrator=time_integrator, name=step_name,
                            subdir=step_name)
 
         namelist_options = {
             'config_run_duration': "'00-00-10_00:00:00'",
+            'config_dt': "'00:05:00'",
+            'config_btr_dt': "'00:00:20'",
             'config_do_restart': '.true.',
             'config_start_time': "'{}'".format(restart_times[2])}
         namelist_options.update(global_stats)
@@ -152,6 +155,29 @@ class SO12to60DynamicAdjustment(DynamicAdjustment):
         step.add_input_file(filename='../{}'.format(restart_filenames[2]))
         step.add_output_file(filename='../{}'.format(restart_filenames[3]))
         step.add_output_file(filename='output.nc')
+        self.add_step(step)
+
+        # final step
+        step_name = 'simulation'
+        step = ForwardStep(test_case=self, mesh=mesh, init=init,
+                           time_integrator=time_integrator, name=step_name,
+                           subdir=step_name)
+
+        namelist_options = {
+            'config_run_duration': "'00-00-10_00:00:00'",
+            'config_do_restart': '.true.',
+            'config_start_time': "'{}'".format(restart_times[3])}
+        namelist_options.update(global_stats)
+        step.add_namelist_options(namelist_options)
+
+        stream_replacements = {
+            'output_interval': '00-00-10_00:00:00',
+            'restart_interval': '00-00-10_00:00:00'}
+        step.add_streams_file(module, 'streams.template',
+                              template_replacements=stream_replacements)
+
+        step.add_input_file(filename='../{}'.format(restart_filenames[3]))
+        step.add_output_file(filename='../{}'.format(restart_filenames[4]))
         self.add_step(step)
 
         self.restart_filenames = restart_filenames

--- a/compass/ocean/tests/global_ocean/mesh/so12to60/dynamic_adjustment/__init__.py
+++ b/compass/ocean/tests/global_ocean/mesh/so12to60/dynamic_adjustment/__init__.py
@@ -62,7 +62,7 @@ class SO12to60DynamicAdjustment(DynamicAdjustment):
         namelist_options = {
             'config_run_duration': "'00-00-02_00:00:00'",
             'config_dt': "'00:05:00'",
-            'config_btr_dt': "'00:00:20'",
+            'config_btr_dt': "'00:00:15'",
             'config_Rayleigh_friction': '.true.',
             'config_Rayleigh_damping_coeff': '1.0e-4'}
         namelist_options.update(global_stats)
@@ -86,9 +86,8 @@ class SO12to60DynamicAdjustment(DynamicAdjustment):
         namelist_options = {
             'config_run_duration': "'00-00-08_00:00:00'",
             'config_dt': "'00:05:00'",
-            'config_btr_dt': "'00:00:20'",
             'config_Rayleigh_friction': '.true.',
-            'config_Rayleigh_damping_coeff': '4.0e-5',
+            'config_Rayleigh_damping_coeff': '1.0e-5',
             'config_do_restart': '.true.',
             'config_start_time': "'{}'".format(restart_times[0])}
         namelist_options.update(global_stats)
@@ -113,9 +112,8 @@ class SO12to60DynamicAdjustment(DynamicAdjustment):
         namelist_options = {
             'config_run_duration': "'00-00-10_00:00:00'",
             'config_dt': "'00:05:00'",
-            'config_btr_dt': "'00:00:20'",
             'config_Rayleigh_friction': '.true.',
-            'config_Rayleigh_damping_coeff': '1.0e-5',
+            'config_Rayleigh_damping_coeff': '1.0e-6',
             'config_do_restart': '.true.',
             'config_start_time': "'{}'".format(restart_times[1])}
         namelist_options.update(global_stats)
@@ -140,7 +138,6 @@ class SO12to60DynamicAdjustment(DynamicAdjustment):
         namelist_options = {
             'config_run_duration': "'00-00-10_00:00:00'",
             'config_dt': "'00:05:00'",
-            'config_btr_dt': "'00:00:20'",
             'config_do_restart': '.true.',
             'config_start_time': "'{}'".format(restart_times[2])}
         namelist_options.update(global_stats)

--- a/compass/ocean/tests/global_ocean/mesh/so12to60/namelist.split_explicit
+++ b/compass/ocean/tests/global_ocean/mesh/so12to60/namelist.split_explicit
@@ -1,7 +1,12 @@
 config_time_integrator = 'split_explicit'
 config_dt = '00:10:00'
-config_btr_dt = '00:00:20'
+config_btr_dt = '00:00:15'
 config_run_duration = '0000_01:00:00'
-config_mom_del4 = 1.5e10
+config_use_mom_del2 = .true.
+config_mom_del2 = 462.0
+config_use_mom_del4 = .true.
+config_mom_del4 = 1.18e10
 config_hmix_scaleWithMesh = .true.
 config_use_GM = .true.
+config_GM_closure = 'constant'
+config_GM_constant_kappa = 600.0


### PR DESCRIPTION
This merge
* uses the same namelist options for SOwISC12to60 as in E3SM 
* reduces the Rayleigh damping in the damped steps
* reduces the barotropic time step to match E3SM
* extends the duration of the existing damped steps
* adds an additional step that runs without damping but with the reduced (5-minute) time step for 10 days

The total adjustment time is extended from 20 to 50 days.  This appear to be necessary to get through some periods of high wave activity during the first 30 to 40 days.

Why exactly the dynamic adjustment that worked before no longer runs successfully is not clear.  It could be the new JIGSAW version, which generates a different mesh and could therefore change the interaction of waves with ice-shelf cavities, but that's pure speculation.

closes #208 