### PR TITLE
Add RPE analysis to RPE tests

### DIFF
--- a/compass/ocean/rpe.py
+++ b/compass/ocean/rpe.py
@@ -95,11 +95,8 @@ def compute_rpe(initial_state_file_name='initial_state.nc',
             thickness = np.divide(vol_sorted.tolist(), areaDomain)
 
             # --- RPE computation
-            z = 0.0
-            for i in range(nCells_1D):
-                zMid[i] = z-thickness[i]/2.0
-                z = z-thickness[i]
-            zMid = zMid + bottomMax
+            z = np.append([0.], -np.cumsum(thickness))
+            zMid = z[0:-1] - thickness/2. + bottomMax
             rpe1 = gravity * np.multiply(
                        np.multiply(density_sorted, zMid),
                        vol_sorted)

--- a/compass/ocean/rpe.py
+++ b/compass/ocean/rpe.py
@@ -1,0 +1,92 @@
+import xarray
+import xarray.plot
+import numpy as np
+import datetime
+import matplotlib.pyplot as plt
+from matplotlib.font_manager import FontProperties
+
+def compute_rpe(initial_state_file_name='initial_state.nc',
+                output_file_prefix='output_', num_files=5):
+    # --- Open and read vars from NC file 
+    
+    dsInit = xarray.open_dataset(initial_state_file_name)
+    nCells = dsInit.sizes['nCells']
+    nEdges = dsInit.sizes['nEdges']
+    nVertLevels = dsInit.sizes['nVertLevels']
+
+    xCell        = dsInit['xCell']
+    yCell        = dsInit['yCell']
+    xEdge        = dsInit['xEdge']
+    yEdge        = dsInit['yEdge']
+    areaCell     = dsInit['areaCell']
+    maxLevelCell = dsInit['maxLevelCell']
+    bottomDepth  = dsInit['bottomDepth']
+    for n in range(num_files):
+        # --- Write in text
+        file1 = open('rpe_'+str(n)+'.txt','w')
+
+        ds = xarray.open_dataset('{}{}.nc'.format(
+                                 output_file_prefix, n+1))
+        
+        nt = ds.sizes['Time']
+        xtime = ds['daysSinceStartOfSim']
+        hFull = ds['layerThickness']
+        densityFull = ds['density']
+        
+        ridgeDepth = 500.0
+        bottomMax = np.max(bottomDepth)
+        yMax = np.max(yEdge)
+        yMin = np.min(yEdge)
+        xMax = np.max(xEdge)
+        
+        gravity = 9.80616
+        rpe = np.zeros(nt)
+        vol_1D = np.zeros((nVertLevels*nCells))
+        density_1D = np.zeros((nVertLevels*nCells))
+        
+        for t,ti in enumerate(xtime.values):
+        
+            print('t=',t) 
+            h = hFull[ti,:,:].values
+            density = densityFull[ti,:,:].values
+        
+            i = 0
+            for iCell in range(nCells):
+                for k in range(maxLevelCell[iCell].values):
+                    vol_1D[i] = h[iCell,k]*areaCell[iCell]
+                    density_1D[i] = density[iCell,k]
+                    i = i+1
+            nCells_1D = i
+            # --- Density sorting in ascending order
+            sorted_ind = np.argsort(density_1D)
+            density_sorted = np.zeros(nCells_1D)
+            vol_sorted = np.zeros(nCells_1D)
+        
+            density_sorted = density_1D[sorted_ind]
+            vol_sorted = vol_1D[sorted_ind]
+        
+            for j in range(len(sorted_ind)):
+                density_sorted[j] = density_1D[sorted_ind[j]]
+                vol_sorted[j] = vol_1D[sorted_ind[j]]
+        
+            rpe1 = np.zeros(nCells_1D)
+            sillWidth = np.zeros(nCells_1D)
+            yWidth = np.zeros(nCells_1D)
+            zMid = np.zeros(nCells_1D)
+            z = 0.0
+        
+            # --- RPE computation
+            for i in range(nCells_1D):
+                yWidth[i] = yMax - yMin
+                area = yWidth[i]*xMax
+                thickness = vol_sorted[i]/area
+                zMid[i] = z-thickness/2.0
+                z = z-thickness
+                rpe1[i] = gravity*density_sorted[i]*(zMid[i]+bottomMax)*vol_sorted[i]
+        
+            rpe[time] = np.sum(rpe1)/np.sum(areaCell)
+        
+            file1.write(str(t)+','+str(rpe[time])+"\n")
+        
+        file1.close()
+        return

--- a/compass/ocean/tests/baroclinic_channel/rpe_test/streams.forward
+++ b/compass/ocean/tests/baroclinic_channel/rpe_test/streams.forward
@@ -3,7 +3,7 @@
 <stream name="output"
         type="output"
         filename_template="output.nc"
-        output_interval="0000-00-20_00:00:00"
+        output_interval="0000-00-01_00:00:00"
         clobber_mode="truncate">
 
     <var_struct name="tracers"/>
@@ -11,6 +11,7 @@
     <var name="density"/>
     <var name="daysSinceStartOfSim"/>
     <var name="relativeVorticity"/>
+    <var name="layerThickness"/>
 </stream>
 
 </streams>

--- a/compass/ocean/tests/internal_wave/rpe_test/analysis.py
+++ b/compass/ocean/tests/internal_wave/rpe_test/analysis.py
@@ -1,9 +1,10 @@
 import numpy as np
-from netCDF4 import Dataset
+import xarray
 import matplotlib.pyplot as plt
 import cmocean
 
 from compass.step import Step
+from compass.ocean.rpe import compute_rpe
 
 
 class Analysis(Step):
@@ -34,6 +35,10 @@ class Analysis(Step):
         super().__init__(test_case=test_case, name='analysis')
         self.nus = nus
 
+        self.add_input_file(
+            filename='initial_state.nc',
+            target='../initial_state/ocean.nc')
+
         for index, nu in enumerate(nus):
             self.add_input_file(
                 filename='output_{}.nc'.format(index+1),
@@ -41,6 +46,7 @@ class Analysis(Step):
 
         self.add_output_file(
             filename='sections_internal_wave.png')
+        self.add_output_file(filename='rpe_t.png')
 
     def run(self):
         """
@@ -49,10 +55,11 @@ class Analysis(Step):
         section = self.config['internal_wave']
         nx = section.getint('nx')
         ny = section.getint('ny')
-        _plot(nx, ny, self.outputs[0], self.nus)
+        rpe = compute_rpe(num_files=len(self.nus))
+        _plot(nx, ny, self.outputs[0], self.nus, rpe)
 
 
-def _plot(nx, ny, filename, nus):
+def _plot(nx, ny, filename, nus, rpe):
     """
     Plot section of the internal wave at different viscosities
 
@@ -69,27 +76,47 @@ def _plot(nx, ny, filename, nus):
 
     nus : list of float
         The viscosity values
+
+    rpe : float, dim len(nu) x len(time)
     """
 
     plt.switch_backend('Agg')
+    nanosecondsPerDay = 8.64e13
+    num_files = len(nus)
+    time = [1, 21]
 
-    fig = plt.gcf()
+    ds = xarray.open_dataset('output_1.nc')
+    times = ds.daysSinceStartOfSim.values
+    times = times.tolist()
+    times = np.divide(times, nanosecondsPerDay)
+
+    fig = plt.figure()
+    for i in range(num_files):
+        rpe_norm = np.divide((rpe[i, :]-rpe[i, 0]), rpe[i, 0])
+        plt.plot(times, rpe_norm,
+                 label="$\\nu_h=${}".format(nus[i]))
+    plt.xlabel('Time, days')
+    plt.ylabel('RPE-RPE(0)/RPE(0)')
+    plt.legend()
+    plt.savefig('rpe_t.png')
+    plt.close(fig)
+
+    nCol = len(time)
     nRow = len(nus)
-    nCol = 2
-    iTime = [0, 1]
-    time = ['1', '21']
 
     fig, axs = plt.subplots(nRow, nCol, figsize=(
         4.0 * nCol, 3.7 * nRow), constrained_layout=True)
 
     for iRow in range(nRow):
-        ncfile = Dataset('output_' + str(iRow + 1) + '.nc', 'r')
-        var = ncfile.variables['temperature']
-        xtime = ncfile.variables['xtime']
+        ds = xarray.open_dataset('output_{}.nc'.format(iRow + 1))
+        times = ds.daysSinceStartOfSim.values
+        times = np.divide(times.tolist(), nanosecondsPerDay)
+        var = ds.temperature.values
         for iCol in range(nCol):
             ax = axs[iRow, iCol]
+            tidx = np.argmin(np.abs(times-time[iCol]))
             dis = ax.imshow(
-                var[iTime[iCol], 0::4, :].T,
+                var[tidx, 0::4, :].T,
                 extent=[0, 250, 500, 0],
                 aspect='0.5',
                 cmap='jet',
@@ -102,6 +129,5 @@ def _plot(nx, ny, filename, nus):
             if iCol == nCol - 1:
                 fig.colorbar(dis, ax=axs[iRow, iCol], aspect=10)
             ax.set_title("day {}, $\\nu_h=${}".format(time[iCol], nus[iRow]))
-        ncfile.close()
 
-    plt.savefig(filename)
+    plt.savefig('sections_internal_wave.png')

--- a/compass/ocean/tests/internal_wave/rpe_test/streams.forward
+++ b/compass/ocean/tests/internal_wave/rpe_test/streams.forward
@@ -3,7 +3,7 @@
 <stream name="output"
         type="output"
         filename_template="output.nc"
-        output_interval="0000-00-20_00:00:00"
+        output_interval="0000-00-01_00:00:00"
         clobber_mode="truncate">
 
     <var_struct name="tracers"/>


### PR DESCRIPTION
This PR adds the computation of Reference Potential Energy (RPE) and a timeseries plot to the analysis step for existing RPE tests for internal wave and baroclinic channel test cases. The details of this computation are in Petersen et al. (2015) https://doi.org/10.1016/j.ocemod.2014.12.004. The timeseries plot is also modeled after figures in that publication. 