### PR TITLE
Fix python 2 bootstrapping issue

### DIFF
--- a/conda/bootstrap.py
+++ b/conda/bootstrap.py
@@ -12,9 +12,32 @@ import grp
 import shutil
 import progressbar
 from jinja2 import Template
+from importlib.resources import path
+from configparser import ConfigParser
 
 from mache import MachineInfo, discover_machine
-from shared import parse_args, get_config, get_conda_base, check_call
+from shared import parse_args, get_conda_base, check_call
+
+
+def get_config(config_file, machine):
+    # we can't load compass so we find the config files
+    here = os.path.abspath(os.path.dirname(__file__))
+    default_config = os.path.join(here, '..', 'compass', 'default.cfg')
+    config = ConfigParser()
+    config.read(default_config)
+
+    if machine is not None:
+        with path('mache.machines', f'{machine}.cfg') as machine_config:
+            config.read(str(machine_config))
+
+        machine_config = os.path.join(here, '..', 'compass', 'machines',
+                                      '{}.cfg'.format(machine))
+        config.read(machine_config)
+
+    if config_file is not None:
+        config.read(config_file)
+
+    return config
 
 
 def get_version():
@@ -597,7 +620,7 @@ def main():
         if machine is not None:
             machine_info = MachineInfo(machine=machine)
 
-    config = get_config(args.config_file, machine=machine)
+    config = get_config(args.config_file, machine)
 
     is_test = not config.getboolean('deploy', 'release')
 

--- a/conda/configure_compass_env.py
+++ b/conda/configure_compass_env.py
@@ -4,14 +4,38 @@ from __future__ import print_function
 
 import os
 import platform
+import sys
+
 try:
     from urllib.request import urlopen, Request
 except ImportError:
     from urllib2 import urlopen, Request
 
-import sys
+try:
+    from configparser import ConfigParser
+except ImportError:
+    from six.moves import configparser
+    import six
 
-from shared import parse_args, get_config, get_conda_base, check_call
+    if six.PY2:
+        ConfigParser = configparser.SafeConfigParser
+    else:
+        ConfigParser = configparser.ConfigParser
+
+from shared import parse_args, get_conda_base, check_call
+
+
+def get_config(config_file):
+    # we can't load compass so we find the config files
+    here = os.path.abspath(os.path.dirname(__file__))
+    default_config = os.path.join(here, '..', 'compass', 'default.cfg')
+    config = ConfigParser()
+    config.read(default_config)
+
+    if config_file is not None:
+        config.read(config_file)
+
+    return config
 
 
 def bootstrap(activate_install_env, source_path):

--- a/conda/shared.py
+++ b/conda/shared.py
@@ -3,18 +3,6 @@ import warnings
 import sys
 import argparse
 import subprocess
-from importlib.resources import path
-
-try:
-    from configparser import ConfigParser
-except ImportError:
-    from six.moves import configparser
-    import six
-
-    if six.PY2:
-        ConfigParser = configparser.SafeConfigParser
-    else:
-        ConfigParser = configparser.ConfigParser
 
 
 def parse_args():
@@ -50,27 +38,6 @@ def parse_args():
     args = parser.parse_args(sys.argv[1:])
 
     return args
-
-
-def get_config(config_file, machine=None):
-    # we can't load compass so we find the config files
-    here = os.path.abspath(os.path.dirname(__file__))
-    default_config = os.path.join(here, '..', 'compass', 'default.cfg')
-    config = ConfigParser()
-    config.read(default_config)
-
-    if machine is not None:
-        with path('mache.machines', f'{machine}.cfg') as machine_config:
-            config.read(str(machine_config))
-
-        machine_config = os.path.join(here, '..', 'compass', 'machines',
-                                      '{}.cfg'.format(machine))
-        config.read(machine_config)
-
-    if config_file is not None:
-        config.read(config_file)
-
-    return config
 
 
 def get_conda_base(conda_base, is_test, config):


### PR DESCRIPTION
If we're bootstrapping compass from python 2, we have to be more careful about what we import before creating the install environment.  This merge moves some `mache`-related imports out of the shared code and into the `bootstrap` module so it only gets run with python 3.