### PR TITLE
Add set_geom_points_and_edges() function

### DIFF
--- a/compass/landice/mesh.py
+++ b/compass/landice/mesh.py
@@ -63,7 +63,7 @@ def gridded_flood_fill(field):
     return floodMask
 
 
-def set_geom_points_and_edges(xmin, xmax, ymin, ymax):
+def set_rectangular_geom_points_and_edges(xmin, xmax, ymin, ymax):
     """
     Set node and edge coordinates to pass to
     :py:func:`mpas_tools.mesh.creation.build_mesh.build_planar_mesh()`.

--- a/compass/landice/mesh.py
+++ b/compass/landice/mesh.py
@@ -63,20 +63,20 @@ def gridded_flood_fill(field):
     return floodMask
 
 
-def set_geom_points_and_edges(xx0, xx1, yy0, yy1):
+def set_geom_points_and_edges(xmin, xmax, ymin, ymax):
     """
-    Set node and edge coordinates to pass to 
+    Set node and edge coordinates to pass to
     :py:func:`mpas_tools.mesh.creation.build_mesh.build_planar_mesh()`.
 
     Parameters
     ----------
-    xx0 : int or float
+    xmin : int or float
         Left-most x-coordinate in region to mesh
-    xx1 : int or float
+    xmax : int or float
         Right-most x-coordinate in region to mesh
-    yy0 : int or float
+    ymin : int or float
         Bottom-most y-coordinate in region to mesh
-    yy1 : int or float
+    ymax : int or float
         Top-most y-coordinate in region to mesh
 
     Returns
@@ -88,10 +88,10 @@ def set_geom_points_and_edges(xx0, xx1, yy0, yy1):
     """
 
     geom_points = np.array([  # list of xy "node" coordinates
-        ((xx0, yy0), 0),
-        ((xx1, yy0), 0),
-        ((xx1, yy1), 0),
-        ((xx0, yy1), 0)],
+        ((xmin, ymin), 0),
+        ((xmax, ymin), 0),
+        ((xmax, ymax), 0),
+        ((xmin, ymax), 0)],
         dtype=jigsawpy.jigsaw_msh_t.VERT2_t)
 
     geom_edges = np.array([  # list of "edges" between nodes

--- a/compass/landice/mesh.py
+++ b/compass/landice/mesh.py
@@ -65,7 +65,8 @@ def gridded_flood_fill(field):
 
 def set_geom_points_and_edges(xx0, xx1, yy0, yy1):
     """
-    Set node and edge coordinates to pass to build_planar_mesh().
+    Set node and edge coordinates to pass to 
+    :py:func:`mpas_tools.mesh.creation.build_mesh.build_planar_mesh()`.
 
     Parameters
     ----------

--- a/compass/landice/mesh.py
+++ b/compass/landice/mesh.py
@@ -1,4 +1,5 @@
 import numpy as np
+import jigsawpy
 
 
 def gridded_flood_fill(field):
@@ -60,3 +61,43 @@ def gridded_flood_fill(field):
         lastSearchList = newSearchList
 
     return floodMask
+
+
+def set_geom_points_and_edges(xx0, xx1, yy0, yy1):
+    """
+    Set node and edge coordinates to pass to build_planar_mesh().
+
+    Parameters
+    ----------
+    xx0 : int or float
+        Left-most x-coordinate in region to mesh
+    xx1 : int or float
+        Right-most x-coordinate in region to mesh
+    yy0 : int or float
+        Bottom-most y-coordinate in region to mesh
+    yy1 : int or float
+        Top-most y-coordinate in region to mesh
+
+    Returns
+    -------
+    geom_points : jigsawpy.jigsaw_msh_t.VERT2_t
+        xy node coordinates to pass to build_planar_mesh()
+    geom_edges : jigsawpy.jigsaw_msh_t.EDGE2_t
+        xy edge coordinates between nodes to pass to build_planar_mesh()
+    """
+
+    geom_points = np.array([  # list of xy "node" coordinates
+        ((xx0, yy0), 0),
+        ((xx1, yy0), 0),
+        ((xx1, yy1), 0),
+        ((xx0, yy1), 0)],
+        dtype=jigsawpy.jigsaw_msh_t.VERT2_t)
+
+    geom_edges = np.array([  # list of "edges" between nodes
+        ((0, 1), 0),
+        ((1, 2), 0),
+        ((2, 3), 0),
+        ((3, 0), 0)],
+        dtype=jigsawpy.jigsaw_msh_t.EDGE2_t)
+
+    return geom_points, geom_edges

--- a/compass/landice/tests/humboldt/mesh.py
+++ b/compass/landice/tests/humboldt/mesh.py
@@ -12,7 +12,7 @@ from mpas_tools.logging import check_call
 
 from compass.step import Step
 from compass.model import make_graph_file
-from compass.landice.mesh import gridded_flood_fill
+from compass.landice.mesh import gridded_flood_fill, set_geom_points_and_edges
 
 
 class Mesh(Step):
@@ -200,19 +200,8 @@ class Mesh(Step):
         xx1 = 84000
         yy0 = -1560000
         yy1 = -860000
-        geom_points = np.array([  # list of xy "node" coordinates
-            ((xx0, yy0), 0),
-            ((xx1, yy0), 0),
-            ((xx1, yy1), 0),
-            ((xx0, yy1), 0)],
-            dtype=jigsawpy.jigsaw_msh_t.VERT2_t)
-
-        geom_edges = np.array([    # list of "edges" between nodes
-            ((0, 1), 0),
-            ((1, 2), 0),
-            ((2, 3), 0),
-            ((3, 0), 0)],
-            dtype=jigsawpy.jigsaw_msh_t.EDGE2_t)
+        geom_points, geom_edges = set_geom_points_and_edges(xx0, xx1,
+                                                            yy0, yy1)
 
         # Remove ice not connected to the ice sheet.
         floodMask = gridded_flood_fill(thk)

--- a/compass/landice/tests/humboldt/mesh.py
+++ b/compass/landice/tests/humboldt/mesh.py
@@ -1,6 +1,5 @@
 import numpy as np
 import netCDF4
-import jigsawpy
 import xarray
 from matplotlib import pyplot as plt
 
@@ -12,7 +11,8 @@ from mpas_tools.logging import check_call
 
 from compass.step import Step
 from compass.model import make_graph_file
-from compass.landice.mesh import gridded_flood_fill, set_geom_points_and_edges
+from compass.landice.mesh import gridded_flood_fill, \
+                                 set_rectangular_geom_points_and_edges
 
 
 class Mesh(Step):
@@ -200,8 +200,8 @@ class Mesh(Step):
         xx1 = 84000
         yy0 = -1560000
         yy1 = -860000
-        geom_points, geom_edges = set_geom_points_and_edges(xx0, xx1,
-                                                            yy0, yy1)
+        geom_points, geom_edges = set_rectangular_geom_points_and_edges(
+                                                           xx0, xx1, yy0, yy1)
 
         # Remove ice not connected to the ice sheet.
         floodMask = gridded_flood_fill(thk)


### PR DESCRIPTION
Add set_geom_points_and_edges() function to compass.landice.mesh module, and call from build_cell_widths(). This will likely be used by all landice mesh-generating test cases.