### PR TITLE
Check compass run for compute node

### DIFF
--- a/compass/parallel.py
+++ b/compass/parallel.py
@@ -39,6 +39,36 @@ def get_available_cores_and_nodes(config):
     return cores, nodes
 
 
+def check_parallel_system(config):
+    """
+    Check whether we are in an appropriate state for the given queuing system.
+    For systems with Slurm, this means that we need to have an interactive
+    or batch job on a compute node, as determined by the ``$SLURM_JOB_ID``
+    environment variable.
+
+    Parameters
+    ----------
+    config : configparser.ConfigParser
+        Configuration options for the test case
+
+    Raises
+    -------
+    ValueError
+        If using Slurm and not on a compute node
+    """
+
+    parallel_system = config.get('parallel', 'system')
+    if parallel_system == 'slurm':
+        if 'SLURM_JOB_ID' not in os.environ:
+            raise ValueError('SLURM_JOB_ID not defined.  You are likely not '
+                             'on a compute node.')
+    elif parallel_system == 'single_node':
+        pass
+    else:
+        raise ValueError('Unexpected parallel system: {}'.format(
+            parallel_system))
+
+
 def _get_subprocess_int(args):
     value = subprocess.check_output(args)
     value = int(value.decode('utf-8').strip('\n'))

--- a/compass/run.py
+++ b/compass/run.py
@@ -8,6 +8,7 @@ import glob
 
 from mpas_tools.logging import LoggingContext
 import mpas_tools.io
+from compass.parallel import check_parallel_system
 
 
 def run_suite(suite_name, quiet=False):
@@ -43,6 +44,15 @@ def run_suite(suite_name, quiet=False):
                          'here.'.format(suite_name))
     with open('{}.pickle'.format(suite_name), 'rb') as handle:
         test_suite = pickle.load(handle)
+
+    # get the config file for the first test case in the suite
+    test_case = next(iter(test_suite['test_cases'].values()))
+    config_filename = os.path.join(test_case.work_dir,
+                                   test_case.config_filename)
+    config = configparser.ConfigParser(
+        interpolation=configparser.ExtendedInterpolation())
+    config.read(config_filename)
+    check_parallel_system(config)
 
     # start logging to stdout/stderr
     with LoggingContext(suite_name) as logger:
@@ -203,6 +213,8 @@ def run_test_case(steps_to_run=None, steps_not_to_run=None):
     config.read(test_case.config_filename)
     test_case.config = config
 
+    check_parallel_system(config)
+
     mpas_tools.io.default_format = config.get('io', 'format')
     mpas_tools.io.default_engine = config.get('io', 'engine')
 
@@ -254,6 +266,8 @@ def run_step():
         interpolation=configparser.ExtendedInterpolation())
     config.read(step.config_filename)
     test_case.config = config
+
+    check_parallel_system(config)
 
     mpas_tools.io.default_format = config.get('io', 'format')
     mpas_tools.io.default_engine = config.get('io', 'engine')


### PR DESCRIPTION
Add a check to all types of calls to `compass run` (suites, test cases and steps) to make sure that, on machines with Slurm, we are running on a compute node (i.e. `$SLURM_JOB_ID` is defined).