### PR TITLE
Add `add_config` method to test cases

### DIFF
--- a/compass/testcase.py
+++ b/compass/testcase.py
@@ -45,6 +45,10 @@ class TestCase:
         The local name of the config file that ``config`` has been written to
         during setup and read from during run
 
+    config_files : list
+        A list of dictionaries that provide information about the config files
+        from which config options are loaded
+
     work_dir : str
         The test case's work directory, defined during setup as the combination
         of ``base_work_dir`` and ``path``
@@ -111,6 +115,7 @@ class TestCase:
         # these will be set during setup
         self.config = None
         self.config_filename = None
+        self.config_files = list()
         self.work_dir = None
         self.base_work_dir = None
         # may be set during setup if there is a baseline for comparison
@@ -214,6 +219,35 @@ class TestCase:
 
             if both_pass:
                 raise ValueError('Comparison failed, see above.')
+
+    def add_config(self, filename, package=None, exception=True):
+        """
+        Add a config file to the list of files to load config options from.
+        These config files are the highest priority config options besides the
+        user config file, overriding default, machine, MPAS-core, test group
+        and test case config options. This method should be called only when
+        initializing the test case. All config files have already been read
+        and added to the test case's config options by the time that the
+        ``configure()`` method is called.
+
+        Parameters
+        ----------
+        filename : str
+            The name of the config file.  This can be an absolute or relative
+            path for a config file to be read directly or a file name within
+            a python package if ``package`` is provided.
+
+        package : str, optional
+            The name of the python package package that contains ``filename``
+
+        exception : bool
+            Whether to raise an exception if the config file isn't found
+        """
+        config_dict = {'filename': filename,
+                       'exception': exception}
+        if package is not None:
+            config_dict['package'] = package
+        self.config_files.append(config_dict)
 
     def _print_to_stdout(self, message):
         """

--- a/docs/developers_guide/api.rst
+++ b/docs/developers_guide/api.rst
@@ -139,6 +139,7 @@ testcase
    TestCase.run
    TestCase.validate
    TestCase.add_step
+   TestCase.add_config
 
 step
 ^^^^

--- a/docs/developers_guide/organization.rst
+++ b/docs/developers_guide/organization.rst
@@ -412,6 +412,14 @@ Another set of attributes is not useful until ``configure()`` is called by the
     The local name of the config file that ``config`` has been written to
     during setup and read from during run
 
+``self.config_files``
+    A list of dictionaries that can be used to determine which config files
+    are used to set up the config options for this test case during setup.
+    These will include the default, machine, MPAS-core, test-group and
+    test-case config files.  It may also include one or more config files added
+    with the ``add_config()`` method.  Finally, it may include a user config
+    file.
+
 ``self.work_dir``
     The test case's work directory, defined during setup as the combination
     of ``base_work_dir`` and ``path``
@@ -592,6 +600,10 @@ The test case imports the classes for its steps --
 :py:func:`compass.TestCase.add_step()`.  After this, the :py:class:`dict` of
 steps will be available in ``self.steps``.
 
+In the constructor, you may add config files that will be loaded on setup by
+using the :py:meth:`compass.TestCase.add_config()` method, as
+described in :ref:`dev_config`.
+
 By default, the test case will go into a subdirectory with the same name as the
 test case (``rpe_test`` in this case).  However, ``compass`` is flexible
 about the subdirectory structure and the names of the subdirectories.  This
@@ -618,15 +630,16 @@ configure()
 ^^^^^^^^^^^
 
 The :py:meth:`compass.TestCase.configure()` method can be overridden by a
-child class to set config options or build them up from defaults stored in
-config files within the test case or its test group. The ``self.config``
-attribute that is modified in this function will be written to a config file
-for the test case (see :ref:`config_files`).
+child class to set config options that may require some calculation (as opposed
+to simply reading them from files with :py:meth:`compass.TestCase.add_config()`
+in the constructor). The ``self.config`` attribute that is modified in this
+function will be written to a config file for the test case
+(see :ref:`config_files`).
 
-If you override this method in a test case, you should assume that the
-``<test_case.name>.cfg`` file in its package has already been added to the
-config options prior to calling ``configure()``.  This happens automatically
-during test-case setup.
+If you override this method in a test case, you should assume that all config
+files including the ``<test_case.name>.cfg`` file in its package have already
+been added to the config options prior to calling ``configure()``.  This
+happens automatically during test-case setup.
 
 Since many test groups need similar behavior in the ``configure()`` method for
 each test case, it is common to have a shared function (sometimes also called


### PR DESCRIPTION
This new method is used to add a config file during test case
init in the same way that input, output, namelist and streams files
can be added to steps during their init.

This is useful because some config options should be computed in
the `configure()` method based on other config options, and it
may be helpful if (other than these computed config options) all
config options are loaded from files before `configure()` is
called.

Additionally, there is a list of dictionaries that keeps track of
the config files that are combined to get the config options for
a test case.  This may be useful in the future, e.g. for provenance.

Test-case setup has been modified to first call the `add_config`
method to build up a list of config files before loading them
more or less as usual.  The main difference is that all config
files are now loaded before calls to `configure()`, with the user
config file being added last.  This makes it more likely that
config options are as close as possible to their final state
before `configure()` is called.