### PR TITLE
Switch to double output

### DIFF
--- a/compass/ocean/streams/streams.frazil
+++ b/compass/ocean/streams/streams.frazil
@@ -2,6 +2,7 @@
 
 <stream name="frazil"
         type="output"
+        precision="double"
         filename_template="frazil.nc"
         output_interval="0000_00:00:01"
         clobber_mode="truncate"

--- a/compass/ocean/streams/streams.land_ice_fluxes
+++ b/compass/ocean/streams/streams.land_ice_fluxes
@@ -2,6 +2,7 @@
 
 <stream name="land_ice_fluxes"
         type="output"
+        precision="double"
         filename_template="land_ice_fluxes.nc"
         output_interval="0000_00:00:01"
         clobber_mode="truncate"

--- a/compass/ocean/streams/streams.output
+++ b/compass/ocean/streams/streams.output
@@ -1,0 +1,7 @@
+<streams>
+
+<stream name="output"
+        type="output"
+        precision="double"/>
+
+</streams>

--- a/compass/ocean/streams/streams.ssh_adjust
+++ b/compass/ocean/streams/streams.ssh_adjust
@@ -8,6 +8,7 @@
 
 <stream name="output_ssh"
         type="output"
+        precision="double"
         filename_template="output_ssh.nc"
         output_interval="0000_01:00:00"
         clobber_mode="truncate">
@@ -18,6 +19,7 @@
 
 <stream name="output"
         type="output"
+        precision="double"
         filename_template="output.nc"
         output_interval="none"
         clobber_mode="truncate">

--- a/compass/ocean/tests/baroclinic_channel/forward.py
+++ b/compass/ocean/tests/baroclinic_channel/forward.py
@@ -60,6 +60,9 @@ class Forward(Step):
             options = {'config_mom_del2': '{}'.format(nu)}
             self.add_namelist_options(options)
 
+        # make sure output is double precision
+        self.add_streams_file('compass.ocean.streams', 'streams.output')
+
         self.add_streams_file('compass.ocean.tests.baroclinic_channel',
                               'streams.forward')
 

--- a/compass/ocean/tests/global_convergence/cosine_bell/forward.py
+++ b/compass/ocean/tests/global_convergence/cosine_bell/forward.py
@@ -33,6 +33,9 @@ class Forward(Step):
 
         self.resolution = resolution
 
+        # make sure output is double precision
+        self.add_streams_file('compass.ocean.streams', 'streams.output')
+
         self.add_namelist_file(
             'compass.ocean.tests.global_convergence.cosine_bell',
             'namelist.forward')

--- a/compass/ocean/tests/global_ocean/analysis_test/streams.forward
+++ b/compass/ocean/tests/global_ocean/analysis_test/streams.forward
@@ -1,47 +1,61 @@
 <streams>
 
 <stream name="globalStatsOutput"
+        precision="double"
         output_interval="0000_00:00:01"/>
 
 <stream name="debugDiagnosticsOutput"
+        precision="double"
         output_interval="0000_00:00:01"/>
 
 <stream name="eliassenPalmOutput"
+        precision="double"
         output_interval="0000_00:00:01"/>
 
 <stream name="eliassenPalmRestart"/>
 
 <stream name="highFrequencyOutput"
+        precision="double"
         output_interval="0000_00:00:01"/>
 
 <stream name="layerVolumeWeightedAverageOutput"
+        precision="double"
         output_interval="0000_00:00:01"/>
 
 <stream name="meridionalHeatTransportOutput"
+        precision="double"
         output_interval="0000_00:00:01"/>
 
 <stream name="mixedLayerDepthsOutput"
+        precision="double"
         output_interval="0000_00:00:01"/>
 
 <stream name="okuboWeissOutput"
+        precision="double"
         output_interval="0000_00:00:01"/>
 
 <stream name="surfaceAreaWeightedAveragesOutput"
+        precision="double"
         output_interval="0000_00:00:01"/>
 
 <stream name="waterMassCensusOutput"
+        precision="double"
         output_interval="0000_00:00:01"/>
 
 <stream name="zonalMeanOutput"
+        precision="double"
         output_interval="0000_00:00:01"/>
 
 <stream name="eddyProductVariablesOutput"
+        precision="double"
         output_interval="0000_00:00:01"/>
 
 <stream name="oceanHeatContentOutput"
+        precision="double"
         output_interval="0000_00:00:01"/>
 
 <stream name="mixedLayerHeatBudgetOutput"
+        precision="double"
         output_interval="0000_00:00:01"/>
 
 </streams>

--- a/compass/ocean/tests/global_ocean/daily_output_test/streams.forward
+++ b/compass/ocean/tests/global_ocean/daily_output_test/streams.forward
@@ -2,6 +2,7 @@
 
 <stream name="timeSeriesStatsDailyOutput"
         type="output"
+        precision="double"
         filename_template="analysis_members/mpaso.hist.am.timeSeriesStatsDaily.$Y-$M-$D.nc"
         output_interval="00-00-01_00:00:00"
         clobber_mode="truncate">

--- a/compass/ocean/tests/global_ocean/forward.py
+++ b/compass/ocean/tests/global_ocean/forward.py
@@ -83,6 +83,9 @@ class ForwardStep(Step):
         self.min_cores_from_config = min_cores is None
         self.threads_from_config = threads is None
 
