### PR TITLE
Create set_cell_width() function

### DIFF
--- a/compass/landice/mesh.py
+++ b/compass/landice/mesh.py
@@ -102,3 +102,100 @@ def set_rectangular_geom_points_and_edges(xmin, xmax, ymin, ymax):
         dtype=jigsawpy.jigsaw_msh_t.EDGE2_t)
 
     return geom_points, geom_edges
+
+
+def set_cell_width(self, section, thk, vx=None, vy=None,
+                   distToEdge=None, distToGroundingLine=None):
+    """
+    Set cell widths based on settings in config file to pass to
+    :py:func:`mpas_tools.mesh.creation.build_mesh.build_planar_mesh()`.
+
+    Parameters
+    ----------
+    section : str
+        Section of the config file from which to read parameters
+    thk : numpy.ndarray
+        Ice thickness field from gridded dataset,
+        usually after trimming to flood fill mask
+    vx : numpy.ndarray
+        x-component of ice velocity from gridded dataset,
+        usually after trimming to flood fill mask. Can be set to None
+        if useSpeed == 'False' in config file.
+    vy : numpy.ndarray
+        y-component of ice velocity from gridded dataset,
+        usually after trimming to flood fill mask. Can be set to None
+        if useSpeed == 'False' in config file.
+    distToEdge : numpy.ndarray
+        Distance from each cell to ice edge, calculated in separate function.
+        Can be set to None if useDistToEdge == 'False' in config file and you
+        do not want to set large cell_width where cells will be culled anyway,
+        but this is not recommended.
+    distToGroundingLine : numpy.ndarray
+        Distance from each cell to grounding line, calculated in separate
+        function.  Can be set to None if useDistToGroundingLine == 'False'
+        in config file.
+
+    Returns
+    -------
+    cell_width : numpy.ndarray
+        Desired width of MPAS cells based on mesh desnity functions to pass to
+        :py:func:`mpas_tools.mesh.creation.build_mesh.build_planar_mesh()`.
+    """
+
+    logger = self.logger
+    section = self.config[section]
+
+    # Get config inputs for cell spacing functions
+    minSpac = float(section.get('minSpac'))
+    maxSpac = float(section.get('maxSpac'))
+    highLogSpeed = float(section.get('highLogSpeed'))
+    lowLogSpeed = float(section.get('lowLogSpeed'))
+    highDist = float(section.get('highDist'))
+    lowDist = float(section.get('lowDist'))
+    cullDistance = float(section.get('cullDistance')) * 1.e3  # convert km to m
+
+    # Make cell spacing function mapping from log speed to cell spacing
+    if section.get('useSpeed') == 'True':
+        logger.info('Using speed for cell spacing')
+        speed = (vx**2 + vy**2)**0.5
+        lspd = np.log10(speed)
+        spacing = np.interp(lspd, [lowLogSpeed, highLogSpeed],
+                            [maxSpac, minSpac], left=maxSpac,
+                            right=minSpac)
+        spacing[thk == 0.0] = minSpac
+    else:
+        spacing = thk * 0. + maxSpac
+
+    # Make cell spacing function mapping from distance to ice edge
+    if section.get('useDistToEdge') == 'True':
+        logger.info('Using distance to ice edge for cell spacing')
+        spacing2 = np.interp(distToEdge, [lowDist, highDist],
+                             [minSpac, maxSpac], left=minSpac,
+                             right=maxSpac)
+        spacing2[thk == 0.0] = minSpac
+    else:
+        spacing2 = thk * 0. + maxSpac
+
+    # Make cell spacing function mapping from distance to grounding line
+    if section.get('useDistToGroundingLine') == 'True':
+        logger.info('Using distance to grounding line for cell spacing')
+        spacing3 = np.interp(distToGroundingLine, [lowDist, highDist],
+                             [minSpac, maxSpac], left=minSpac,
+                             right=maxSpac)
+        spacing3[thk == 0.0] = minSpac
+    else:
+        spacing3 = thk * 0. + maxSpac
+
+    # Merge cell spacing methods
+    cell_width = np.minimum(spacing, spacing2)
+    cell_width = np.minimum(cell_width, spacing3)
+
+    # Set large cell_width in areas we are going to cull anyway (speeds up
+    # whole process). Use 10x the cullDistance to avoid this affecting
+    # cell size in the final mesh. There may be a more rigorous way to set
+    # that distance.
+    if distToEdge is not None:
+        cell_width[np.logical_and(thk == 0.0,
+                   distToEdge > (10. * cullDistance))] = maxSpac
+
+    return cell_width

