### PR TITLE
Add pip to build section of conda recipe

### DIFF
--- a/conda/recipe/meta.yaml
+++ b/conda/recipe/meta.yaml
@@ -34,6 +34,8 @@ build:
     - compass = compass.__main__:main
 
 requirements:
+  build:
+    - pip
   host:
     - python >=3.6
     - pip


### PR DESCRIPTION
This will hopefully fix a CI problem with OSX and OpenMPI.