+        # make sure output is double precision
+        self.add_streams_file('compass.ocean.streams', 'streams.output')
+
         self.add_namelist_file(
             'compass.ocean.tests.global_ocean', 'namelist.forward')
         self.add_streams_file(

--- a/compass/ocean/tests/global_ocean/init/ssh_adjustment.py
+++ b/compass/ocean/tests/global_ocean/init/ssh_adjustment.py
@@ -34,6 +34,9 @@ class SshAdjustment(Step):
         super().__init__(test_case=test_case, name='ssh_adjustment',
                          cores=cores, min_cores=min_cores, threads=threads)
 
+        # make sure output is double precision
+        self.add_streams_file('compass.ocean.streams', 'streams.output')
+
         self.add_namelist_file(
             'compass.ocean.tests.global_ocean', 'namelist.forward')
         self.add_namelist_options({'config_AM_globalStats_enable': '.false.'})

--- a/compass/ocean/tests/global_ocean/init/streams.ssh_adjust
+++ b/compass/ocean/tests/global_ocean/init/streams.ssh_adjust
@@ -1,6 +1,7 @@
 <streams>
 
 <stream name="mixedLayerDepthsOutput"
+        precision="double"
         output_interval="none"/>
 
 </streams>

--- a/compass/ocean/tests/global_ocean/streams.forward
+++ b/compass/ocean/tests/global_ocean/streams.forward
@@ -24,6 +24,7 @@
         filename_template="forcing_data.nc"/>
 
 <stream name="mixedLayerDepthsOutput"
+        precision="double"
         output_interval="none"/>
 
 </streams>

--- a/compass/ocean/tests/gotm/default/forward.py
+++ b/compass/ocean/tests/gotm/default/forward.py
@@ -19,6 +19,9 @@ class Forward(Step):
         """
         super().__init__(test_case=test_case, name='forward', cores=1,
                          min_cores=1, threads=1)
+        # make sure output is double precision
+        self.add_streams_file('compass.ocean.streams', 'streams.output')
+
         self.add_namelist_file('compass.ocean.tests.gotm.default',
                                'namelist.forward')
 

--- a/compass/ocean/tests/ice_shelf_2d/forward.py
+++ b/compass/ocean/tests/ice_shelf_2d/forward.py
@@ -52,6 +52,9 @@ class Forward(Step):
         super().__init__(test_case=test_case, name=name, subdir=subdir,
                          cores=cores, min_cores=min_cores, threads=threads)
 
+        # make sure output is double precision
+        self.add_streams_file('compass.ocean.streams', 'streams.output')
+
         self.add_namelist_file('compass.ocean.tests.ice_shelf_2d',
                                'namelist.forward')
         if with_frazil:

--- a/compass/ocean/tests/isomip_plus/forward.py
+++ b/compass/ocean/tests/isomip_plus/forward.py
@@ -54,6 +54,9 @@ class Forward(Step):
         super().__init__(test_case=test_case, name=name, subdir=subdir,
                          cores=None, min_cores=None, threads=None)
 
+        # make sure output is double precision
+        self.add_streams_file('compass.ocean.streams', 'streams.output')
+
         self.add_namelist_file('compass.ocean.tests.isomip_plus',
                                'namelist.forward_and_ssh_adjust')
         self.add_namelist_file('compass.ocean.tests.isomip_plus',

--- a/compass/ocean/tests/ziso/forward.py
+++ b/compass/ocean/tests/ziso/forward.py
@@ -64,6 +64,9 @@ class Forward(Step):
         super().__init__(test_case=test_case, name=name, subdir=subdir,
                          cores=cores, min_cores=min_cores, threads=threads)
 
+        # make sure output is double precision
+        self.add_streams_file('compass.ocean.streams', 'streams.output')
+
         self.add_namelist_file('compass.ocean.tests.ziso', 'namelist.forward')
         self.add_streams_file('compass.ocean.tests.ziso', 'streams.forward')
 

--- a/compass/ocean/tests/ziso/streams.analysis
+++ b/compass/ocean/tests/ziso/streams.analysis
@@ -11,22 +11,26 @@
 </stream>
 
 <stream name="zonalMeanOutput"
+        precision="double"
         output_interval="0003_00:00:00">
 
 </stream>
 
 <stream name="okuboWeissOutput"
+        precision="double"
         output_interval="00-00-05_00:00:00"
         reference_time="0001-01-01_00:00:00">
 
 </stream>
 
 <stream name="highFrequencyOutput"
+        precision="double"
         output_interval="00-00-01_00:00:00">
 
 </stream>
 
 <stream name="timeFiltersOutput"
+        precision="double"
         output_interval="0000-01-00_00:00:00">
 
 </stream>
@@ -34,6 +38,7 @@
 <stream name="timeFiltersRestart"/>
 
 <stream name="eliassenPalmOutput"
+        precision="double"
         output_interval="00-01-00_00:00:00">
 
 </stream>
@@ -49,6 +54,7 @@
 
 <stream name="lagrPartTrackRestart"/>
 
-<stream name="mixedLayerDepthsOutput"/>
+<stream name="mixedLayerDepthsOutput"
+        precision="double"/>
 
 </streams>


### PR DESCRIPTION
This merge adds  new streams template for double-precision output.  It makes other templates explicitly double precision and updates all `forward` and `ssh_adjustment` steps with new streams template.

For analysis steps steps, the streams files have been updated for double precision as well.