### PR TITLE
Fix compass docs

### DIFF
--- a/docs/developers_guide/overview.rst
+++ b/docs/developers_guide/overview.rst
@@ -15,7 +15,7 @@ is the command-line interface with commands like :ref:`dev_compass_list` and
 
     symlink('../initial_condition/initial_condition.nc', 'init.nc')
 
-Before we dig into the details of now to develop new test cases and other
+Before we dig into the details of how to develop new test cases and other
 infrastructure for ``compass``, we first give a little bit of background on
 the design philosophy behind the package.
 
@@ -64,7 +64,7 @@ of scripts (as was the case for :ref:`legacy_compass`) are that:
 
 3) functions within ``compass`` modules and subpackages have relatively simple
    interfaces that are easier to document and understand than the arguments
-   passed in to a script; and
+   passed into a script; and
 
 4) releases of the ``compass`` package would make it easy for developers of
    other python packages and scripts to use our code (though there are not yet

--- a/docs/developers_guide/quick_start.rst
+++ b/docs/developers_guide/quick_start.rst
@@ -276,7 +276,7 @@ compile MPAS-Ocean:
 
     source ./load_dev_compass_<version>_<machine>_<compiler>_<mpi>.sh
     cd E3SM-Project/components/mpas-ocean/
-    make <mpas_compiler>
+    make <mpas_make_target>
 
 For MALI:
 
@@ -284,10 +284,10 @@ For MALI:
 
     source ./load_dev_compass_<version>_<machine>_<compiler>_<mpi>.sh
     cd MALI-Dev/components/mpas-albany-landice
-    make <mpas_compiler>
+    make <mpas_make_target>
 
-See :ref:`dev_supported_machines` for the right ``<mpas_compiler>`` command for
-each machine and compiler.
+See the last column of the table in :ref:`dev_supported_machines` for the right
+``<mpas_make_target>`` command for each machine and compiler.
 
 
 .. _dev_working_with_compass:
@@ -313,6 +313,10 @@ To set up a test case, you will run something like:
 .. code-block:: bash
 
     compass setup -t ocean/global_ocean/QU240/mesh -m $MACHINE -w $WORKDIR -p $MPAS
+
+where ``$MACHINE`` is an ES3M machine, ``$WORKDIR`` is the location where compass
+test cases will be set up and ``$MPAS`` is the directory where the MPAS model
+executable has been compiled. See :ref:`dev_compass_setup` for details.
 
 To list available test suites, you would run:
 

--- a/docs/users_guide/machines/index.rst
+++ b/docs/users_guide/machines/index.rst
@@ -141,7 +141,7 @@ in your user config file:
     # the number of multiprocessing or dask threads to use
     threads = 8
 
-The paths for the MPAS core "databases" can be any emtpy path to being with.
+The paths for the MPAS core "databases" can be any emtpy path to begin with.
 If the path doesn't exist, ``compass`` will create it.
 
 If you're not working on an HPC machine, you will probably not have multiple

--- a/docs/users_guide/quick_start.rst
+++ b/docs/users_guide/quick_start.rst
@@ -97,15 +97,16 @@ and you get output like this:
 
 .. code-block:: none
 
-   0: landice/dome/2000m/smoke_test
-   1: landice/dome/2000m/decomposition_test
-   2: landice/dome/2000m/restart_test
-   3: landice/dome/variable_resolution/smoke_test
-   4: landice/dome/variable_resolution/decomposition_test
-   5: landice/dome/variable_resolution/restart_test
-   6: landice/eismint2/standard_experiments
-   7: landice/eismint2/decomposition_test
-   8: landice/eismint2/restart_test
+   0: landice/circular_shelf/decomposition_test
+   1: landice/dome/2000m/sia_smoke_test
+   2: landice/dome/2000m/sia_decomposition_test
+   3: landice/dome/2000m/sia_restart_test
+   4: landice/dome/2000m/fo_smoke_test
+   5: landice/dome/2000m/fo_decomposition_test
+   6: landice/dome/2000m/fo_restart_test
+   7: landice/variable_resolution/sia_smoke_test
+   8: landice/variable_resolution/sia_decomposition_test
+   9: landice/variable_resolution/sia_restart_test
 
 The list is long, so it will likely be useful to ``grep`` for particular
 content:


### PR DESCRIPTION
This merge 

- fixes typos in multiple places in the compass docs.
- updates the list of test cases shown as an example.
- clarifies the instruction on choosing the right option
   for the machine-specific MPAS target compiler and other flag options.
