### PR TITLE
Fix check for missing config file

### DIFF
--- a/compass/setup.py
+++ b/compass/setup.py
@@ -77,7 +77,7 @@ def setup_cases(tests=None, numbers=None, config_file=None, machine=None,
     if config_file is None and machine is None:
         raise ValueError('At least one of config_file and machine is needed.')
 
-    if not os.path.exists(config_file):
+    if config_file is not None and not os.path.exists(config_file):
         raise FileNotFoundError(
             f'The user config file wasn\'t found: {config_file}')
 


### PR DESCRIPTION
In #300, I forgot to include a check that a config file was even provided before I checked to see if that file exists.  That causes `compass setup` to fail when a config file is *not* provided.  This PR fixes that blunder.

This goes to show that no PR is too small to get *proper* testing :-(