### PR TITLE
Fix out-of-range problem with permissions progress bar

### DIFF
--- a/conda/bootstrap.py
+++ b/conda/bootstrap.py
@@ -540,7 +540,10 @@ def update_permissions(config, is_test, activ_path, conda_base, system_libs):
         for root, dirs, files in os.walk(base):
             for directory in dirs:
                 progress += 1
-                bar.update(progress)
+                try:
+                    bar.update(progress)
+                except ValueError:
+                    pass
 
                 directory = os.path.join(root, directory)
 
@@ -566,7 +569,10 @@ def update_permissions(config, is_test, activ_path, conda_base, system_libs):
 
             for file_name in files:
                 progress += 1
-                bar.update(progress)
+                try:
+                    bar.update(progress)
+                except ValueError:
+                    pass
                 file_name = os.path.join(root, file_name)
                 try:
                     file_stat = os.stat(file_name)


### PR DESCRIPTION
This happens when the number of files or directories changes in the middle of updating permissions on the conda or spack environment (often because the same user or someone else is modifying it).