### PR TITLE
Increase `config_Redi_min_layers_diag_terms` to 8

### DIFF
--- a/compass/ocean/tests/global_ocean/namelist.forward
+++ b/compass/ocean/tests/global_ocean/namelist.forward
@@ -15,6 +15,7 @@ config_implicit_bottom_drag_coeff = 1.0e-3
 config_use_bulk_wind_stress = .true.
 config_use_bulk_thickness_flux = .true.
 config_use_Redi = .true.
+config_Redi_min_layers_diag_terms = 8
 config_use_GM = .true.
 config_AM_mixedLayerDepths_enable = .true.
 config_AM_mixedLayerDepths_compute_interval = 'dt'


### PR DESCRIPTION
Based on testing with the EC30to60 mesh, this seems necessary to avoid spurious surface temperature extrema.