### PR TITLE
Add `--use_local` flag to conda configure script

### DIFF
--- a/conda/shared.py
+++ b/conda/shared.py
@@ -34,6 +34,8 @@ def parse_args():
     parser.add_argument("--check", dest="check", action='store_true',
                         help="Check the resulting environment for expected "
                              "packages")
+    parser.add_argument("--use_local", dest="use_local", action='store_true',
+                        help="Use locally built conda packages (for testing).")
 
     args = parser.parse_args(sys.argv[1:])
 


### PR DESCRIPTION
This makes it easier to test with local builds of dependenciesvlike `mpas_tools`.

Also, begin the process of switching the bootstrap script to f-strings.  Whereas the main configure script has to work for older python versions, the bootstrap script doesn't and should therefore use f-strings for better clarity.