### PR TITLE
Constrain to exclude python 3.10

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -44,7 +44,7 @@ jobs:
 
   - bash: |
       eval "$(conda shell.bash hook)"
-      conda build -m ci/mpi_$(mpi).yaml conda/recipe
+      conda mambabuild -m ci/mpi_$(mpi).yaml conda/recipe
     displayName: Build COMPASS metapackage
 
   - bash: |
@@ -190,7 +190,7 @@ jobs:
 
   - bash: |
       eval "$(conda shell.bash hook)"
-      conda build -m ci/mpi_$(mpi).yaml conda/recipe
+      conda mambabuild -m ci/mpi_$(mpi).yaml conda/recipe
     displayName: Build COMPASS metapackage
 
   - bash: |

--- a/conda/compass_env/spec-file.template
+++ b/conda/compass_env/spec-file.template
@@ -2,7 +2,7 @@
 # $ conda create --name <env> --file <this file>
 
 # Base
-python>=3.6
+python>=3.6,<3.10
 cartopy
 cartopy_offlinedata
 cmocean

--- a/conda/recipe/meta.yaml
+++ b/conda/recipe/meta.yaml
@@ -35,11 +35,11 @@ build:
 
 requirements:
   host:
-    - python >=3.6
+    - python >=3.6,<3.10
     - pip
     - setuptools
   run:
-    - python >=3.6
+    - python >=3.6,<3.10
     - cartopy
     - cartopy_offlinedata
     - cmocean


### PR DESCRIPTION
conda-forge clearly isn't ready for it yet.