### PR TITLE
Generalize flood-fill routine for use by multiple test groups

### DIFF
--- a/compass/landice/landice.py
+++ b/compass/landice/landice.py
@@ -1,0 +1,71 @@
+import numpy as np
+
+
+def flood_fill(thk, vx, vy):
+    """
+    Remove glaciers and ice-fields that are not connected to the ice sheet.
+
+    Parameters
+    ----------
+    thk : numpy.ndarray
+        Ice thickness from gridded dataset
+    vx : numpy.ndarry
+        Velocity x-component from gridded dataset
+    vy : numpy.ndarray
+        Velocity y-component from gridded dataset
+
+    Returns
+    -------
+    thkTrimmed : numpy.ndarray
+        Ice thickness after flood-fill is applied
+    vxTrimmed : numpy.ndarray
+        Velocity x-component after flood-fill is applied
+    vyTrimmed : numpy.ndarry
+        Velocity y-component after flood-fill is applied
+    """
+    sz = thk.shape
+    searchedMask = np.zeros(sz)
+    floodMask = np.zeros(sz)
+    iStart = sz[0] // 2
+    jStart = sz[1] // 2
+    floodMask[iStart, jStart] = 1
+
+    neighbors = np.array([[1, 0], [-1, 0], [0, 1], [0, -1]])
+
+    lastSearchList = np.ravel_multi_index([[iStart], [jStart]],
+                                          sz, order='F')
+
+    cnt = 0
+    while len(lastSearchList) > 0:
+        cnt += 1
+        newSearchList = np.array([], dtype='i')
+
+        for iii in range(len(lastSearchList)):
+            [i, j] = np.unravel_index(lastSearchList[iii], sz, order='F')
+            # search neighbors
+            for n in neighbors:
+                ii = i + n[0]
+                jj = j + n[1]  # subscripts to neighbor
+                # only consider unsearched neighbors
+                if searchedMask[ii, jj] == 0:
+                    searchedMask[ii, jj] = 1  # mark as searched
+
+                    if thk[ii, jj] > 0.0:
+                        floodMask[ii, jj] = 1  # mark as ice
+                        # add to list of newly found  cells
+                        newSearchList = np.append(newSearchList,
+                                                  np.ravel_multi_index(
+                                                      [[ii], [jj]], sz,
+                                                      order='F')[0])
+        lastSearchList = newSearchList
+
+    # apply flood fill
+    thkTrimmed = thk.copy()
+    vxTrimmed = vx.copy()
+    vyTrimmed = vy.copy()
+
+    thkTrimmed[floodMask == 0] = 0.0
+    vxTrimmed[floodMask == 0] = 0.0
+    vyTrimmed[floodMask == 0] = 0.0
+
+    return thkTrimmed, vxTrimmed, vyTrimmed

--- a/compass/landice/mesh.py
+++ b/compass/landice/mesh.py
@@ -1,7 +1,7 @@
 import numpy as np
 
 
-def flood_fill(thk, vx, vy):
+def flood_fill(thk):
     """
     Remove glaciers and ice-fields that are not connected to the ice sheet.
 
@@ -9,20 +9,15 @@ def flood_fill(thk, vx, vy):
     ----------
     thk : numpy.ndarray
         Ice thickness from gridded dataset
-    vx : numpy.ndarry
-        Velocity x-component from gridded dataset
-    vy : numpy.ndarray
-        Velocity y-component from gridded dataset
 
     Returns
     -------
-    thkTrimmed : numpy.ndarray
-        Ice thickness after flood-fill is applied
-    vxTrimmed : numpy.ndarray
-        Velocity x-component after flood-fill is applied
-    vyTrimmed : numpy.ndarry
-        Velocity y-component after flood-fill is applied
+    floodMask : numpy.ndarray
+        Ice sheet mask calculated by the flood fill routine,
+        where ice connected to the ice sheet is 1 and
+        everything else is 0.
     """
