### PR TITLE
Switch default python version to 3.9

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -20,13 +20,13 @@ jobs:
   strategy:
     matrix:
       nompi:
-        python.version: '3.8'
+        python.version: '3.9'
         mpi: 'nompi'
       openmpi:
-        python.version: '3.8'
+        python.version: '3.9'
         mpi: 'openmpi'
       mpich:
-        python.version: '3.8'
+        python.version: '3.9'
         mpi: 'mpich'
 
   steps:
@@ -163,13 +163,13 @@ jobs:
   strategy:
     matrix:
       nompi:
-        python.version: '3.8'
+        python.version: '3.9'
         mpi: 'nompi'
       openmpi:
-        python.version: '3.8'
+        python.version: '3.9'
         mpi: 'openmpi'
       mpich:
-        python.version: '3.8'
+        python.version: '3.9'
         mpi: 'mpich'
 
   steps:

--- a/compass/default.cfg
+++ b/compass/default.cfg
@@ -62,7 +62,7 @@ recreate = False
 suffix =
 
 # the python version
-python = 3.8
+python = 3.9
 
 # the MPI version (nompi, mpich or openmpi)
 mpi = nompi

--- a/conda/compass_env/spec-file.template
+++ b/conda/compass_env/spec-file.template
@@ -2,7 +2,7 @@
 # $ conda create --name <env> --file <this file>
 
 # Base
-python>=3.6,<3.10
+python>=3.6
 cartopy
 cartopy_offlinedata
 cmocean

--- a/conda/recipe/meta.yaml
+++ b/conda/recipe/meta.yaml
@@ -35,11 +35,11 @@ build:
 
 requirements:
   host:
-    - python >=3.6,<3.10
+    - python >=3.6
     - pip
     - setuptools
   run:
-    - python >=3.6,<3.10
+    - python >=3.6
     - cartopy
     - cartopy_offlinedata
     - cmocean


### PR DESCRIPTION
Now that dependencies are available, allow python 3.10 (if a user explicitly asks for it).