### PR TITLE
Update to mache>=1.1.4

### DIFF
--- a/conda/compass_env/spec-file.template
+++ b/conda/compass_env/spec-file.template
@@ -15,7 +15,7 @@ jigsaw=0.9.14
 jigsawpy=0.3.3
 jupyter
 lxml
-mache=1.1.1
+mache >=1.1.4
 matplotlib-base
 metis
 mpas_tools=0.11.0

--- a/conda/configure_compass_env.py
+++ b/conda/configure_compass_env.py
@@ -85,8 +85,8 @@ def install_miniconda(conda_base, activate_base):
 def setup_install_env(activate_base):
     print('Setting up a conda environment for installing compass')
     commands = '{}; ' \
-               'conda create -y -n temp_compass_install ' \
-               'progressbar2 jinja2 "mache>=1.1.1"'.format(activate_base)
+               'mamba create -y -n temp_compass_install ' \
+               'progressbar2 jinja2 "mache>=1.1.4"'.format(activate_base)
 
     check_call(commands)
 

--- a/conda/recipe/meta.yaml
+++ b/conda/recipe/meta.yaml
@@ -52,7 +52,7 @@ requirements:
     - jigsawpy 0.3.3
     - jupyter
     - lxml
-    - mache 1.1.1
+    - mache >=1.1.4
     - matplotlib-base
     - metis
     - mpas_tools 0.11.0


### PR DESCRIPTION
`mache` 1.1.4 includes a bug fix that replaces the `$SHELL{}` directive with `$()` in environment variables.