--- a/compass/landice/mesh.py
+++ b/compass/landice/mesh.py
@@ -111,7 +111,8 @@ def set_cell_width(self, section, thk, vx=None, vy=None,
     :py:func:`mpas_tools.mesh.creation.build_mesh.build_planar_mesh()`.
     Requires the following options to be set in the given config section:
     ``min_spac``, ``max_spac``, ``high_log_speed``, ``low_log_speed``,
-    ``high_dist``, ``low_dist``, and ``cull_distance``.
+    ``high_dist``, ``low_dist``,``cull_distance``, ``use_speed``,
+    ``use_dist_to_edge``, and ``use_dist_to_grounding_line``.
 
     Parameters
     ----------
@@ -123,20 +124,20 @@ def set_cell_width(self, section, thk, vx=None, vy=None,
     vx : numpy.ndarray, optional
         x-component of ice velocity from gridded dataset,
         usually after trimming to flood fill mask. Can be set to ``None``
-        if ``useSpeed == False`` in config file.
+        if ``use_speed == False`` in config file.
     vy : numpy.ndarray, optional
         y-component of ice velocity from gridded dataset,
         usually after trimming to flood fill mask. Can be set to ``None``
-        if ``useSpeed == False`` in config file.
+        if ``use_speed == False`` in config file.
     dist_to_edge : numpy.ndarray, optional
         Distance from each cell to ice edge, calculated in separate function.
-        Can be set to ``None`` if ``useDistToEdge == False`` in config file
-        and you do not want to set large cell_width where cells will be culled
-        anyway, but this is not recommended.
+        Can be set to ``None`` if ``use_dist_to_edge == False`` in config file
+        and you do not want to set large ``cell_width`` where cells will be
+        culled anyway, but this is not recommended.
     dist_to_grounding_line : numpy.ndarray, optional
         Distance from each cell to grounding line, calculated in separate
         function.  Can be set to ``None`` if
-        ``useDistToGroundingLine == False`` in config file.
+        ``use_dist_to_grounding_line == False`` in config file.
 
     Returns
     -------
@@ -155,7 +156,8 @@ def set_cell_width(self, section, thk, vx=None, vy=None,
     low_log_speed = float(section.get('low_log_speed'))
     high_dist = float(section.get('high_dist'))
     low_dist = float(section.get('low_dist'))
-    cull_distance = float(section.get('cull_distance')) * 1.e3  # convert km to m
+    # convert km to m
+    cull_distance = float(section.get('cull_distance')) * 1.e3
 
     # Make cell spacing function mapping from log speed to cell spacing
     if section.get('use_speed') == 'True':

--- a/compass/landice/mesh.py
+++ b/compass/landice/mesh.py
@@ -117,20 +117,20 @@ def set_cell_width(self, section, thk, vx=None, vy=None,
     thk : numpy.ndarray
         Ice thickness field from gridded dataset,
         usually after trimming to flood fill mask
-    vx : numpy.ndarray
+    vx : numpy.ndarray, optional
         x-component of ice velocity from gridded dataset,
         usually after trimming to flood fill mask. Can be set to None
         if useSpeed == 'False' in config file.
-    vy : numpy.ndarray
+    vy : numpy.ndarray, optional
         y-component of ice velocity from gridded dataset,
         usually after trimming to flood fill mask. Can be set to None
         if useSpeed == 'False' in config file.
-    distToEdge : numpy.ndarray
+    dist_to_edge : numpy.ndarray, optional
         Distance from each cell to ice edge, calculated in separate function.
         Can be set to None if useDistToEdge == 'False' in config file and you
         do not want to set large cell_width where cells will be culled anyway,
         but this is not recommended.
-    distToGroundingLine : numpy.ndarray
+    dist_to_grounding_line : numpy.ndarray, optional
         Distance from each cell to grounding line, calculated in separate
         function.  Can be set to None if useDistToGroundingLine == 'False'
         in config file.
@@ -164,7 +164,7 @@ def set_cell_width(self, section, thk, vx=None, vy=None,
                             right=minSpac)
         spacing[thk == 0.0] = minSpac
     else:
-        spacing = thk * 0. + maxSpac
+        spacing = maxSpac*np.ones_like(thk)
 
     # Make cell spacing function mapping from distance to ice edge
     if section.get('useDistToEdge') == 'True':
@@ -174,7 +174,7 @@ def set_cell_width(self, section, thk, vx=None, vy=None,
                              right=maxSpac)
         spacing2[thk == 0.0] = minSpac
     else:
-        spacing2 = thk * 0. + maxSpac
+        spacing2 = maxSpac*np.ones_like(thk)
 
     # Make cell spacing function mapping from distance to grounding line
     if section.get('useDistToGroundingLine') == 'True':
@@ -184,7 +184,7 @@ def set_cell_width(self, section, thk, vx=None, vy=None,
                              right=maxSpac)
         spacing3[thk == 0.0] = minSpac
     else:
-        spacing3 = thk * 0. + maxSpac
+        spacing3 = maxSpac*np.ones_like(thk)
 
     # Merge cell spacing methods
     cell_width = np.minimum(spacing, spacing2)

--- a/compass/landice/tests/humboldt/humboldt.cfg
+++ b/compass/landice/tests/humboldt/humboldt.cfg
@@ -7,23 +7,23 @@ levels = 10
 # distance from ice margin to cull (km).
 # Set to a value <= 0 if you do not want
 # to cull based on distance from margin.
-cullDistance = 5.0
+cull_distance = 5.0
 
 # mesh density parameters
 # minimum cell spacing (meters)
-minSpac = 1.e3
+min_spac = 1.e3
 # maximum cell spacing (meters)
-maxSpac = 1.e4
-# log10 of max speed for cell spacing
-highLogSpeed = 2.5
-# log10 of min speed for cell spacing
-lowLogSpeed = 0.75
-# distance at which cell spacing = maxSpac
-highDist = 1.e5
-# distance within which cell spacing = minSpac
-lowDist = 1.e4
+max_spac = 1.e4
+# log10 of max speed (m/yr) for cell spacing
+high_log_speed = 2.5
+# log10 of min speed (m/yr) for cell spacing
+low_log_speed = 0.75
+# distance at which cell spacing = max_spac (meters)
+high_dist = 1.e5
+# distance within which cell spacing = min_spac (meters)
+low_dist = 1.e4
 
 # mesh density functions
-useSpeed = True
-useDistToGroundingLine = False
-useDistToEdge = True
+use_speed = True
+use_dist_to_grounding_line = False
+use_dist_to_edge = True

--- a/compass/landice/tests/humboldt/humboldt.cfg
+++ b/compass/landice/tests/humboldt/humboldt.cfg
@@ -9,3 +9,21 @@ levels = 10
 # to cull based on distance from margin.
 cullDistance = 5.0
 
+# mesh density parameters
+# minimum cell spacing (meters)
+minSpac = 1.e3
+# maximum cell spacing (meters)
+maxSpac = 1.e4
+# log10 of max speed for cell spacing
+highLogSpeed = 2.5
+# log10 of min speed for cell spacing
+lowLogSpeed = 0.75
+# distance at which cell spacing = maxSpac
+highDist = 1.e5
+# distance within which cell spacing = minSpac
+lowDist = 1.e4
+
+# mesh density functions
+useSpeed = True
+useDistToGroundingLine = False
+useDistToEdge = True

--- a/compass/landice/tests/humboldt/mesh.py
+++ b/compass/landice/tests/humboldt/mesh.py
@@ -98,7 +98,7 @@ class Mesh(Step):
         # This step is only necessary if you wish to cull a certain
         # distance from the ice margin, within the bounds defined by
         # the GeoJSON file.
-        cullDistance = section.get('cullDistance')
+        cullDistance = section.get('cull_distance')
         if float(cullDistance) > 0.:
             logger.info('calling define_cullMask.py')
             args = ['define_cullMask.py', '-f',
@@ -269,8 +269,8 @@ class Mesh(Step):
 
         # Set cell widths based on mesh parameters set in config file
         cell_width = set_cell_width(self, section='humboldt', thk=thk,
-                                    vx=vx, vy=vy, distToEdge=distToEdge,
-                                    distToGroundingLine=None)
+                                    vx=vx, vy=vy, dist_to_edge=distToEdge,
+                                    dist_to_grounding_line=None)
 
         # plt.pcolor(cell_width); plt.colorbar(); plt.show()
 

--- a/docs/users_guide/landice/test_groups/humboldt.rst
+++ b/docs/users_guide/landice/test_groups/humboldt.rst
@@ -28,6 +28,25 @@ The test group uses the following default config options:
     # to cull based on distance from margin.
     cullDistance = 5.0
 
+    # mesh density parameters
+    # minimum cell spacing (meters)
+    minSpac = 1.e3
+    # maximum cell spacing (meters)
+    maxSpac = 1.e4
+    # log10 of max speed (m/yr) for cell spacing
+    highLogSpeed = 2.5
+    # log10 of min speed (m/yr) for cell spacing
+    lowLogSpeed = 0.75
+    # distance at which cell spacing = maxSpac (meters)
+    highDist = 1.e5
+    # distance within which cell spacing = minSpac (meters)
+    lowDist = 1.e4
+    
+    # mesh density functions
+    useSpeed = True
+    useDistToGroundingLine = False
+    useDistToEdge = True
+
 default
 -------
 

--- a/docs/users_guide/landice/test_groups/humboldt.rst
+++ b/docs/users_guide/landice/test_groups/humboldt.rst
@@ -26,26 +26,26 @@ The test group uses the following default config options:
     # distance from ice margin to cull (km).
     # Set to a value <= 0 if you do not want
     # to cull based on distance from margin.
-    cullDistance = 5.0
+    cull_distance = 5.0
 
     # mesh density parameters
     # minimum cell spacing (meters)
-    minSpac = 1.e3
+    min_spac = 1.e3
     # maximum cell spacing (meters)
-    maxSpac = 1.e4
+    max_spac = 1.e4
     # log10 of max speed (m/yr) for cell spacing
-    highLogSpeed = 2.5
+    high_log_speed = 2.5
     # log10 of min speed (m/yr) for cell spacing
-    lowLogSpeed = 0.75
-    # distance at which cell spacing = maxSpac (meters)
-    highDist = 1.e5
-    # distance within which cell spacing = minSpac (meters)
-    lowDist = 1.e4
+    low_log_speed = 0.75
+    # distance at which cell spacing = max_spac (meters)
+    high_dist = 1.e5
+    # distance within which cell spacing = min_spac (meters)
+    low_dist = 1.e4
     
     # mesh density functions
-    useSpeed = True
-    useDistToGroundingLine = False
-    useDistToEdge = True
+    use_speed = True
+    use_dist_to_grounding_line = False
+    use_dist_to_edge = True
 
 default
 -------


### PR DESCRIPTION
Create a function to determine cell_width based on input parameters in the config file. This currently contains three different cell spacing functions based on log10(speed), distance to ice edge, and distance to the grounding line that can be turned on or off in the config file. Minimum and maximum cell width and the distances over which cell width is varied are also set in the config file. Implement a use case for Humboldt and update User's Guide. This will be used by all mesh-generating land ice test cases based on real-world geometries.

Note: The mesh created here is not bit-for-bit with the previous version. It is not clear why this is the case, but the differences are trivial.