### PR TITLE
Turn on surface restoring for all dynamic adjustment

### DIFF
--- a/compass/ocean/tests/global_ocean/mesh/ec30to60/dynamic_adjustment/__init__.py
+++ b/compass/ocean/tests/global_ocean/mesh/ec30to60/dynamic_adjustment/__init__.py
@@ -48,9 +48,11 @@ class EC30to60DynamicAdjustment(DynamicAdjustment):
 
         module = self.__module__
 
-        global_stats = {'config_AM_globalStats_enable': '.true.',
-                        'config_AM_globalStats_compute_on_startup': '.true.',
-                        'config_AM_globalStats_write_on_startup': '.true.'}
+        shared_options = \
+            {'config_AM_globalStats_enable': '.true.',
+             'config_AM_globalStats_compute_on_startup': '.true.',
+             'config_AM_globalStats_write_on_startup': '.true.',
+             'config_use_activeTracers_surface_restoring': '.true.'}
 
         # first step
         step_name = 'damped_adjustment_1'
@@ -63,7 +65,7 @@ class EC30to60DynamicAdjustment(DynamicAdjustment):
             'config_dt': "'00:15:00'",
             'config_Rayleigh_friction': '.true.',
             'config_Rayleigh_damping_coeff': '1.0e-4'}
-        namelist_options.update(global_stats)
+        namelist_options.update(shared_options)
         step.add_namelist_options(namelist_options)
 
         stream_replacements = {
@@ -86,7 +88,7 @@ class EC30to60DynamicAdjustment(DynamicAdjustment):
             'config_dt': "'00:15:00'",
             'config_do_restart': '.true.',
             'config_start_time': "'{}'".format(restart_times[0])}
-        namelist_options.update(global_stats)
+        namelist_options.update(shared_options)
         step.add_namelist_options(namelist_options)
 
         stream_replacements = {
@@ -109,7 +111,7 @@ class EC30to60DynamicAdjustment(DynamicAdjustment):
             'config_run_duration': "'00-00-10_00:00:00'",
             'config_do_restart': '.true.',
             'config_start_time': "'{}'".format(restart_times[1])}
-        namelist_options.update(global_stats)
+        namelist_options.update(shared_options)
         step.add_namelist_options(namelist_options)
 
         stream_replacements = {

--- a/compass/ocean/tests/global_ocean/mesh/qu240/dynamic_adjustment/__init__.py
+++ b/compass/ocean/tests/global_ocean/mesh/qu240/dynamic_adjustment/__init__.py
@@ -38,9 +38,11 @@ class QU240DynamicAdjustment(DynamicAdjustment):
 
         module = self.__module__
 
-        global_stats = {'config_AM_globalStats_enable': '.true.',
-                        'config_AM_globalStats_compute_on_startup': '.true.',
-                        'config_AM_globalStats_write_on_startup': '.true.'}
+        shared_options = \
+            {'config_AM_globalStats_enable': '.true.',
+             'config_AM_globalStats_compute_on_startup': '.true.',
+             'config_AM_globalStats_write_on_startup': '.true.',
+             'config_use_activeTracers_surface_restoring': '.true.'}
 
         # first step
         step_name = 'damped_adjustment_1'
@@ -52,7 +54,7 @@ class QU240DynamicAdjustment(DynamicAdjustment):
             'config_run_duration': "'00-00-01_00:00:00'",
             'config_Rayleigh_friction': '.true.',
             'config_Rayleigh_damping_coeff': '1.0e-4'}
-        namelist_options.update(global_stats)
+        namelist_options.update(shared_options)
         step.add_namelist_options(namelist_options)
 
         stream_replacements = {
@@ -74,7 +76,7 @@ class QU240DynamicAdjustment(DynamicAdjustment):
             'config_run_duration': "'00-00-01_00:00:00'",
             'config_do_restart': '.true.',
             'config_start_time': "'{}'".format(restart_times[0])}
