### PR TITLE
Add bathymetry smoothing to global ocean init

### DIFF
--- a/compass/ocean/tests/global_ocean/init/namelist.init
+++ b/compass/ocean/tests/global_ocean/init/namelist.init
@@ -63,3 +63,5 @@ config_global_ocean_depth_conversion_factor = 1.0
 config_global_ocean_minimum_depth = 10
 config_global_ocean_deepen_critical_passages = .false.
 config_block_decomp_file_prefix = 'graph.info.part.'
+config_global_ocean_topography_smooth_iterations = 6
+config_global_ocean_topography_smooth_weight = 0.9


### PR DESCRIPTION
At @mark-petersen's request, we perform 6 iterations of smoothing with a weight of 0.9.

For more info on the smoothing approach, see:
https://github.com/MPAS-Dev/MPAS-Model/pull/440
For more on some slightly more aggressive values used previously (related to ice-shelf cavities), see:
https://github.com/MPAS-Dev/MPAS-Model/pull/532#issuecomment-620760208

Partially addresses #308 