### PR TITLE
Update to `mache >=1.2.1`

### DIFF
--- a/conda/compass_env/spec-file.template
+++ b/conda/compass_env/spec-file.template
@@ -15,7 +15,7 @@ jigsaw=0.9.14
 jigsawpy=0.3.3
 jupyter
 lxml
-mache >=1.1.4
+mache >=1.2.1
 matplotlib-base
 metis
 mpas_tools=0.13.0

--- a/conda/configure_compass_env.py
+++ b/conda/configure_compass_env.py
@@ -86,7 +86,7 @@ def setup_install_env(activate_base):
     print('Setting up a conda environment for installing compass')
     commands = '{}; ' \
                'mamba create -y -n temp_compass_install ' \
-               'progressbar2 jinja2 "mache>=1.1.4"'.format(activate_base)
+               'progressbar2 jinja2 "mache>=1.2.1"'.format(activate_base)
 
     check_call(commands)
 

--- a/conda/configure_compass_env.py
+++ b/conda/configure_compass_env.py
@@ -82,11 +82,16 @@ def install_miniconda(conda_base, activate_base):
     check_call(commands)
 
 
-def setup_install_env(activate_base):
+def setup_install_env(activate_base, use_local):
+    if use_local:
+        channels = '--use-local'
+    else:
+        channels = ''
     print('Setting up a conda environment for installing compass')
     commands = '{}; ' \
-               'mamba create -y -n temp_compass_install ' \
-               'progressbar2 jinja2 "mache>=1.2.1"'.format(activate_base)
+               'mamba create -y -n temp_compass_install {} ' \
+               'progressbar2 jinja2 "mache>=1.2.1"'.format(activate_base,
+                                                           channels)
 
     check_call(commands)
 
@@ -122,7 +127,7 @@ def main():
     # install miniconda if needed
     install_miniconda(conda_base, activate_base)
 
-    setup_install_env(activate_base)
+    setup_install_env(activate_base, args.use_local)
 
     bootstrap(activate_install_env, source_path)
 

--- a/conda/recipe/meta.yaml
+++ b/conda/recipe/meta.yaml
@@ -51,7 +51,7 @@ requirements:
     - jigsawpy 0.3.3
     - jupyter
     - lxml
-    - mache >=1.1.4
+    - mache >=1.2.1
     - matplotlib-base
     - metis
     - mpas_tools 0.13.0


### PR DESCRIPTION
This version brings in important module update on Cori-Haswell and Chrysalis.

This merge also makes a change that helps with testing `mache`:  In addition to getting packages for the compass env from local builds when `--use_local` is provided, do the same for the temporary install environment so a local build of `mache` can be used.  This allows me to build `mache` locally and use it for making the `compass` conda environment.