### PR TITLE
Update module commands and env vars for new mache

### DIFF
--- a/conda/compass_env/load_compass.template
+++ b/conda/compass_env/load_compass.template
@@ -3,8 +3,6 @@ conda activate {{ compass_env }}
 
 {{ update_compass }}
 
-{{ modules }}
+{{ mod_env_commands }}
 
 {{ netcdf_paths }}
-
-{{ env_vars }}

--- a/conda/compass_env/spec-file.template
+++ b/conda/compass_env/spec-file.template
@@ -15,7 +15,7 @@ jigsaw=0.9.14
 jigsawpy=0.3.3
 jupyter
 lxml
-mache >=1.2.1
+mache >=1.3.0
 matplotlib-base
 metis
 mpas_tools=0.13.0

--- a/conda/configure_compass_env.py
+++ b/conda/configure_compass_env.py
@@ -90,7 +90,7 @@ def setup_install_env(activate_base, use_local):
     print('Setting up a conda environment for installing compass')
     commands = '{}; ' \
                'mamba create -y -n temp_compass_install {} ' \
-               'progressbar2 jinja2 "mache>=1.2.1"'.format(activate_base,
+               'progressbar2 jinja2 "mache>=1.3.0"'.format(activate_base,
                                                            channels)
 
     check_call(commands)

--- a/conda/recipe/meta.yaml
+++ b/conda/recipe/meta.yaml
@@ -51,7 +51,7 @@ requirements:
     - jigsawpy 0.3.3
     - jupyter
     - lxml
-    - mache >=1.2.1
+    - mache >=1.3.0
     - matplotlib-base
     - metis
     - mpas_tools 0.13.0


### PR DESCRIPTION
The two are combined and no longer in lists or dictionaries.

This merge also updates to `mache >=1.3.0`.