### PR TITLE
A few more small fixes to the User's Guide

### DIFF
--- a/docs/users_guide/machines/cori.rst
+++ b/docs/users_guide/machines/cori.rst
@@ -3,15 +3,6 @@ Cori
 
 login: ``ssh $my_username@cori.nersc.gov``
 
-compass environment:
-
-.. code-block:: bash
-
-    source /global/cfs/cdirs/e3sm/software/anaconda_envs/load_latest_compass.sh
-
-example compass config file:
-`general.config.ocean_cori <https://gist.github.com/mark-petersen/c61095d65216415ee0bb62a76da3c6cb>`_
-
 interactive login:
 
 .. code-block:: bash

--- a/docs/users_guide/machines/grizzly.rst
+++ b/docs/users_guide/machines/grizzly.rst
@@ -120,11 +120,6 @@ setting up test cases or a test suite:
 grizzly, gnu
 ------------
 
-.. note::
-
-    Compass 1.0.0 has not yet been released.  The following will apply after
-    the release.
-
 To load the compass environment and modules, and set appropriate environment
 variables:
 
@@ -146,11 +141,6 @@ or
 
 grizzly, intel
 --------------
-
-.. note::
-
-    Compass 1.0.0 has not yet been released.  The following will apply after
-    the release.
 
 To load the compass environment and modules, and set appropriate environment
 variables:

--- a/docs/users_guide/machines/grizzly.rst
+++ b/docs/users_guide/machines/grizzly.rst
@@ -131,13 +131,7 @@ To build the MPAS model with
 
 .. code-block:: bash
 
-    make CORE=landice gfortran
-
-or
-
-.. code-block:: bash
-
-    make CORE=ocean gfortran
+    make gfortran
 
 grizzly, intel
 --------------
@@ -153,10 +147,4 @@ To build the MPAS model with
 
 .. code-block:: bash
 
-    make CORE=landice intel-mpi
-
-or
-
-.. code-block:: bash
-
-    make CORE=ocean intel-mpi
+    make intel-mpi

--- a/docs/users_guide/machines/grizzly.rst
+++ b/docs/users_guide/machines/grizzly.rst
@@ -64,17 +64,6 @@ Archiving
 
 * you can just copy files directly into here for a particular project.
 
-git and compass environment, for all LANL IC machines:
-
-.. code-block:: bash
-
-    module load git
-    module use /usr/projects/climate/SHARED_CLIMATE/modulefiles/all/
-    module unload python
-    source /usr/projects/climate/SHARED_CLIMATE/anaconda_envs/load_latest_compass.sh
-
-Example compass config file for LANL IC: ``general.config.ocean_turq``
-
 LANL uses slurm. To obtain an interactive node:
 
 .. code-block:: bash


### PR DESCRIPTION
This merge removes some instructions that are valid for legacy compass, not the 1.0.0 release.  It also removes the remaining warning notes about the user's guide not being valid until a release is made.