+
     sz = thk.shape
     searchedMask = np.zeros(sz)
     floodMask = np.zeros(sz)
@@ -59,13 +54,4 @@ def flood_fill(thk, vx, vy):
                                                       order='F')[0])
         lastSearchList = newSearchList
 
-    # apply flood fill
-    thkTrimmed = thk.copy()
-    vxTrimmed = vx.copy()
-    vyTrimmed = vy.copy()
-
-    thkTrimmed[floodMask == 0] = 0.0
-    vxTrimmed[floodMask == 0] = 0.0
-    vyTrimmed[floodMask == 0] = 0.0
-
-    return thkTrimmed, vxTrimmed, vyTrimmed
+    return floodMask

--- a/compass/landice/mesh.py
+++ b/compass/landice/mesh.py
@@ -1,24 +1,29 @@
 import numpy as np
 
 
-def flood_fill(thk):
+def gridded_flood_fill(field):
     """
-    Remove glaciers and ice-fields that are not connected to the ice sheet.
+    Generic flood-fill routine to create mask of connected elements
+    in the desired input array (field) from a gridded dataset. This
+    is generally used to remove glaciers and ice-fields that are not
+    connected to the ice sheet. Note that there may be more efficient
+    algorithms.
 
     Parameters
     ----------
-    thk : numpy.ndarray
-        Ice thickness from gridded dataset
+    field : numpy.ndarray
+        Array from gridded dataset to use for flood-fill.
+        Usually ice thickness.
 
     Returns
     -------
     floodMask : numpy.ndarray
-        Ice sheet mask calculated by the flood fill routine,
-        where ice connected to the ice sheet is 1 and
-        everything else is 0.
+        Mask calculated by the flood fill routine,
+        where cells connected to the ice sheet (or main feature)
+        are 1 and everything else is 0.
     """
 
-    sz = thk.shape
+    sz = field.shape
     searchedMask = np.zeros(sz)
     floodMask = np.zeros(sz)
     iStart = sz[0] // 2
@@ -45,7 +50,7 @@ def flood_fill(thk):
                 if searchedMask[ii, jj] == 0:
                     searchedMask[ii, jj] = 1  # mark as searched
 
