### PR TITLE
Add method for updating streams files at runtime

### DIFF
--- a/compass/step.py
+++ b/compass/step.py
@@ -460,6 +460,40 @@ class Step(ABC):
             dict(package=package, streams=streams,
                  replacements=template_replacements, mode=mode))
 
+    def update_streams_at_runtime(self, package, streams,
+                                  template_replacements, out_name=None):
+        """
+        Update the streams files during the run phase of this step using the
+        given template and replacements.  This may be useful for updating
+        streams based on config options that a user may have changed before
+        running the step.
+
+        Parameters
+        ----------
+        package : Package
+            The package name or module object that contains the streams file
+
+        streams : str
+            The name of a Jinja2 template to be rendered with replacements
+
+        template_replacements : dict
+            A dictionary of replacements
+
+        out_name : str, optional
+            The name of the streams file to write out, ``streams.<core>`` by
+            default
+        """
+
+        if out_name is None:
+            out_name = f'streams.{self.mpas_core.name}'
+
+        filename = os.path.join(self.work_dir, out_name)
+
+        tree = etree.parse(filename)
+        tree = compass.streams.read(package, streams, tree=tree,
+                                    replacements=template_replacements)
+        compass.streams.write(tree, filename)
+
     def process_inputs_and_outputs(self):
         """
         Process the inputs to and outputs from a step added with

--- a/compass/step.py
+++ b/compass/step.py
@@ -380,9 +380,13 @@ class Step(ABC):
         """
 
         if out_name is None:
-            out_name = 'namelist.{}'.format(self.mpas_core.name)
+            out_name = f'namelist.{self.mpas_core.name}'
 
-        filename = '{}/{}'.format(self.work_dir, out_name)
+        print(f'Warning: replacing namelist options in {out_name}')
+        for key, value in options.items():
+            print(f'{key} = {value}')
+
+        filename = os.path.join(self.work_dir, out_name)
 
         namelist = compass.namelist.ingest(filename)
 
@@ -486,6 +490,13 @@ class Step(ABC):
 
         if out_name is None:
             out_name = f'streams.{self.mpas_core.name}'
+
+        if template_replacements is not None:
+            print(f'Warning: updating streams in {out_name} using the '
+                  f'following template and replacements:')
+            print(f'{package} {streams}')
+            for key, value in template_replacements.items():
+                print(f'{key} = {value}')
 
         filename = os.path.join(self.work_dir, out_name)
 

--- a/docs/developers_guide/api.rst
+++ b/docs/developers_guide/api.rst
@@ -159,6 +159,7 @@ step
    Step.update_namelist_at_runtime
    Step.update_namelist_pio
    Step.add_streams_file
+   Step.update_streams_at_runtime
 
 config
 ^^^^^^

--- a/docs/developers_guide/organization.rst
+++ b/docs/developers_guide/organization.rst
@@ -1882,6 +1882,44 @@ Thus, calls to :py:meth:`compass.Step.add_streams_file()` with
 ``template_replacements`` are qualitatively similar to namelist calls to
 :py:meth:`compass.Step.add_namelist_options()`.
 
+.. _dev_step_update_streams:
+
+Updating a streams file at runtime
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Just as with namelist options, it is sometimes useful to update streams files
+after it has already been generated as part of setting up.  This typically
+happens within a step's ``run()`` method for properties of the stream that
+may be affected by config options that a user may have changed.  In such
+cases, call :py:meth:`compass.Step.update_streams_at_runtime()`.  In this
+fairly complicated example, the duration of the run in hours is a config option
+that we turn into a string.  A dictionary of replacements together with a
+template streams file, as described above, are used to update the streams file
+with the new run duration:
+
+.. code-block:: python
+
+    import time
+    from datetime import datetime, timedelta
+    ...
+
+    config = self.config
+    # the duration (hours) of the run
+    duration = int(3600 * config.getfloat('planar_convergence', 'duration'))
+    delta = timedelta(seconds=duration)
+    hours = delta.seconds//3600
+    minutes = delta.seconds//60 % 60
+    seconds = delta.seconds % 60
+    duration = f'{delta.days:03d}_{hours:02d}:{minutes:02d}:{seconds:02d}'
+
+    stream_replacements = {'output_interval': duration}
+
+    self.update_streams_at_runtime(
+        'compass.ocean.tests.planar_convergence',
+        'streams.template', template_replacements=stream_replacements,
+        out_name='streams.ocean')
+
+
 Adding MPAS model as an input
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 


### PR DESCRIPTION
This is similar to the approach for updating namelist files, and can be used when config options that users might edit could affect things like output interval.