### PR TITLE
Add a version of ISOMIP+ test cases with time-varying ice-shelf thickness (pressure)

### DIFF
--- a/compass/ocean/tests/isomip_plus/__init__.py
+++ b/compass/ocean/tests/isomip_plus/__init__.py
@@ -21,3 +21,10 @@ class IsomipPlus(TestGroup):
                         OceanTest(test_group=self, resolution=resolution,
                                   experiment=experiment,
                                   vertical_coordinate=vertical_coordinate))
+            for experiment in ['Ocean0']:
+                for vertical_coordinate in ['z-star']:
+                    self.add_test_case(
+                        OceanTest(test_group=self, resolution=resolution,
+                                  experiment=experiment,
+                                  vertical_coordinate=vertical_coordinate,
+                                  time_varying_forcing=True))

--- a/compass/ocean/tests/isomip_plus/forward.py
+++ b/compass/ocean/tests/isomip_plus/forward.py
@@ -25,7 +25,7 @@ class Forward(Step):
 
     """
     def __init__(self, test_case, resolution, experiment, name='forward',
-                 subdir=None, run_duration=None):
+                 subdir=None, run_duration=None, time_varying_forcing=False):
         """
         Create a new test case
 
@@ -48,6 +48,9 @@ class Forward(Step):
 
         run_duration : str, optional
             The duration of the run
+
+        time_varying_forcing : bool, optional
+            Whether the run includes time-varying land-ice forcing
         """
         self.resolution = resolution
         self.experiment = experiment
@@ -76,6 +79,15 @@ class Forward(Step):
         self.add_streams_file('compass.ocean.tests.isomip_plus',
                               'streams.forward.template',
                               template_replacements=template_replacements)
+
+        if time_varying_forcing:
+            self.add_namelist_file('compass.ocean.tests.isomip_plus',
+                                   'namelist.time_varying_forcing')
+            self.add_streams_file('compass.ocean.tests.isomip_plus',
+                                  'streams.time_varying_forcing')
+            self.add_input_file(
+                filename='land_ice_forcing.nc',
+                target='../initial_state/land_ice_forcing.nc')
 
         self.add_input_file(filename='init.nc',
                             target='../ssh_adjustment/adjusted_init.nc')

--- a/compass/ocean/tests/isomip_plus/isomip_plus.cfg
+++ b/compass/ocean/tests/isomip_plus/isomip_plus.cfg
@@ -95,6 +95,16 @@ coriolis_parameter = -1.409e-4
 # domain
 effective_density = 1026.
 
+# config options for ISOMIP+ time-varying land-ice forcing
+[isomip_plus_forcing]
+
+# the forcing dates
+dates = 0001-01-01_00:00:00, 0002-01-01_00:00:00, 0003-01-01_00:00:00
+
+# the amount by which the initial landIcePressure and landIceDraft are scaled
+# at each date
+scales = 0.1, 1.0, 1.0
+
 # config options for computing ISOMIP+ streamfunctions
 [isomip_plus_streamfunction]
 

--- a/compass/ocean/tests/isomip_plus/namelist.time_varying_forcing
+++ b/compass/ocean/tests/isomip_plus/namelist.time_varying_forcing
@@ -1,0 +1,8 @@
+config_use_time_varying_land_ice_forcing = .true.
+config_time_varying_land_ice_forcing_start_time = '0001-01-01_00:00:00'
+config_time_varying_land_ice_forcing_reference_time = '0001-01-01_00:00:00'
+config_time_varying_land_ice_forcing_cycle_start = 'none'
+config_time_varying_land_ice_forcing_cycle_duration = '0002-00-00_00:00:00'
+config_time_varying_land_ice_forcing_interval = '0001-00-00_00:00:00'
+config_pressure_gradient_type = 'Jacobian_from_TS'
+config_eos_type = 'jm'

--- a/compass/ocean/tests/isomip_plus/ocean_test/__init__.py
+++ b/compass/ocean/tests/isomip_plus/ocean_test/__init__.py
@@ -22,10 +22,13 @@ class OceanTest(TestCase):
 
     vertical_coordinate : str
             The type of vertical coordinate (``z-star``, ``z-level``, etc.)
+
+    time_varying_forcing : bool
+        Whether the run includes time-varying land-ice forcing
     """
 
     def __init__(self, test_group, resolution, experiment,
-                 vertical_coordinate):
+                 vertical_coordinate, time_varying_forcing=False):
         """
         Create the test case
 
@@ -42,16 +45,23 @@ class OceanTest(TestCase):
 
         vertical_coordinate : str
             The type of vertical coordinate (``z-star``, ``z-level``, etc.)
+
+        time_varying_forcing : bool, optional
+            Whether the run includes time-varying land-ice forcing
         """
