### PR TITLE
Add load package to compass

### DIFF
--- a/compass/load/__init__.py
+++ b/compass/load/__init__.py
@@ -1,0 +1,66 @@
+import argparse
+import os
+import subprocess
+import sys
+
+from compass import __version__ as compass_version
+from jinja2 import Template
+from importlib import resources
+
+
+def get_conda_base_and_env():
+    if 'CONDA_EXE' in os.environ:
+        conda_exe = os.environ['CONDA_EXE']
+        conda_base = os.path.abspath(
+            os.path.join(conda_exe, '..', '..'))
+    else:
+        raise ValueError('No conda executable detected.')
+
+    if 'CONDA_DEFAULT_ENV' in os.environ:
+        conda_env = os.environ['CONDA_DEFAULT_ENV']
+    else:
+        raise ValueError('No conda environment detected.')
+
+    return conda_base, conda_env
+
+
+def get_mpi():
+
+    for mpi in ['mpich', 'openmpi']:
+        check = subprocess.check_output(
+            ['conda', 'list', 'mpich']).decode('utf-8')
+        if mpi in check:
+            return mpi
+
+    return None
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description='Generate a load script for a Linux or OSX machine')
+    parser.parse_args()
+
+    conda_base, conda_env = get_conda_base_and_env()
+
+    mpi = get_mpi()
+
+    if mpi is None:
+        suffix = ''
+    else:
+        suffix = f'_{mpi}'
+
+    if sys.platform == 'Linux':
+        env_vars = 'export MPAS_EXTERNAL_LIBS="-lgomp"'
+    else:
+        env_vars = ''
+
+    script_filename = f'load_compass_{compass_version}{suffix}.sh'
+    script_filename = os.path.abspath(script_filename)
+
+    template = Template(resources.read_text(
+        'compass.load', 'load_script.template'))
+    text = template.render(conda_base=conda_base, conda_env=conda_env,
+                           env_vars=env_vars, load_script=script_filename)
+
+    with open(script_filename, 'w') as handle:
+        handle.write(text)

--- a/compass/load/load_script.template
+++ b/compass/load/load_script.template
@@ -1,0 +1,12 @@
+source {{ conda_base }}/etc/profile.d/conda.sh
+conda activate {{ conda_env }}
+
+export NETCDF=$(dirname $(dirname $(which nc-config)))
+export NETCDFF=$(dirname $(dirname $(which nf-config)))
+export PNETCDF=$(dirname $(dirname $(which pnetcdf-config)))
+
+{{ env_vars }}
+export PIO={{ conda_base}}/envs/{{ conda_env }}
+export USE_PIO2=true
+export HDF5_USE_FILE_LOCKING=FALSE
+export LOAD_COMPASS_ENV={{ load_script }}

--- a/conda/recipe/meta.yaml
+++ b/conda/recipe/meta.yaml
@@ -31,6 +31,7 @@ build:
   string: "{{ mpi_prefix }}_py{{ CONDA_PY }}h{{ PKG_HASH }}_{{ build }}"
   entry_points:
     - compass = compass.__main__:main
+    - create_compass_load_script = compass.load:main
 
 requirements:
   host:

--- a/setup.py
+++ b/setup.py
@@ -79,4 +79,5 @@ setup(name='compass',
       package_data={'': data_files},
       install_requires=install_requires,
       entry_points={'console_scripts':
-                    ['compass = compass.__main__:main']})
+                    ['compass = compass.__main__:main',
+                     'create_compass_load_script=compass.load:main']})


### PR DESCRIPTION
The `compass.load` package and the `create_compass_load_script` command-line tool can be used to generate a load script when `compass` is installed as a conda package, rather than cloning the git repository.