-                    if thk[ii, jj] > 0.0:
+                    if field[ii, jj] > 0.0:
                         floodMask[ii, jj] = 1  # mark as ice
                         # add to list of newly found  cells
                         newSearchList = np.append(newSearchList,

--- a/compass/landice/tests/humboldt/mesh.py
+++ b/compass/landice/tests/humboldt/mesh.py
@@ -12,6 +12,7 @@ from mpas_tools.logging import check_call
 
 from compass.step import Step
 from compass.model import make_graph_file
+from compass.landice.landice import flood_fill
 
 
 class Mesh(Step):
@@ -171,12 +172,10 @@ class Mesh(Step):
         Determine MPAS mesh cell size based on user-defined density function.
 
         This includes hard-coded definition of the extent of the regional
-        mesh, a flood-fill routine to ignore glaciers and ice caps not
-        connected to the ice sheet, and user-defined mesh density functions
-        based on observed flow speed and distance to the ice margin. In the
-        future, this function and its components will likely be separated
-        into separate generalized functions to be reusable by multiple test
-        groups.
+        mesh and user-defined mesh density functions based on observed flow
+        speed and distance to the ice margin. In the future, this function
+        and its components will likely be separated into separate generalized
+        functions to be reusable by multiple test groups.
         """
         # get needed fields from GIS dataset
         f = netCDF4.Dataset('greenland_8km_2020_04_20.epsg3413.nc', 'r')
@@ -215,53 +214,8 @@ class Mesh(Step):
             ((3, 0), 0)],
             dtype=jigsawpy.jigsaw_msh_t.EDGE2_t)
 
-        # flood fill to remove island, icecaps, etc.
-        searchedMask = np.zeros(sz)
-        floodMask = np.zeros(sz)
-        iStart = sz[0] // 2
-        jStart = sz[1] // 2
-        floodMask[iStart, jStart] = 1
-
-        neighbors = np.array([[1, 0], [-1, 0], [0, 1], [0, -1]])
-
-        lastSearchList = np.ravel_multi_index([[iStart], [jStart]],
-                                              sz, order='F')
-
-        # flood fill -------------------
-        # In the future this might become a separate function
-        # to be used by multiple test groups.
-        cnt = 0
-        while len(lastSearchList) > 0:
-            # logger.info(cnt)
-            cnt += 1
-            newSearchList = np.array([], dtype='i')
-
-            for iii in range(len(lastSearchList)):
-                [i, j] = np.unravel_index(lastSearchList[iii], sz, order='F')
-                # search neighbors
-                for n in neighbors:
-                    ii = i + n[0]
-                    jj = j + n[1]  # subscripts to neighbor
-                    # only consider unsearched neighbors
-                    if searchedMask[ii, jj] == 0:
-                        searchedMask[ii, jj] = 1  # mark as searched
-
-                        if thk[ii, jj] > 0.0:
-                            floodMask[ii, jj] = 1  # mark as ice
-                            # add to list of newly found  cells
-                            newSearchList = np.append(newSearchList,
-                                                      np.ravel_multi_index(
-                                                          [[ii], [jj]], sz,
-                                                          order='F')[0])
-            lastSearchList = newSearchList
-        # optional - plot flood mask
-        # plt.pcolor(floodMask)
-        # plt.show()
-
-        # apply flood fill
-        thk[floodMask == 0] = 0.0
-        vx[floodMask == 0] = 0.0
-        vy[floodMask == 0] = 0.0
+        # Remove ice not connected to the ice sheet.
+        thk, vx, vy = flood_fill(thk, vx, vy)
 
         # make masks -------------------
         neighbors = np.array([[1, 0], [-1, 0], [0, 1], [0, -1],

--- a/compass/landice/tests/humboldt/mesh.py
+++ b/compass/landice/tests/humboldt/mesh.py
@@ -12,7 +12,7 @@ from mpas_tools.logging import check_call
 
 from compass.step import Step
 from compass.model import make_graph_file
-from compass.landice.landice import flood_fill
+from compass.landice.mesh import flood_fill
 
 
 class Mesh(Step):
@@ -215,7 +215,10 @@ class Mesh(Step):
             dtype=jigsawpy.jigsaw_msh_t.EDGE2_t)
 
         # Remove ice not connected to the ice sheet.
-        thk, vx, vy = flood_fill(thk, vx, vy)
+        floodMask = flood_fill(thk)
+        thk[floodMask == 0] = 0.0
+        vx[floodMask == 0] = 0.0
+        vy[floodMask == 0] = 0.0
 
         # make masks -------------------
         neighbors = np.array([[1, 0], [-1, 0], [0, 1], [0, -1],

--- a/compass/landice/tests/humboldt/mesh.py
+++ b/compass/landice/tests/humboldt/mesh.py
@@ -12,7 +12,7 @@ from mpas_tools.logging import check_call
 
 from compass.step import Step
 from compass.model import make_graph_file
-from compass.landice.mesh import flood_fill
+from compass.landice.mesh import gridded_flood_fill
 
 
 class Mesh(Step):
@@ -215,7 +215,7 @@ class Mesh(Step):
             dtype=jigsawpy.jigsaw_msh_t.EDGE2_t)
 
         # Remove ice not connected to the ice sheet.
-        floodMask = flood_fill(thk)
+        floodMask = gridded_flood_fill(thk)
         thk[floodMask == 0] = 0.0
         vx[floodMask == 0] = 0.0
         vy[floodMask == 0] = 0.0


### PR DESCRIPTION
Create module compass.landice.landice that will contain functions for general use in creating landice meshes, and add flood_fill() function. Also add usage example in Humboldt mesh creation step. The flood_fill() function will likely be used by all landice test groups that interpolate gridded observational data onto an MPAS mesh.