### PR TITLE
Update to `mpas_tools` v0.11.0

### DIFF
--- a/conda/compass_env/spec-file.template
+++ b/conda/compass_env/spec-file.template
@@ -17,7 +17,7 @@ jupyter
 lxml
 matplotlib-base
 metis
-mpas_tools=0.10.0
+mpas_tools=0.11.0
 nco
 netcdf4=*=nompi_*
 numpy

--- a/conda/recipe/meta.yaml
+++ b/conda/recipe/meta.yaml
@@ -54,7 +54,7 @@ requirements:
     - lxml
     - matplotlib-base
     - metis
-    - mpas_tools 0.10.0
+    - mpas_tools 0.11.0
     - {{ mpi }}  # [mpi != 'nompi']
     - nco
     - netcdf4 * nompi_*


### PR DESCRIPTION
This gets rid of the dependency on `pyflann` and uses `scipy`'s `KDTree` instead.

With this change, `WC14` and `SOwISC12to60` meshes are expected to see small but non-bit-for-bit changes because the signed distance functions used to create them are computed with this new approach.