### PR TITLE
Add dev tools to the conda package

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -46,14 +46,16 @@ jobs:
       eval "$(conda shell.bash hook)"
       # workaround based on recent failures
       rm /usr/share/miniconda/pkgs/cache/*.json
-      conda mambabuild -m ci/mpi_$(mpi)_python${PYTHON_VERSION}.yaml conda/recipe
+      conda mambabuild -m ci/mpi_$(mpi)_python${PYTHON_VERSION}.yaml \
+          -c conda-forge -c e3sm/label/compass conda/recipe
     displayName: Build COMPASS metapackage
 
   - bash: |
       set -e
       eval "$(conda shell.bash hook)"
       mamba create --yes --quiet --name compass -c ${CONDA_PREFIX}/conda-bld/ \
-          python=$PYTHON_VERSION compass  sphinx mock sphinx_rtd_theme m2r
+          -c conda-forge -c e3sm/label/compass python=$PYTHON_VERSION compass \
+          sphinx mock sphinx_rtd_theme m2r2
     displayName: Create compass conda environment
 
   - bash: |
@@ -192,14 +194,15 @@ jobs:
 
   - bash: |
       eval "$(conda shell.bash hook)"
-      conda mambabuild -m ci/mpi_$(mpi)_python${PYTHON_VERSION}.yaml conda/recipe
+      conda mambabuild -m ci/mpi_$(mpi)_python${PYTHON_VERSION}.yaml \
+          -c conda-forge -c e3sm/label/compass conda/recipe
     displayName: Build COMPASS metapackage
 
   - bash: |
       set -e
       eval "$(conda shell.bash hook)"
       mamba create --yes --quiet --name compass -c ${CONDA_PREFIX}/conda-bld/ \
-          python=$PYTHON_VERSION compass
+          -c conda-forge -c e3sm/label/compass python=$PYTHON_VERSION compass
     displayName: Create compass conda environment
 
   - bash: |

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -46,7 +46,7 @@ jobs:
       eval "$(conda shell.bash hook)"
       # workaround based on recent failures
       rm /usr/share/miniconda/pkgs/cache/*.json
-      conda mambabuild -m ci/mpi_$(mpi)_python${PYTHON_VERSION}.yaml \
+      conda mambabuild -m ci/linux_mpi_$(mpi)_python${PYTHON_VERSION}.yaml \
           -c conda-forge -c e3sm/label/compass conda/recipe
     displayName: Build COMPASS metapackage
 
@@ -194,7 +194,7 @@ jobs:
 
   - bash: |
       eval "$(conda shell.bash hook)"
-      conda mambabuild -m ci/mpi_$(mpi)_python${PYTHON_VERSION}.yaml \
+      conda mambabuild -m ci/osx_mpi_$(mpi)_python${PYTHON_VERSION}.yaml \
           -c conda-forge -c e3sm/label/compass conda/recipe
     displayName: Build COMPASS metapackage
 

--- a/ci/generate.py
+++ b/ci/generate.py
@@ -3,13 +3,14 @@
 from jinja2 import Template
 
 
-with open('template.yaml') as f:
-    tempate_test = f.read()
+for os in ['linux', 'osx']:
+    with open(f'template_{os}.yaml') as f:
+        template_test = f.read()
 
-template = Template(tempate_test)
-for python in ['3.7', '3.8', '3.9', '3.10']:
-    for mpi in ['nompi', 'mpich', 'openmpi']:
-        script = template.render(python=python, mpi=mpi)
-        filename = 'mpi_{}_python{}.yaml'.format(mpi, python)
-        with open(filename, 'w') as handle:
-            handle.write(script)
+    template = Template(template_test)
+    for python in ['3.7', '3.8', '3.9', '3.10']:
+        for mpi in ['nompi', 'mpich', 'openmpi']:
+            script = template.render(python=python, mpi=mpi)
+            filename = f'{os}_mpi_{mpi}_python{python}.yaml'
+            with open(filename, 'w') as handle:
+                handle.write(script)

--- a/ci/linux_mpi_mpich_python3.10.yaml
+++ b/ci/linux_mpi_mpich_python3.10.yaml
@@ -1,3 +1,15 @@
+c_compiler:
+- gcc
+c_compiler_version:
+- 10
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- 10
+fortran_compiler:
+- gfortran
+fortran_compiler_version:
+- 10
 hdf5:
 - 1.12.1
 libnetcdf:

--- a/ci/linux_mpi_mpich_python3.7.yaml
+++ b/ci/linux_mpi_mpich_python3.7.yaml
@@ -1,0 +1,26 @@
+c_compiler:
+- gcc
+c_compiler_version:
+- 10
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- 10
+fortran_compiler:
+- gfortran
+fortran_compiler_version:
+- 10
+hdf5:
+- 1.12.1
+libnetcdf:
+- 4.8.1
+mpi:
+- mpich
+netcdf_fortran:
+- 4.5
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.7.* *_cpython

--- a/ci/linux_mpi_mpich_python3.8.yaml
+++ b/ci/linux_mpi_mpich_python3.8.yaml
@@ -1,0 +1,26 @@
+c_compiler:
+- gcc
+c_compiler_version:
+- 10
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- 10
+fortran_compiler:
+- gfortran
+fortran_compiler_version:
+- 10
+hdf5:
+- 1.12.1
+libnetcdf:
+- 4.8.1
+mpi:
+- mpich
+netcdf_fortran:
+- 4.5
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.8.* *_cpython

--- a/ci/linux_mpi_mpich_python3.9.yaml
+++ b/ci/linux_mpi_mpich_python3.9.yaml
@@ -1,3 +1,15 @@
+c_compiler:
+- gcc
+c_compiler_version:
+- 10
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- 10
+fortran_compiler:
+- gfortran
+fortran_compiler_version:
+- 10
 hdf5:
 - 1.12.1
 libnetcdf:

--- a/ci/linux_mpi_nompi_python3.10.yaml
+++ b/ci/linux_mpi_nompi_python3.10.yaml
@@ -1,0 +1,26 @@
+c_compiler:
+- gcc
+c_compiler_version:
+- 10
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- 10
+fortran_compiler:
+- gfortran
+fortran_compiler_version:
+- 10
+hdf5:
+- 1.12.1
+libnetcdf:
+- 4.8.1
+mpi:
+- nompi
+netcdf_fortran:
+- 4.5
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.10.* *_cpython

--- a/ci/linux_mpi_nompi_python3.7.yaml
+++ b/ci/linux_mpi_nompi_python3.7.yaml
@@ -1,0 +1,26 @@
+c_compiler:
+- gcc
+c_compiler_version:
+- 10
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- 10
+fortran_compiler:
+- gfortran
+fortran_compiler_version:
+- 10
+hdf5:
+- 1.12.1
+libnetcdf:
+- 4.8.1
+mpi:
+- nompi
+netcdf_fortran:
+- 4.5
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.7.* *_cpython

--- a/ci/linux_mpi_nompi_python3.8.yaml
+++ b/ci/linux_mpi_nompi_python3.8.yaml
@@ -1,3 +1,15 @@
+c_compiler:
+- gcc
+c_compiler_version:
+- 10
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- 10
+fortran_compiler:
+- gfortran
+fortran_compiler_version:
+- 10
 hdf5:
 - 1.12.1
 libnetcdf:

--- a/ci/linux_mpi_nompi_python3.9.yaml
+++ b/ci/linux_mpi_nompi_python3.9.yaml
@@ -1,3 +1,15 @@
+c_compiler:
+- gcc
+c_compiler_version:
+- 10
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- 10
+fortran_compiler:
+- gfortran
+fortran_compiler_version:
+- 10
 hdf5:
 - 1.12.1
 libnetcdf:

--- a/ci/linux_mpi_openmpi_python3.10.yaml
+++ b/ci/linux_mpi_openmpi_python3.10.yaml
@@ -1,3 +1,15 @@
+c_compiler:
+- gcc
+c_compiler_version:
+- 10
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- 10
+fortran_compiler:
+- gfortran
+fortran_compiler_version:
+- 10
 hdf5:
 - 1.12.1
 libnetcdf:

--- a/ci/linux_mpi_openmpi_python3.7.yaml
+++ b/ci/linux_mpi_openmpi_python3.7.yaml
@@ -1,3 +1,15 @@
+c_compiler:
+- gcc
+c_compiler_version:
+- 10
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- 10
+fortran_compiler:
+- gfortran
+fortran_compiler_version:
+- 10
 hdf5:
 - 1.12.1
 libnetcdf:

--- a/ci/linux_mpi_openmpi_python3.8.yaml
+++ b/ci/linux_mpi_openmpi_python3.8.yaml
@@ -1,3 +1,15 @@
+c_compiler:
+- gcc
+c_compiler_version:
+- 10
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- 10
+fortran_compiler:
+- gfortran
+fortran_compiler_version:
+- 10
 hdf5:
 - 1.12.1
 libnetcdf:

--- a/ci/linux_mpi_openmpi_python3.9.yaml
+++ b/ci/linux_mpi_openmpi_python3.9.yaml
@@ -1,0 +1,26 @@
+c_compiler:
+- gcc
+c_compiler_version:
+- 10
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- 10
+fortran_compiler:
+- gfortran
+fortran_compiler_version:
+- 10
+hdf5:
+- 1.12.1
+libnetcdf:
+- 4.8.1
+mpi:
+- openmpi
+netcdf_fortran:
+- 4.5
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.9.* *_cpython

--- a/ci/mpi_mpich_python3.10.yaml
+++ b/ci/mpi_mpich_python3.10.yaml
@@ -1,5 +1,14 @@
-python:
-- 3.10.* *_cpython
-
+hdf5:
+- 1.12.1
+libnetcdf:
+- 4.8.1
 mpi:
 - mpich
+netcdf_fortran:
+- 4.5
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.10.* *_cpython

--- a/ci/mpi_mpich_python3.7.yaml
+++ b/ci/mpi_mpich_python3.7.yaml
@@ -1,5 +1,14 @@
-python:
-- 3.7.* *_cpython
-
+hdf5:
+- 1.12.1
+libnetcdf:
+- 4.8.1
 mpi:
 - mpich
+netcdf_fortran:
+- 4.5
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.7.* *_cpython

--- a/ci/mpi_mpich_python3.8.yaml
+++ b/ci/mpi_mpich_python3.8.yaml
@@ -1,5 +1,14 @@
-python:
-- 3.8.* *_cpython
-
+hdf5:
+- 1.12.1
+libnetcdf:
+- 4.8.1
 mpi:
 - mpich
+netcdf_fortran:
+- 4.5
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.8.* *_cpython

--- a/ci/mpi_mpich_python3.9.yaml
+++ b/ci/mpi_mpich_python3.9.yaml
@@ -1,5 +1,14 @@
-python:
-- 3.9.* *_cpython
-
+hdf5:
+- 1.12.1
+libnetcdf:
+- 4.8.1
 mpi:
 - mpich
+netcdf_fortran:
+- 4.5
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.9.* *_cpython

--- a/ci/mpi_nompi_python3.10.yaml
+++ b/ci/mpi_nompi_python3.10.yaml
@@ -1,5 +1,14 @@
-python:
-- 3.10.* *_cpython
-
+hdf5:
+- 1.12.1
+libnetcdf:
+- 4.8.1
 mpi:
 - nompi
+netcdf_fortran:
+- 4.5
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.10.* *_cpython

--- a/ci/mpi_nompi_python3.7.yaml
+++ b/ci/mpi_nompi_python3.7.yaml
@@ -1,5 +1,14 @@
-python:
-- 3.7.* *_cpython
-
+hdf5:
+- 1.12.1
+libnetcdf:
+- 4.8.1
 mpi:
 - nompi
+netcdf_fortran:
+- 4.5
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.7.* *_cpython

--- a/ci/mpi_nompi_python3.8.yaml
+++ b/ci/mpi_nompi_python3.8.yaml
@@ -1,5 +1,14 @@
-python:
-- 3.8.* *_cpython
-
+hdf5:
+- 1.12.1
+libnetcdf:
+- 4.8.1
 mpi:
 - nompi
+netcdf_fortran:
+- 4.5
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.8.* *_cpython

--- a/ci/mpi_nompi_python3.9.yaml
+++ b/ci/mpi_nompi_python3.9.yaml
@@ -1,5 +1,14 @@
-python:
-- 3.9.* *_cpython
-
+hdf5:
+- 1.12.1
+libnetcdf:
+- 4.8.1
 mpi:
 - nompi
+netcdf_fortran:
+- 4.5
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.9.* *_cpython

--- a/ci/mpi_openmpi_python3.10.yaml
+++ b/ci/mpi_openmpi_python3.10.yaml
@@ -1,5 +1,14 @@
-python:
-- 3.10.* *_cpython
-
+hdf5:
+- 1.12.1
+libnetcdf:
+- 4.8.1
 mpi:
 - openmpi
+netcdf_fortran:
+- 4.5
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.10.* *_cpython

--- a/ci/mpi_openmpi_python3.7.yaml
+++ b/ci/mpi_openmpi_python3.7.yaml
@@ -1,5 +1,14 @@
-python:
-- 3.7.* *_cpython
-
+hdf5:
+- 1.12.1
+libnetcdf:
+- 4.8.1
 mpi:
 - openmpi
+netcdf_fortran:
+- 4.5
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.7.* *_cpython

--- a/ci/mpi_openmpi_python3.8.yaml
+++ b/ci/mpi_openmpi_python3.8.yaml
@@ -1,5 +1,14 @@
-python:
-- 3.8.* *_cpython
-
+hdf5:
+- 1.12.1
+libnetcdf:
+- 4.8.1
 mpi:
 - openmpi
+netcdf_fortran:
+- 4.5
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.8.* *_cpython

--- a/ci/mpi_openmpi_python3.9.yaml
+++ b/ci/mpi_openmpi_python3.9.yaml
@@ -1,5 +1,14 @@
-python:
-- 3.9.* *_cpython
-
+hdf5:
+- 1.12.1
+libnetcdf:
+- 4.8.1
 mpi:
 - openmpi
+netcdf_fortran:
+- 4.5
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.9.* *_cpython

--- a/ci/osx_mpi_mpich_python3.10.yaml
+++ b/ci/osx_mpi_mpich_python3.10.yaml
@@ -1,0 +1,26 @@
+c_compiler:
+- clang
+c_compiler_version:
+- 12
+cxx_compiler:
+- clangxx
+cxx_compiler_version:
+- 12
+fortran_compiler:
+- gfortran
+fortran_compiler_version:
+- 9
+hdf5:
+- 1.12.1
+libnetcdf:
+- 4.8.1
+mpi:
+- mpich
+netcdf_fortran:
+- 4.5
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.10.* *_cpython

--- a/ci/osx_mpi_mpich_python3.7.yaml
+++ b/ci/osx_mpi_mpich_python3.7.yaml
@@ -1,3 +1,15 @@
+c_compiler:
+- clang
+c_compiler_version:
+- 12
+cxx_compiler:
+- clangxx
+cxx_compiler_version:
+- 12
+fortran_compiler:
+- gfortran
+fortran_compiler_version:
+- 9
 hdf5:
 - 1.12.1
 libnetcdf:

--- a/ci/osx_mpi_mpich_python3.8.yaml
+++ b/ci/osx_mpi_mpich_python3.8.yaml
@@ -1,3 +1,15 @@
+c_compiler:
+- clang
+c_compiler_version:
+- 12
+cxx_compiler:
+- clangxx
+cxx_compiler_version:
+- 12
+fortran_compiler:
+- gfortran
+fortran_compiler_version:
+- 9
 hdf5:
 - 1.12.1
 libnetcdf:

--- a/ci/osx_mpi_mpich_python3.9.yaml
+++ b/ci/osx_mpi_mpich_python3.9.yaml
@@ -1,0 +1,26 @@
+c_compiler:
+- clang
+c_compiler_version:
+- 12
+cxx_compiler:
+- clangxx
+cxx_compiler_version:
+- 12
+fortran_compiler:
+- gfortran
+fortran_compiler_version:
+- 9
+hdf5:
+- 1.12.1
+libnetcdf:
+- 4.8.1
+mpi:
+- mpich
+netcdf_fortran:
+- 4.5
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.9.* *_cpython

--- a/ci/osx_mpi_nompi_python3.10.yaml
+++ b/ci/osx_mpi_nompi_python3.10.yaml
@@ -1,3 +1,15 @@
+c_compiler:
+- clang
+c_compiler_version:
+- 12
+cxx_compiler:
+- clangxx
+cxx_compiler_version:
+- 12
+fortran_compiler:
+- gfortran
+fortran_compiler_version:
+- 9
 hdf5:
 - 1.12.1
 libnetcdf:

--- a/ci/osx_mpi_nompi_python3.7.yaml
+++ b/ci/osx_mpi_nompi_python3.7.yaml
@@ -1,3 +1,15 @@
+c_compiler:
+- clang
+c_compiler_version:
+- 12
+cxx_compiler:
+- clangxx
+cxx_compiler_version:
+- 12
+fortran_compiler:
+- gfortran
+fortran_compiler_version:
+- 9
 hdf5:
 - 1.12.1
 libnetcdf:

--- a/ci/osx_mpi_nompi_python3.8.yaml
+++ b/ci/osx_mpi_nompi_python3.8.yaml
@@ -1,0 +1,26 @@
+c_compiler:
+- clang
+c_compiler_version:
+- 12
+cxx_compiler:
+- clangxx
+cxx_compiler_version:
+- 12
+fortran_compiler:
+- gfortran
+fortran_compiler_version:
+- 9
+hdf5:
+- 1.12.1
+libnetcdf:
+- 4.8.1
+mpi:
+- nompi
+netcdf_fortran:
+- 4.5
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.8.* *_cpython

--- a/ci/osx_mpi_nompi_python3.9.yaml
+++ b/ci/osx_mpi_nompi_python3.9.yaml
@@ -1,0 +1,26 @@
+c_compiler:
+- clang
+c_compiler_version:
+- 12
+cxx_compiler:
+- clangxx
+cxx_compiler_version:
+- 12
+fortran_compiler:
+- gfortran
+fortran_compiler_version:
+- 9
+hdf5:
+- 1.12.1
+libnetcdf:
+- 4.8.1
+mpi:
+- nompi
+netcdf_fortran:
+- 4.5
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.9.* *_cpython

--- a/ci/osx_mpi_openmpi_python3.10.yaml
+++ b/ci/osx_mpi_openmpi_python3.10.yaml
@@ -1,0 +1,26 @@
+c_compiler:
+- clang
+c_compiler_version:
+- 12
+cxx_compiler:
+- clangxx
+cxx_compiler_version:
+- 12
+fortran_compiler:
+- gfortran
+fortran_compiler_version:
+- 9
+hdf5:
+- 1.12.1
+libnetcdf:
+- 4.8.1
+mpi:
+- openmpi
+netcdf_fortran:
+- 4.5
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.10.* *_cpython

--- a/ci/osx_mpi_openmpi_python3.7.yaml
+++ b/ci/osx_mpi_openmpi_python3.7.yaml
@@ -1,0 +1,26 @@
+c_compiler:
+- clang
+c_compiler_version:
+- 12
+cxx_compiler:
+- clangxx
+cxx_compiler_version:
+- 12
+fortran_compiler:
+- gfortran
+fortran_compiler_version:
+- 9
+hdf5:
+- 1.12.1
+libnetcdf:
+- 4.8.1
+mpi:
+- openmpi
+netcdf_fortran:
+- 4.5
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.7.* *_cpython

--- a/ci/osx_mpi_openmpi_python3.8.yaml
+++ b/ci/osx_mpi_openmpi_python3.8.yaml
@@ -1,0 +1,26 @@
+c_compiler:
+- clang
+c_compiler_version:
+- 12
+cxx_compiler:
+- clangxx
+cxx_compiler_version:
+- 12
+fortran_compiler:
+- gfortran
+fortran_compiler_version:
+- 9
+hdf5:
+- 1.12.1
+libnetcdf:
+- 4.8.1
+mpi:
+- openmpi
+netcdf_fortran:
+- 4.5
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.8.* *_cpython

--- a/ci/osx_mpi_openmpi_python3.9.yaml
+++ b/ci/osx_mpi_openmpi_python3.9.yaml
@@ -1,3 +1,15 @@
+c_compiler:
+- clang
+c_compiler_version:
+- 12
+cxx_compiler:
+- clangxx
+cxx_compiler_version:
+- 12
+fortran_compiler:
+- gfortran
+fortran_compiler_version:
+- 9
 hdf5:
 - 1.12.1
 libnetcdf:

--- a/ci/template.yaml
+++ b/ci/template.yaml
@@ -1,5 +1,14 @@
-python:
-- {{ python }}.* *_cpython
-
+hdf5:
+- 1.12.1
+libnetcdf:
+- 4.8.1
 mpi:
 - {{ mpi }}
+netcdf_fortran:
+- 4.5
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- {{ python }}.* *_cpython

--- a/ci/template_linux.yaml
+++ b/ci/template_linux.yaml
@@ -1,0 +1,26 @@
+c_compiler:
+- gcc
+c_compiler_version:
+- 10
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- 10
+fortran_compiler:
+- gfortran
+fortran_compiler_version:
+- 10
+hdf5:
+- 1.12.1
+libnetcdf:
+- 4.8.1
+mpi:
+- {{ mpi }}
+netcdf_fortran:
+- 4.5
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- {{ python }}.* *_cpython

--- a/ci/template_osx.yaml
+++ b/ci/template_osx.yaml
@@ -1,3 +1,15 @@
+c_compiler:
+- clang
+c_compiler_version:
+- 12
+cxx_compiler:
+- clangxx
+cxx_compiler_version:
+- 12
+fortran_compiler:
+- gfortran
+fortran_compiler_version:
+- 9
 hdf5:
 - 1.12.1
 libnetcdf:

--- a/conda/recipe/meta.yaml
+++ b/conda/recipe/meta.yaml
@@ -55,7 +55,6 @@ requirements:
     - matplotlib-base
     - metis
     - mpas_tools 0.13.0
-    - {{ mpi }}  # [mpi != 'nompi']
     - nco
     - netcdf4 * nompi_*
     - numpy
@@ -66,6 +65,21 @@ requirements:
     - scipy
     - shapely
     - xarray
+
+# tools for building MPAS components
+{% if mpi != "nompi" %}
+    - {{ compiler('c') }}
+    - {{ compiler('cxx') }}
+    - {{ compiler('fortran') }}
+    - cmake
+    - libnetcdf * {{ mpi_prefix }}_*
+    - libpnetcdf * {{ mpi_prefix }}_*
+    - m4
+    - make
+    - {{ mpi }}
+    - netcdf-fortran
+    - scorpio * {{ mpi_prefix }}_*
+{% endif %}
 
 test:
   requires:

--- a/conda/recipe/meta.yaml
+++ b/conda/recipe/meta.yaml
@@ -68,10 +68,10 @@ requirements:
 
 # tools for building MPAS components
 {% if mpi != "nompi" %}
-    - {{ compiler('c') }}
-    - {{ compiler('cxx') }}
-    - {{ compiler('fortran') }}
+    - c-compiler
     - cmake
+    - cxx-compiler
+    - fortran-compiler
     - hdf5 * {{ mpi_prefix }}_*
     - libnetcdf * {{ mpi_prefix }}_*
     - libpnetcdf 1.12.2 {{ mpi_prefix }}_*

--- a/conda/recipe/meta.yaml
+++ b/conda/recipe/meta.yaml
@@ -72,13 +72,14 @@ requirements:
     - {{ compiler('cxx') }}
     - {{ compiler('fortran') }}
     - cmake
+    - hdf5 * {{ mpi_prefix }}_*
     - libnetcdf * {{ mpi_prefix }}_*
-    - libpnetcdf * {{ mpi_prefix }}_*
+    - libpnetcdf 1.12.2 {{ mpi_prefix }}_*
     - m4
     - make
     - {{ mpi }}
     - netcdf-fortran
-    - scorpio * {{ mpi_prefix }}_*
+    - scorpio 1.2.2 {{ mpi_prefix }}_*
 {% endif %}
 
 test:


### PR DESCRIPTION
This merge adds the development tools (compilers, netcdf libraries and build tools like cmake) as dependencies of the compass package if using conda-forge MPI.