### PR TITLE
Fix machine name arg in conda configure script

### DIFF
--- a/conda/bootstrap.py
+++ b/conda/bootstrap.py
@@ -622,6 +622,8 @@ def main():
     if not args.env_only:
         if args.machine is None:
             machine = discover_machine()
+        else:
+            machine = args.machine
         if machine is not None:
             machine_info = MachineInfo(machine=machine)
 


### PR DESCRIPTION
Before this fix, specifying a machine name to the configure script in fact resulted in `machine = None`, which is obviously not the desired behavior.

This likely went unnoticed for 2+ months because we typically let the machine name be discovered automatically.