### PR TITLE
Add an error message if user config not found

### DIFF
--- a/compass/setup.py
+++ b/compass/setup.py
@@ -77,6 +77,10 @@ def setup_cases(tests=None, numbers=None, config_file=None, machine=None,
     if config_file is None and machine is None:
         raise ValueError('At least one of config_file and machine is needed.')
 
+    if not os.path.exists(config_file):
+        raise FileNotFoundError(
+            f'The user config file wasn\'t found: {config_file}')
+
     if tests is None and numbers is None:
         raise ValueError('At least one of tests or numbers is needed.')
 


### PR DESCRIPTION
If the user provides a config file but that file isn't found, there was previously no error message but obviously no config options were added.  This merge adds an error message if the file doesn't exit.