-        namelist_options.update(global_stats)
+        namelist_options.update(shared_options)
         step.add_namelist_options(namelist_options)
 
         stream_replacements = {

--- a/compass/ocean/tests/global_ocean/mesh/qu240/namelist.rk4
+++ b/compass/ocean/tests/global_ocean/mesh/qu240/namelist.rk4
@@ -6,6 +6,7 @@ config_use_tracer_del2 = .true.
 config_use_tracer_del4 = .true.
 config_tracer_del4 = 1.2e11
 config_use_Leith_del2 = .true.
+config_use_GM = .true.
 config_Rayleigh_friction = .true.
 config_Rayleigh_damping_depth_variable = .true.
 config_Rayleigh_bottom_friction = .true.

--- a/compass/ocean/tests/global_ocean/mesh/qu240/namelist.split_explicit
+++ b/compass/ocean/tests/global_ocean/mesh/qu240/namelist.split_explicit
@@ -7,6 +7,7 @@ config_use_tracer_del2 = .true.
 config_use_tracer_del4 = .true.
 config_tracer_del4 = 1.2e11
 config_use_Leith_del2 = .true.
+config_use_GM = .true.
 config_Rayleigh_friction = .true.
 config_Rayleigh_damping_depth_variable = .true.
 config_Rayleigh_bottom_friction = .true.

--- a/compass/ocean/tests/global_ocean/mesh/so12to60/dynamic_adjustment/__init__.py
+++ b/compass/ocean/tests/global_ocean/mesh/so12to60/dynamic_adjustment/__init__.py
@@ -49,9 +49,11 @@ class SO12to60DynamicAdjustment(DynamicAdjustment):
 
         module = self.__module__
 
-        global_stats = {'config_AM_globalStats_enable': '.true.',
-                        'config_AM_globalStats_compute_on_startup': '.true.',
-                        'config_AM_globalStats_write_on_startup': '.true.'}
+        shared_options = \
+            {'config_AM_globalStats_enable': '.true.',
+             'config_AM_globalStats_compute_on_startup': '.true.',
+             'config_AM_globalStats_write_on_startup': '.true.',
+             'config_use_activeTracers_surface_restoring': '.true.'}
 
         # first step
         step_name = 'damped_adjustment_1'
@@ -65,7 +67,7 @@ class SO12to60DynamicAdjustment(DynamicAdjustment):
             'config_btr_dt': "'00:00:15'",
             'config_Rayleigh_friction': '.true.',
             'config_Rayleigh_damping_coeff': '1.0e-4'}
-        namelist_options.update(global_stats)
+        namelist_options.update(shared_options)
         step.add_namelist_options(namelist_options)
 
         stream_replacements = {
@@ -90,7 +92,7 @@ class SO12to60DynamicAdjustment(DynamicAdjustment):
             'config_Rayleigh_damping_coeff': '1.0e-5',
             'config_do_restart': '.true.',
             'config_start_time': "'{}'".format(restart_times[0])}
-        namelist_options.update(global_stats)
+        namelist_options.update(shared_options)
         step.add_namelist_options(namelist_options)
 
         stream_replacements = {
@@ -116,7 +118,7 @@ class SO12to60DynamicAdjustment(DynamicAdjustment):
             'config_Rayleigh_damping_coeff': '1.0e-6',
             'config_do_restart': '.true.',
             'config_start_time': "'{}'".format(restart_times[1])}
-        namelist_options.update(global_stats)
+        namelist_options.update(shared_options)
         step.add_namelist_options(namelist_options)
 
         stream_replacements = {
@@ -140,7 +142,7 @@ class SO12to60DynamicAdjustment(DynamicAdjustment):
             'config_dt': "'00:05:00'",
             'config_do_restart': '.true.',
             'config_start_time': "'{}'".format(restart_times[2])}
-        namelist_options.update(global_stats)
+        namelist_options.update(shared_options)
         step.add_namelist_options(namelist_options)
 
         stream_replacements = {
@@ -163,7 +165,7 @@ class SO12to60DynamicAdjustment(DynamicAdjustment):
             'config_run_duration': "'00-00-10_00:00:00'",
             'config_do_restart': '.true.',
             'config_start_time': "'{}'".format(restart_times[3])}
