### PR TITLE
Fix conda package string

### DIFF
--- a/conda/recipe/meta.yaml
+++ b/conda/recipe/meta.yaml
@@ -28,7 +28,7 @@ build:
   # `PKG_NAME * mpi_mpich_*` for mpich
   # `PKG_NAME * mpi_*` for any mpi
   # `PKG_NAME * nompi_*` for no mpi
-  string: "{{ mpi_prefix }}_py_h{{ PKG_HASH }}_{{ build }}"
+  string: "{{ mpi_prefix }}_py{{ CONDA_PY }}h{{ PKG_HASH }}_{{ build }}"
   entry_points:
     - compass = compass.__main__:main
 


### PR DESCRIPTION
This merge adds the python version to the build string so each python version gets its own package, which is necessary given that each package supports only that version of python.