-        name = experiment
+        if time_varying_forcing:
+            name = f'time_varying_{experiment}'
+        else:
+            name = experiment
         self.resolution = resolution
         self.experiment = experiment
         self.vertical_coordinate = vertical_coordinate
+        self.time_varying_forcing = time_varying_forcing
 
         if resolution == int(resolution):
-            res_folder = '{}km'.format(int(resolution))
+            res_folder = f'{int(resolution)}km'
         else:
-            res_folder = '{}km'.format(resolution)
+            res_folder = f'{resolution}km'
 
         subdir = '{}/{}/{}'.format(res_folder, vertical_coordinate, name)
         super().__init__(test_group=test_group, name=name, subdir=subdir)
@@ -59,18 +69,21 @@ class OceanTest(TestCase):
         self.add_step(
             InitialState(test_case=self, resolution=resolution,
                          experiment=experiment,
-                         vertical_coordinate=vertical_coordinate))
+                         vertical_coordinate=vertical_coordinate,
+                         time_varying_forcing=time_varying_forcing))
         self.add_step(
             SshAdjustment(test_case=self, resolution=resolution))
         self.add_step(
             Forward(test_case=self, name='performance', resolution=resolution,
                     experiment=experiment,
-                    run_duration='0000-00-00_01:00:00'))
+                    run_duration='0000-00-00_01:00:00',
+                    time_varying_forcing=time_varying_forcing))
 
         self.add_step(
             Forward(test_case=self, name='simulation', resolution=resolution,
                     experiment=experiment,
-                    run_duration='0000-01-00_00:00:00'),
+                    run_duration='0000-01-00_00:00:00',
+                    time_varying_forcing=time_varying_forcing),
             run_by_default=False)
 
         self.add_step(

--- a/compass/ocean/tests/isomip_plus/streams.time_varying_forcing
+++ b/compass/ocean/tests/isomip_plus/streams.time_varying_forcing
@@ -1,0 +1,6 @@
+<streams>
+
+<immutable_stream name="land_ice_forcing"
+                  filename_template="land_ice_forcing.nc"/>
+
+</streams>

--- a/docs/developers_guide/ocean/test_groups/isomip_plus.rst
+++ b/docs/developers_guide/ocean/test_groups/isomip_plus.rst
@@ -79,6 +79,18 @@ boundary and for "evaporative" fluxes a the surface that are used to mimic a
 spillway, removing water at the northern boundary and preventing runaway
 sea-level rise from the the incoming ice-shelf meltwater.
 
+For the time-varying version of a test case, ``initial_state`` also computes
+a set of time-varying ``landIcePressureForcing`` and ``landIceDraftForcing``
+fields, based on the ``isomip_plus_forcing`` config options (see
+:ref:`ocean_isomip_plus_time_varying_ocean0`).  The time evolution of the
+``landIcePressure`` and ``landIceDraft`` fields is determined by linear
+interpolation in time between consecutive entries in the these forcing
+fields, which are stored in a file ``land_ice_forcing.nc``.
+
+Currently, the grounding line and calving front are held fixed in time, so
+the field ``landIceFractionForcing`` is the same as ``landIceFraction``
+in the initial condition for all time.
+
 ssh_adjustment
 ~~~~~~~~~~~~~~
 

--- a/docs/users_guide/ocean/test_groups/isomip_plus.rst
+++ b/docs/users_guide/ocean/test_groups/isomip_plus.rst
@@ -157,6 +157,16 @@ The ``isomip_plus`` test cases share the following config options:
     # domain
     effective_density = 1026.
 
+    # config options for ISOMIP+ time-varying land-ice forcing
+    [isomip_plus_forcing]
+
+    # the forcing dates
+    dates = 0001-01-01_00:00:00, 0002-01-01_00:00:00, 0003-01-01_00:00:00
+
+    # the amount by which the initial landIcePressure and landIceDraft are scaled
+    # at each date
+    scales = 0.1, 1.0, 1.0
+
     # config options for computing ISOMIP+ streamfunctions
     [isomip_plus_streamfunction]
 
@@ -185,6 +195,8 @@ The ``isomip_plus`` test cases share the following config options:
 You can modify the horizontal mesh, vertical grid, geometry, and initial
 temperature and salinity of the test case by altering these options.
 
+.. _ocean_isomip_plus_ocean0:
+
 Ocean0
 ------
 
@@ -199,6 +211,8 @@ boundary, the temperature is restored to the same warm profile, leading to a
 vigorous circulation under the ice shelf that continually supplies heat and
 produces relatively high melt rates.  Because of the rigorous flow, the
 simulation reaches a quasi-steady state in 2-3 years.
+
+.. _ocean_isomip_plus_ocean1:
 
 Ocean1
 ------
@@ -216,6 +230,8 @@ ice-shelf base.  At this point, the melting and flow rapidly increase,
 eventually (in the coarse of ~20 years) leading to the same quasi-steady-state
 as in Ocean0.  The ISOMIP+ protocol suggests running this simulation for 20
 years.
+
+.. _ocean_isomip_plus_ocean2:
 
 Ocean2
 ------
@@ -235,6 +251,41 @@ water from the northern boundary will reach the ice-shelf base within a few
 years.  At this point, the melting and flow exponentially decrease, approaching
 a new quasi-steady state.  The ISOMIP+ protocol suggests running this
 simulation for 20 years, which is not long enough to reach quasi-steady state.
+
+.. _ocean_isomip_plus_time_varying_ocean0:
+
+time_varying_Ocean0
+-------------------
+
+``ocean/isomip_plus/2km/z-star/time_varying_Ocean0`` and
+``ocean/isomip_plus/5km/z-star/time_varying_Ocean0``
+
+This test case is identical to ``Ocean0`` except that the land-ice pressure
+and land-ice draft are prescribed to evolve in a very simple way in time.
+By default, the these 2 fields start out at year 0001 with 10% of their normal
+value (so the ice shelf is 10% of its thickness in a normal ``Ocean0`` run).
+Then, over the course of a year, both fields increase to 100% of their normal
+value and stay there for another year.  This test case is a simple way of
+exploring changing ice thickness without the need to support a changing
+grounding line (which remains fixed in time).
+
+Users can modify the test case by adding or modifying entries in these config
+options before running the test case:
+
+.. code-block:: cfg
+
+    # config options for ISOMIP+ time-varying land-ice forcing
+    [isomip_plus_forcing]
+
+    # the forcing dates
+    dates = 0001-01-01_00:00:00, 0002-01-01_00:00:00, 0003-01-01_00:00:00
+
+    # the amount by which the initial landIcePressure and landIceDraft are scaled
+    # at each date
+    scales = 0.1, 1.0, 1.0
+
+Dates do not have to be the beginnings of years, they could be any list that is
+monotonic in time. Scales can be any fraction between 0.0 and 1.0.
 
 Performance run
 ---------------


### PR DESCRIPTION
For now, this is just supported for `Ocean0` (a warm-cavity experiment) but could easily be added for other experiments.