### PR TITLE
Add a description on the path to config files

### DIFF
--- a/docs/developers_guide/quick_start.rst
+++ b/docs/developers_guide/quick_start.rst
@@ -116,7 +116,7 @@ See :ref:`dev_other_machines` for more details.
 
 In addition, unknown machines require a config file to be specified when setting
 up the compass test environment.  A config file can be specified using
-``-f <filename>``, where ``<filename>`` includes an absolute or relative path to the file.  More information, including example config files, can be found
+``-f <filename>``, where ``<filename>`` is an absolute or relative path to the file.  More information, including example config files, can be found
 in :ref:`config_files`.
 
 What the script does

--- a/docs/developers_guide/quick_start.rst
+++ b/docs/developers_guide/quick_start.rst
@@ -116,7 +116,8 @@ See :ref:`dev_other_machines` for more details.
 
 In addition, unknown machines require a config file to be specified when setting
 up the compass test environment.  A config file can be specified using
-``-f <filename>``, where ``<filename>`` is an absolute or relative path to the file.  More information, including example config files, can be found
+``-f <filename>``, where ``<filename>`` is an absolute or relative path to the
+file. More information, including example config files, can be found
 in :ref:`config_files`.
 
 What the script does

--- a/docs/developers_guide/quick_start.rst
+++ b/docs/developers_guide/quick_start.rst
@@ -116,7 +116,7 @@ See :ref:`dev_other_machines` for more details.
 
 In addition, unknown machines require a config file to be specified when setting
 up the compass test environment.  A config file can be specified using
-``-f <filename>``.  More information, including example config files, can be found
+``-f <filename>``, where ``<filename>`` includes an absolute or relative path to the file.  More information, including example config files, can be found
 in :ref:`config_files`.
 
 What the script does


### PR DESCRIPTION
Hi Xylar, 

I've added a sentence in the compass developers' guide describing the path to a config file after a flag `-f` for users to avoid confusion in setting up test cases on COMPASS.

Please review this if this addition is clear and sound. 

Thank you,
Holly 