### PR TITLE
Update to libnetcdf 4.8.1

### DIFF
--- a/conda/compass_env/spec-file.template
+++ b/conda/compass_env/spec-file.template
@@ -37,7 +37,7 @@ c-compiler
 cmake
 cxx-compiler
 fortran-compiler
-libnetcdf=4.8.0={{ mpi_prefix }}_*
+libnetcdf=4.8.1={{ mpi_prefix }}_*
 libpnetcdf=1.12.2={{ mpi_prefix }}_*
 scorpio=1.2.2={{ mpi_prefix }}_*
 m4

--- a/conda/pnetcdf/ci/linux_mpi_mpich.yaml
+++ b/conda/pnetcdf/ci/linux_mpi_mpich.yaml
@@ -15,7 +15,7 @@ cxx_compiler_version:
 hdf5:
 - 1.10.6
 libnetcdf:
-- 4.8.0
+- 4.8.1
 mpi:
 - mpich
 target_platform:

--- a/conda/pnetcdf/ci/linux_mpi_openmpi.yaml
+++ b/conda/pnetcdf/ci/linux_mpi_openmpi.yaml
@@ -15,7 +15,7 @@ cxx_compiler_version:
 hdf5:
 - 1.10.6
 libnetcdf:
-- 4.8.0
+- 4.8.1
 mpi:
 - openmpi
 target_platform:

--- a/conda/pnetcdf/ci/osx_mpi_mpich.yaml
+++ b/conda/pnetcdf/ci/osx_mpi_mpich.yaml
@@ -13,7 +13,7 @@ cxx_compiler_version:
 hdf5:
 - 1.10.6
 libnetcdf:
-- 4.8.0
+- 4.8.1
 mpi:
 - mpich
 target_platform:

--- a/conda/pnetcdf/ci/osx_mpi_openmpi.yaml
+++ b/conda/pnetcdf/ci/osx_mpi_openmpi.yaml
@@ -13,7 +13,7 @@ cxx_compiler_version:
 hdf5:
 - 1.10.6
 libnetcdf:
-- 4.8.0
+- 4.8.1
 mpi:
 - openmpi
 target_platform:

--- a/conda/pnetcdf/recipe/meta.yaml
+++ b/conda/pnetcdf/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set version = "1.12.2" %}
-{% set build = 3 %}
+{% set build = 4 %}
 
 # recipe-lint fails if mpi is undefined
 {% set mpi = mpi or 'mpich' %}

--- a/conda/scorpio/ci/linux_mpi_mpich.yaml
+++ b/conda/scorpio/ci/linux_mpi_mpich.yaml
@@ -15,7 +15,7 @@ cxx_compiler_version:
 hdf5:
 - 1.10.6
 libnetcdf:
-- 4.8.0
+- 4.8.1
 libpnetcdf:
 - 1.12.2
 mpi:

--- a/conda/scorpio/ci/linux_mpi_openmpi.yaml
+++ b/conda/scorpio/ci/linux_mpi_openmpi.yaml
@@ -15,7 +15,7 @@ cxx_compiler_version:
 hdf5:
 - 1.10.6
 libnetcdf:
-- 4.8.0
+- 4.8.1
 libpnetcdf:
 - 1.12.2
 mpi:

--- a/conda/scorpio/ci/osx_mpi_mpich.yaml
+++ b/conda/scorpio/ci/osx_mpi_mpich.yaml
@@ -13,7 +13,7 @@ cxx_compiler_version:
 hdf5:
 - 1.10.6
 libnetcdf:
-- 4.8.0
+- 4.8.1
 libpnetcdf:
 - 1.12.2
 mpi:

--- a/conda/scorpio/ci/osx_mpi_openmpi.yaml
+++ b/conda/scorpio/ci/osx_mpi_openmpi.yaml
@@ -13,7 +13,7 @@ cxx_compiler_version:
 hdf5:
 - 1.10.6
 libnetcdf:
-- 4.8.0
+- 4.8.1
 libpnetcdf:
 - 1.12.2
 mpi:

--- a/conda/scorpio/recipe/meta.yaml
+++ b/conda/scorpio/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set version = "1.2.2" %}
-{% set build = 0 %}
+{% set build = 1 %}
 
 # recipe-lint fails if mpi is undefined
 {% set mpi = mpi or 'mpich' %}


### PR DESCRIPTION
Packages on conda-forge are migrating to this version so compass should, too.