### PR TITLE
Constrain `scipy <1.8.0`

### DIFF
--- a/conda/compass_env/spec-file.template
+++ b/conda/compass_env/spec-file.template
@@ -26,7 +26,7 @@ progressbar2
 pyamg
 pyremap>=0.0.13,<0.1.0
 requests
-scipy
+scipy <1.8.0
 shapely
 xarray
 

--- a/conda/recipe/meta.yaml
+++ b/conda/recipe/meta.yaml
@@ -64,7 +64,7 @@ requirements:
     - pyamg
     - pyremap >=0.0.13,<0.1.0
     - requests
-    - scipy
+    - scipy <1.8.0
     - shapely
     - xarray
 

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ install_requires = \
      'progressbar2',
      'pyamg',
      'requests',
-     'scipy',
+     'scipy<1.8.0',
      'shapely',
      'xarray']
 


### PR DESCRIPTION
This is needed until https://github.com/pyamg/pyamg/issues/307 is addressed, likely via https://github.com/pyamg/pyamg/pull/308 and a patch or new release is on conda-forge.