### PR TITLE
Update to MPAS-Toos 0.12.0

### DIFF
--- a/conda/compass_env/spec-file.template
+++ b/conda/compass_env/spec-file.template
@@ -18,7 +18,7 @@ lxml
 mache >=1.1.4
 matplotlib-base
 metis
-mpas_tools=0.11.0
+mpas_tools=0.12.0
 nco
 netcdf4=*=nompi_*
 numpy

--- a/conda/pnetcdf/ci/linux_mpi_mpich.yaml
+++ b/conda/pnetcdf/ci/linux_mpi_mpich.yaml
@@ -13,7 +13,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '9'
 hdf5:
-- 1.10.6
+- 1.12.1
 libnetcdf:
 - 4.8.1
 mpi:

--- a/conda/pnetcdf/ci/linux_mpi_openmpi.yaml
+++ b/conda/pnetcdf/ci/linux_mpi_openmpi.yaml
@@ -13,7 +13,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '9'
 hdf5:
-- 1.10.6
+- 1.12.1
 libnetcdf:
 - 4.8.1
 mpi:

--- a/conda/pnetcdf/ci/osx_mpi_mpich.yaml
+++ b/conda/pnetcdf/ci/osx_mpi_mpich.yaml
@@ -11,7 +11,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '11'
 hdf5:
-- 1.10.6
+- 1.12.1
 libnetcdf:
 - 4.8.1
 mpi:

--- a/conda/pnetcdf/ci/osx_mpi_openmpi.yaml
+++ b/conda/pnetcdf/ci/osx_mpi_openmpi.yaml
@@ -11,7 +11,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '11'
 hdf5:
-- 1.10.6
+- 1.12.1
 libnetcdf:
 - 4.8.1
 mpi:

--- a/conda/pnetcdf/recipe/meta.yaml
+++ b/conda/pnetcdf/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set version = "1.12.2" %}
-{% set build = 4 %}
+{% set build = 5 %}
 
 # recipe-lint fails if mpi is undefined
 {% set mpi = mpi or 'mpich' %}

--- a/conda/recipe/meta.yaml
+++ b/conda/recipe/meta.yaml
@@ -55,7 +55,7 @@ requirements:
     - mache >=1.1.4
     - matplotlib-base
     - metis
-    - mpas_tools 0.11.0
+    - mpas_tools 0.12.0
     - {{ mpi }}  # [mpi != 'nompi']
     - nco
     - netcdf4 * nompi_*

--- a/conda/scorpio/ci/linux_mpi_mpich.yaml
+++ b/conda/scorpio/ci/linux_mpi_mpich.yaml
@@ -13,7 +13,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '9'
 hdf5:
-- 1.10.6
+- 1.12.1
 libnetcdf:
 - 4.8.1
 libpnetcdf:

--- a/conda/scorpio/ci/linux_mpi_openmpi.yaml
+++ b/conda/scorpio/ci/linux_mpi_openmpi.yaml
@@ -13,7 +13,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '9'
 hdf5:
-- 1.10.6
+- 1.12.1
 libnetcdf:
 - 4.8.1
 libpnetcdf:

--- a/conda/scorpio/ci/osx_mpi_mpich.yaml
+++ b/conda/scorpio/ci/osx_mpi_mpich.yaml
@@ -11,7 +11,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '11'
 hdf5:
-- 1.10.6
+- 1.12.1
 libnetcdf:
 - 4.8.1
 libpnetcdf:

--- a/conda/scorpio/ci/osx_mpi_openmpi.yaml
+++ b/conda/scorpio/ci/osx_mpi_openmpi.yaml
@@ -11,7 +11,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '11'
 hdf5:
-- 1.10.6
+- 1.12.1
 libnetcdf:
 - 4.8.1
 libpnetcdf:

--- a/conda/scorpio/recipe/meta.yaml
+++ b/conda/scorpio/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set version = "1.2.2" %}
-{% set build = 1 %}
+{% set build = 2 %}
 
 # recipe-lint fails if mpi is undefined
 {% set mpi = mpi or 'mpich' %}


### PR DESCRIPTION
This version generalizes the `check_call()` function with logging to include arguments such as `env` for passing environment variables.  This functionality is needed for task parallelism, in which we will want to make different calls in parallel with different sets of environment variables (notably, different numbers of OpenMP threads).

This merge also updates the hdf5 version for the `libpnetcdf` and `scorpio` conda package to v1.12.1 to stay in sync with conda-forge and MPAS-Tools.

Packages uploaded to `e3sm/label/compass`:
- [x] linux
- [x] osx