-        namelist_options.update(global_stats)
+        namelist_options.update(shared_options)
         step.add_namelist_options(namelist_options)
 
         stream_replacements = {

--- a/compass/ocean/tests/global_ocean/mesh/wc14/dynamic_adjustment/__init__.py
+++ b/compass/ocean/tests/global_ocean/mesh/wc14/dynamic_adjustment/__init__.py
@@ -50,9 +50,11 @@ class WC14DynamicAdjustment(DynamicAdjustment):
 
         module = self.__module__
 
-        global_stats = {'config_AM_globalStats_enable': '.true.',
-                        'config_AM_globalStats_compute_on_startup': '.true.',
-                        'config_AM_globalStats_write_on_startup': '.true.'}
+        shared_options = \
+            {'config_AM_globalStats_enable': '.true.',
+             'config_AM_globalStats_compute_on_startup': '.true.',
+             'config_AM_globalStats_write_on_startup': '.true.',
+             'config_use_activeTracers_surface_restoring': '.true.'}
 
         # first step
         step_name = 'damped_adjustment_1'
@@ -66,7 +68,7 @@ class WC14DynamicAdjustment(DynamicAdjustment):
             'config_btr_dt': "'00:00:01.5'",
             'config_Rayleigh_friction': '.true.',
             'config_Rayleigh_damping_coeff': '1.0e-3'}
-        namelist_options.update(global_stats)
+        namelist_options.update(shared_options)
         step.add_namelist_options(namelist_options)
 
         stream_replacements = {
@@ -92,7 +94,7 @@ class WC14DynamicAdjustment(DynamicAdjustment):
             'config_Rayleigh_damping_coeff': '4.0e-4',
             'config_do_restart': '.true.',
             'config_start_time': "'{}'".format(restart_times[0])}
-        namelist_options.update(global_stats)
+        namelist_options.update(shared_options)
         step.add_namelist_options(namelist_options)
 
         stream_replacements = {
@@ -119,7 +121,7 @@ class WC14DynamicAdjustment(DynamicAdjustment):
             'config_Rayleigh_damping_coeff': '1.0e-4',
             'config_do_restart': '.true.',
             'config_start_time': "'{}'".format(restart_times[1])}
-        namelist_options.update(global_stats)
+        namelist_options.update(shared_options)
         step.add_namelist_options(namelist_options)
 
         stream_replacements = {
@@ -146,7 +148,7 @@ class WC14DynamicAdjustment(DynamicAdjustment):
             'config_Rayleigh_damping_coeff': '4.0e-5',
             'config_do_restart': '.true.',
             'config_start_time': "'{}'".format(restart_times[2])}
-        namelist_options.update(global_stats)
+        namelist_options.update(shared_options)
         step.add_namelist_options(namelist_options)
 
         stream_replacements = {
@@ -173,7 +175,7 @@ class WC14DynamicAdjustment(DynamicAdjustment):
             'config_Rayleigh_damping_coeff': '2.0e-5',
             'config_do_restart': '.true.',
             'config_start_time': "'{}'".format(restart_times[3])}
-        namelist_options.update(global_stats)
+        namelist_options.update(shared_options)
         step.add_namelist_options(namelist_options)
 
         stream_replacements = {
@@ -198,7 +200,7 @@ class WC14DynamicAdjustment(DynamicAdjustment):
             'config_btr_dt': "'00:00:15'",
             'config_do_restart': '.true.',
             'config_start_time': "'{}'".format(restart_times[4])}
-        namelist_options.update(global_stats)
+        namelist_options.update(shared_options)
         step.add_namelist_options(namelist_options)
 
         stream_replacements = {
@@ -221,7 +223,7 @@ class WC14DynamicAdjustment(DynamicAdjustment):
             'config_run_duration': "'00-00-24_00:00:00'",
             'config_do_restart': '.true.',
             'config_start_time': "'{}'".format(restart_times[5])}
-        namelist_options.update(global_stats)
+        namelist_options.update(shared_options)
         step.add_namelist_options(namelist_options)
 
         stream_replacements = {


### PR DESCRIPTION
This merge re-enables surface restoring of tracers in the dynamic adjustment test cases from the global ocean test group. This choice was discussed at length in #308.

This merge also enables GM in the QU240 configuration to be (somewhat) more consistent with other resolutions.  QU240 also enables many features that are not used at other resolutions.