### PR TITLE
Add a few missing pieces to internal_wave docs

### DIFF
--- a/docs/developers_guide/ocean/api.rst
+++ b/docs/developers_guide/ocean/api.rst
@@ -278,6 +278,37 @@ ice_shelf_2d
    viz.Viz
    viz.Viz.run
 
+internal_wave
+~~~~~~~~~~~~~
+
+.. currentmodule:: compass.ocean.tests.internal_wave
+
+.. autosummary::
+   :toctree: generated/
+
+   InternalWave
+
+   default.Default
+   default.Default.validate
+
+   rpe_test.RpeTest
+
+   rpe_test.analysis.Analysis
+   rpe_test.analysis.Analysis.run
+
+   ten_day_test.TenDayTest
+   ten_day_test.TenDayTest.validate
+
+   forward.Forward
+   forward.Forward.run
+
+   initial_state.InitialState
+   initial_state.InitialState.run
+
+   viz.Viz
+   viz.Viz.run
+
+
 isomip_plus
 ~~~~~~~~~~~
 

--- a/docs/developers_guide/ocean/test_groups/index.rst
+++ b/docs/developers_guide/ocean/test_groups/index.rst
@@ -12,5 +12,6 @@ Test groups
    global_ocean
    gotm
    ice_shelf_2d
+   internal_wave
    isomip_plus
    ziso

--- a/docs/users_guide/ocean/test_groups/index.rst
+++ b/docs/users_guide/ocean/test_groups/index.rst
@@ -16,5 +16,6 @@ coming months.
    global_ocean
    gotm
    ice_shelf_2d
+   internal_wave
    isomip_plus
    ziso


### PR DESCRIPTION
This merge adds the missing links to the internal-wave test group in the User's and Developer's Guides, and adds all public classes and methods to the API.