### PR TITLE
Add a customized config parser

### DIFF
--- a/compass/cache.py
+++ b/compass/cache.py
@@ -4,11 +4,10 @@ import sys
 from datetime import datetime
 import os
 from importlib import resources
-import configparser
 import shutil
 import pickle
 
-from compass.config import add_config
+from compass.config import CompassConfigParser
 
 
 def update_cache(step_paths, date_string=None, dry_run=False):
@@ -39,9 +38,8 @@ def update_cache(step_paths, date_string=None, dry_run=False):
     if invalid:
         raise ValueError('You must cache files from either Anvil or Chrysalis')
 
-    config = configparser.ConfigParser(
-        interpolation=configparser.ExtendedInterpolation())
-    add_config(config, 'compass.machines', '{}.cfg'.format(machine))
+    config = CompassConfigParser()
+    config.add_from_package('compass.machines', '{}.cfg'.format(machine))
 
     if date_string is None:
         date_string = datetime.now().strftime("%y%m%d")

--- a/compass/config.py
+++ b/compass/config.py
@@ -219,6 +219,8 @@ class CompassConfigParser:
             A comment to include with the config option when it is written
             to a file
         """
+        section = section.lower()
+        option = option.lower()
         calling_frame = inspect.stack(context=2)[1]
         filename = os.path.abspath(calling_frame.filename)
         if filename not in self._configs:
@@ -232,6 +234,7 @@ class CompassConfigParser:
         self._sources = None
         if filename not in self._comments:
             self._comments[filename] = dict()
+        comment = ''.join([f'# {line}\n' for line in comment.split('\n')])
         self._comments[filename][(section, option)] = comment
 
     def write(self, fp, include_sources=True, include_comments=True):

--- a/compass/config.py
+++ b/compass/config.py
@@ -199,7 +199,7 @@ class CompassConfigParser:
             self._combine()
         return self._combined.has_option(section, option)
 
-    def set(self, section, option, value=None, comment=''):
+    def set(self, section, option, value=None, comment=None):
         """
         Set the value of the given option in the given section.  The file from
          which this function was called is also retained for provenance.
@@ -234,7 +234,10 @@ class CompassConfigParser:
         self._sources = None
         if filename not in self._comments:
             self._comments[filename] = dict()
-        comment = ''.join([f'# {line}\n' for line in comment.split('\n')])
+        if comment is None:
+            comment = ''
+        else:
+            comment = ''.join([f'# {line}\n' for line in comment.split('\n')])
         self._comments[filename][(section, option)] = comment
 
     def write(self, fp, include_sources=True, include_comments=True):

--- a/compass/config.py
+++ b/compass/config.py
@@ -1,119 +1,290 @@
+from configparser import RawConfigParser, ConfigParser, ExtendedInterpolation
 import os
-import configparser
-from io import StringIO
 from importlib import resources
+import inspect
 
 
-def duplicate_config(config):
+class CompassConfigParser:
     """
-    Make a deep copy of config to changes can be made without affecting the
-    original
-
-    Parameters
-    ----------
-    config : configparser.ConfigParser
-        Configuration options
-
-    Returns
-    -------
-    new_config : configparser.ConfigParser
-        Deep copy of configuration options
+    A "meta" config parser that keeps a dictionary of config parsers and their
+    sources to combine when needed.  The custom config parser allows provenance
+    of the source of different config options and allows the "user" config
+    options to always take precedence over other config options (even if they
+    are added later).
     """
+    def __init__(self):
+        """
+        Make a new (empty) config parser
+        """
 
-    config_string = StringIO()
-    config.write(config_string)
-    # We must reset the buffer to make it ready for reading.
-    config_string.seek(0)
-    new_config = configparser.ConfigParser(
-        interpolation=configparser.ExtendedInterpolation())
-    new_config.read_file(config_string)
-    return new_config
+        self._configs = dict()
+        self._user_config = dict()
+        self._combined = None
 
+    def add_user_config(self, filename):
+        """
+        Add a the contents of a user config file to the parser.  These options
+        take precedence over all other options.
 
-def add_config(config, package, config_file, exception=True):
-    """
-    Add the contents of a config file within a package to the current config
-    parser
+        Parameters
+        ----------
+        filename : str
+            The relative or absolute path to the config file
+        """
+        self._add(filename, user=True)
 
-    Parameters
-    ----------
-    config : configparser.ConfigParser
-        Configuration options
+    def add_from_file(self, filename):
+        """
+        Add the contents of a config file to the parser.
 
-    package : str or Package
-        The package where ``config_file`` is found
+        Parameters
+        ----------
+        filename : str
+            The relative or absolute path to the config file
+        """
+        self._add(filename, user=False)
 
-    config_file : str
-        The name of the config file to add
+    def add_from_package(self, package, config_filename, exception=True):
+        """
+        Add the contents of a config file to the parser.
 
-    exception : bool
-        Whether to raise an exception if the config file isn't found
-    """
-    try:
-        with resources.path(package, config_file) as path:
-            config.read(path)
-    except (ModuleNotFoundError, FileNotFoundError, TypeError):
-        if exception:
-            raise
+        Parameters
+        ----------
+        package : str or Package
+            The package where ``config_filename`` is found
 
+        config_filename : str
+            The name of the config file to add
 
-def merge_other_config(config, other_config):
-    """
-    Add config options from the other config parser to this one
+        exception : bool, optional
+            Whether to raise an exception if the config file isn't found
+        """
+        try:
+            with resources.path(package, config_filename) as path:
+                self._add(path, user=False)
+        except (ModuleNotFoundError, FileNotFoundError, TypeError):
+            if exception:
+                raise
 
-    Parameters
-    ----------
-    config : configparser.ConfigParser
-        Configuration options
+    def get(self, section, option):
+        """
+        Get an option value for a given section.
 
-    other_config : configparser.ConfigParser
-        Configuration options to add
-    """
-    for section in other_config.sections():
+        Parameters
+        ----------
+        section : str
+            The name of the config section
+
+        option : str
+            The name of the config option
+
+        Returns
+        -------
+        value : str
+            The value of the config option
+        """
+        if self._combined is None:
+            self._combine()
+        return self._combined.get(section, option)
+
+    def getint(self, section, option):
+        """
+        Get an option integer value for a given section.
+
+        Parameters
+        ----------
+        section : str
+            The name of the config section
+
+        option : str
+            The name of the config option
+
+        Returns
+        -------
+        value : int
+            The value of the config option
+        """
+        if self._combined is None:
+            self._combine()
+        return self._combined.getint(section, option)
+
+    def getfloat(self, section, option):
+        """
+        Get an option float value for a given section.
+
+        Parameters
+        ----------
+        section : str
+            The name of the config section
+
+        option : str
+            The name of the config option
+
+        Returns
+        -------
+        value : float
+            The value of the config option
+        """
+        if self._combined is None:
+            self._combine()
+        return self._combined.getfloat(section, option)
+
+    def getboolean(self, section, option):
+        """
+        Get an option boolean value for a given section.
+
+        Parameters
+        ----------
+        section : str
+            The name of the config section
+
+        option : str
+            The name of the config option
+
+        Returns
+        -------
+        value : bool
+            The value of the config option
+        """
+        if self._combined is None:
+            self._combine()
+        return self._combined.getboolean(section, option)
+
+    def getlist(self, section, option, dtype=str):
+        """
+        Get an option value as a list for a given section.
+
+        Parameters
+        ----------
+        section : str
+            The name of the config section
+
+        option : str
+            The name of the config option
+
+        dtype : {Type[str], Type[int], Type[float]}
+            The type of the elements in the list
+
+        Returns
+        -------
+        value : list
+            The value of the config option parsed into a list
+        """
+        values = self.get(section, option)
+        values = [dtype(value) for value in values.replace(',', ' ').split()]
+        return values
+
+    def has_option(self, section, option):
+        """
+        Whether the given section has the given option
+
+        Parameters
+        ----------
+        section : str
+            The name of the config section
+
+        option : str
+            The name of the config option
+
+        Returns
+        -------
+        found : bool
+            Whether the option was found in the section
+        """
+        if self._combined is None:
+            self._combine()
+        return self._combined.has_option(section, option)
+
+    def set(self, section, option, value=None):
+        """
+        Set the value of the given option in the given section.  The file from
+         which this function was called is also retained for provenance.
+
+        Parameters
+        ----------
+        section : str
+            The name of the config section
+
+        option : str
+            The name of the config option
+
+        value : str, optional
+            The value to set the option to
+        """
+        calling_frame = inspect.stack(context=2)[1]
+        filename = os.path.abspath(calling_frame.filename)
+        if filename not in self._configs:
+            self._configs[filename] = RawConfigParser()
+        config = self._configs[filename]
         if not config.has_section(section):
             config.add_section(section)
-        for key, value in other_config.items(section):
-            config.set(section, key, value)
+        config.set(section, option, value)
+        self._combined = None
 
+    def write(self, fp):
+        """
+        Write the config options to the given file pointer.
 
-def ensure_absolute_paths(config):
-    """
-    make sure all paths in the paths, namelists and streams sections are
-    absolute paths
+        Parameters
+        ----------
+        fp : typing.TestIO
+            The file pointer to write to.
+        """
+        if self._combined is None:
+            self._combine()
+        self._combined.write(fp)
 
-    Parameters
-    ----------
-    config : configparser.ConfigParser
-        Configuration options
-    """
-    for section in ['paths', 'namelists', 'streams', 'executables']:
-        for option, value in config.items(section):
-            value = os.path.abspath(value)
-            config.set(section, option, value)
+    def __getitem__(self, section):
+        """
+        Get get the config options for a given section.
 
+        Parameters
+        ----------
+        section : str
+            The name of the section to retrieve.
 
-def get_source_file(source_path, source, config):
-    """
-    Get an absolute path given a tag name for that path
+        Returns
+        -------
+        section_proxy : configparser.SectionProxy
+            The config options for the given section.
+        """
+        if self._combined is None:
+            self._combine()
+        return self._combined[section]
 
-    Parameters
-    ----------
-    source_path : str
-        The keyword path for a path as defined in :ref:`dev_config`,
-        a config option from a relative or absolute directory for the source
+    def _add(self, filename, user):
+        filename = os.path.abspath(filename)
+        config = RawConfigParser()
+        if not os.path.exists(filename):
+            raise FileNotFoundError(f'Config file does not exist: {filename}')
+        config.read(filenames=filename)
+        if user:
+            self._user_config = {filename: config}
+        else:
+            self._configs[filename] = config
+        self._combined = None
 
-    source : str
-        The basename or relative path of the source within the ``source_path``
-        directory
+    def _combine(self):
+        self._combined = ConfigParser(interpolation=ExtendedInterpolation())
+        configs = dict(self._configs)
+        configs.update(self._user_config)
+        for source, config in configs.items():
+            for section in config.sections():
+                if not self._combined.has_section(section):
+                    self._combined.add_section(section)
+                for key, value in config.items(section):
+                    self._combined.set(section, key, value)
+        self._ensure_absolute_paths()
 
-    config : configparser.ConfigParser
-        Configuration options used to determine the the absolute paths for the
-        given ``source_path``
-    """
-
-    if config.has_option('paths', source_path):
-        source_path = config.get('paths', source_path)
-
-    source_file = '{}/{}'.format(source_path, source)
-    source_file = os.path.abspath(source_file)
-    return source_file
+    def _ensure_absolute_paths(self):
+        """
+        make sure all paths in the paths, namelists, streams, and executables
+        sections are absolute paths
+        """
+        config = self._combined
+        for section in ['paths', 'namelists', 'streams', 'executables']:
+            if not config.has_section(section):
+                continue
+            for option, value in config.items(section):
+                value = os.path.abspath(value)
+                config.set(section, option, value)

--- a/compass/config.py
+++ b/compass/config.py
@@ -20,6 +20,7 @@ class CompassConfigParser:
         self._configs = dict()
         self._user_config = dict()
         self._combined = None
+        self._sources = None
 
     def add_user_config(self, filename):
         """
@@ -221,7 +222,7 @@ class CompassConfigParser:
         config.set(section, option, value)
         self._combined = None
 
-    def write(self, fp):
+    def write(self, fp, include_sources=True):
         """
         Write the config options to the given file pointer.
 
@@ -229,10 +230,23 @@ class CompassConfigParser:
         ----------
         fp : typing.TestIO
             The file pointer to write to.
+
+        include_sources : bool, optional
+            Whether to include a comment above each option indicating the
+            source file where it was defined
         """
         if self._combined is None:
             self._combine()
-        self._combined.write(fp)
+        for section in self._combined.sections():
+            section_items = self._combined.items(section=section)
+            fp.write(f'[{section}]\n')
+            for key, value in section_items:
+                if include_sources:
+                    source = self._sources[(section, key)]
+                    fp.write(f'# source: {source}\n')
+                value = str(value).replace('\n', '\n\t')
+                fp.write(f'{key} = {value}\n')
+            fp.write('\n')
 
     def __getitem__(self, section):
         """
@@ -268,11 +282,13 @@ class CompassConfigParser:
         self._combined = ConfigParser(interpolation=ExtendedInterpolation())
         configs = dict(self._configs)
         configs.update(self._user_config)
+        self._sources = dict()
         for source, config in configs.items():
             for section in config.sections():
                 if not self._combined.has_section(section):
                     self._combined.add_section(section)
                 for key, value in config.items(section):
+                    self._sources[(section, key)] = source
                     self._combined.set(section, key, value)
         self._ensure_absolute_paths()
 

--- a/compass/io.py
+++ b/compass/io.py
@@ -18,7 +18,7 @@ def download(url, dest_path, config, exceptions=True):
         The path (including file name) where the downloaded file should be
         saved
 
-    config : configparser.ConfigParser
+    config : compass.config.CompassConfigParser
         Configuration options used to find custom paths if ``dest_path`` is
         a config option
 

--- a/compass/landice/tests/circular_shelf/setup_mesh.py
+++ b/compass/landice/tests/circular_shelf/setup_mesh.py
@@ -81,7 +81,7 @@ def _setup_circular_shelf_initial_conditions(config, logger, filename):
 
     Parameters
     ----------
-    config : configparser.ConfigParser
+    config : compass.config.CompassConfigParser
         Configuration options for this test case, a combination of the defaults
         for the machine, core and configuration
 

--- a/compass/landice/tests/circular_shelf/visualize.py
+++ b/compass/landice/tests/circular_shelf/visualize.py
@@ -58,7 +58,7 @@ def visualize_circular_shelf(config, logger, filename):
 
     Parameters
     ----------
-    config : configparser.ConfigParser
+    config : compass.config.CompassConfigParser
         Configuration options for this test case, a combination of the defaults
         for the machine, core and configuration
 

--- a/compass/landice/tests/dome/setup_mesh.py
+++ b/compass/landice/tests/dome/setup_mesh.py
@@ -91,7 +91,7 @@ def _setup_dome_initial_conditions(config, logger, filename):
 
     Parameters
     ----------
-    config : configparser.ConfigParser
+    config : compass.config.CompassConfigParser
         Configuration options for this test case, a combination of the defaults
         for the machine, core and configuration
 

--- a/compass/landice/tests/dome/visualize.py
+++ b/compass/landice/tests/dome/visualize.py
@@ -61,7 +61,7 @@ def visualize_dome(config, logger, filename):
 
     Parameters
     ----------
-    config : configparser.ConfigParser
+    config : compass.config.CompassConfigParser
         Configuration options for this test case, a combination of the defaults
         for the machine, core and configuration
 

--- a/compass/landice/tests/eismint2/standard_experiments/visualize.py
+++ b/compass/landice/tests/eismint2/standard_experiments/visualize.py
@@ -51,7 +51,7 @@ def visualize_eismint2(config, logger, experiment):
 
     Parameters
     ----------
-    config : configparser.ConfigParser
+    config : compass.config.CompassConfigParser
         Configuration options for this test case, a combination of the defaults
         for the machine, core and configuration
 

--- a/compass/landice/tests/hydro_radial/visualize.py
+++ b/compass/landice/tests/hydro_radial/visualize.py
@@ -57,7 +57,7 @@ def visualize_hydro_radial(config, logger):
 
     Parameters
     ----------
-    config : configparser.ConfigParser
+    config : compass.config.CompassConfigParser
         Configuration options for this test case, a combination of the defaults
         for the machine, core and configuration
 

--- a/compass/model.py
+++ b/compass/model.py
@@ -76,7 +76,7 @@ def partition(cores, config, logger, graph_file='graph.info'):
     cores : int
         The number of cores that the model should be run on
 
-    config : configparser.ConfigParser
+    config : compass.config.CompassConfigParser
         Configuration options for the test case, used to get the partitioning
         executable
 

--- a/compass/ocean/plot.py
+++ b/compass/ocean/plot.py
@@ -132,7 +132,7 @@ def plot_vertical_grid(grid_filename, config,
     grid_filename : str
         The name of the NetCDF file containing the vertical grid
 
-    config : configparser.ConfigParser
+    config : compass.config.CompassConfigParser
         Configuration options for the vertical grid
 
     out_filename : str, optional

--- a/compass/ocean/tests/baroclinic_channel/__init__.py
+++ b/compass/ocean/tests/baroclinic_channel/__init__.py
@@ -53,9 +53,14 @@ def configure(resolution, config):
                           'ny': 500,
                           'dc': 1e3}}
 
+    comment = {'nx': 'the number of mesh cells in the x direction',
+               'ny': 'the number of mesh cells in the y direction',
+               'dc': 'the distance between adjacent cell centers'}
+
     if resolution not in res_params:
-        raise ValueError('Unsupported resolution {}. Supported values are: '
-                         '{}'.format(resolution, list(res_params)))
+        raise ValueError(f'Unsupported resolution {resolution}. Supported '
+                         f'values are: {list(res_params)}')
     res_params = res_params[resolution]
     for param in res_params:
-        config.set('baroclinic_channel', param, '{}'.format(res_params[param]))
+        config.set('baroclinic_channel', param, str(res_params[param]),
+                   comment=comment[param])

--- a/compass/ocean/tests/baroclinic_channel/__init__.py
+++ b/compass/ocean/tests/baroclinic_channel/__init__.py
@@ -40,7 +40,7 @@ def configure(resolution, config):
     resolution : str
         The resolution of the test case
 
-    config : configparser.ConfigParser
+    config : compass.config.CompassConfigParser
         Configuration options for this test case
     """
     res_params = {'10km': {'nx': 16,

--- a/compass/ocean/tests/global_convergence/cosine_bell/__init__.py
+++ b/compass/ocean/tests/global_convergence/cosine_bell/__init__.py
@@ -1,6 +1,4 @@
-import configparser
-
-from compass.config import add_config
+from compass.config import CompassConfigParser
 from compass.testcase import TestCase
 
 from compass.ocean.tests.global_convergence.cosine_bell.mesh import Mesh
@@ -31,9 +29,8 @@ class CosineBell(TestCase):
         self.resolutions = None
 
         # add the steps with default resolutions so they can be listed
-        config = configparser.ConfigParser(
-            interpolation=configparser.ExtendedInterpolation())
-        add_config(config, self.__module__, '{}.cfg'.format(self.name))
+        config = CompassConfigParser()
+        config.add_from_package(self.__module__, '{}.cfg'.format(self.name))
         self._setup_steps(config)
 
     def configure(self):

--- a/compass/ocean/tests/global_convergence/cosine_bell/__init__.py
+++ b/compass/ocean/tests/global_convergence/cosine_bell/__init__.py
@@ -30,7 +30,7 @@ class CosineBell(TestCase):
 
         # add the steps with default resolutions so they can be listed
         config = CompassConfigParser()
-        config.add_from_package(self.__module__, '{}.cfg'.format(self.name))
+        config.add_from_package(self.__module__, f'{self.name}.cfg')
         self._setup_steps(config)
 
     def configure(self):
@@ -44,7 +44,7 @@ class CosineBell(TestCase):
         init_options = dict()
         for option in ['temperature', 'salinity', 'lat_center', 'lon_center',
                        'radius', 'psi0', 'vel_pd']:
-            init_options['config_cosine_bell_{}'.format(option)] = \
+            init_options[f'config_cosine_bell_{option}'] = \
                 config.get('cosine_bell', option)
 
         for step in self.steps.values():
@@ -59,11 +59,10 @@ class CosineBell(TestCase):
         """
         config = self.config
         for resolution in self.resolutions:
-            cores = config.getint('cosine_bell',
-                                  'QU{}_cores'.format(resolution))
+            cores = config.getint('cosine_bell', f'QU{resolution}_cores')
             min_cores = config.getint('cosine_bell',
-                                      'QU{}_min_cores'.format(resolution))
-            step = self.steps['QU{}_forward'.format(resolution)]
+                                      f'QU{resolution}_min_cores')
+            step = self.steps[f'QU{resolution}_forward']
             step.cores = cores
             step.min_cores = min_cores
 
@@ -90,14 +89,15 @@ class CosineBell(TestCase):
             # In a pinch, about 3000 cells per core
             min_cores = max(1,
                             round(approx_cells / max_cells_per_core))
-            step = self.steps['QU{}_forward'.format(resolution)]
+            step = self.steps[f'QU{resolution}_forward']
             step.cores = cores
             step.min_cores = min_cores
 
-            config.set('cosine_bell', 'QU{}_cores'.format(resolution),
-                       str(cores))
-            config.set('cosine_bell', 'QU{}_min_cores'.format(resolution),
-                       str(min_cores))
+            config.set('cosine_bell', f'QU{resolution}_cores', str(cores),
+                       comment=f'Target core count for {resolution} km mesh')
+            config.set('cosine_bell', f'QU{resolution}_min_cores',
+                       str(min_cores),
+                       comment=f'Minimum core count for {resolution} km mesh')
 
     def _setup_steps(self, config):
         """ setup steps given resolutions """

--- a/compass/ocean/tests/global_convergence/cosine_bell/__init__.py
+++ b/compass/ocean/tests/global_convergence/cosine_bell/__init__.py
@@ -101,9 +101,7 @@ class CosineBell(TestCase):
 
     def _setup_steps(self, config):
         """ setup steps given resolutions """
-        resolutions = config.get('cosine_bell', 'resolutions')
-        resolutions = [int(resolution) for resolution in
-                       resolutions.replace(',', ' ').split()]
+        resolutions = config.getlist('cosine_bell', 'resolutions', dtype=int)
 
         if self.resolutions is not None and self.resolutions == resolutions:
             return

--- a/compass/ocean/tests/global_ocean/configure.py
+++ b/compass/ocean/tests/global_ocean/configure.py
@@ -1,4 +1,3 @@
-from compass.config import add_config
 from compass.ocean.tests.global_ocean.metadata import \
     get_author_and_email_from_git
 
@@ -20,8 +19,8 @@ def configure_global_ocean(test_case, mesh, init=None):
     """
     config = test_case.config
     mesh_step = mesh.mesh_step
-    add_config(config, mesh_step.package, mesh_step.mesh_config_filename,
-               exception=True)
+    config.add_from_package(mesh_step.package, mesh_step.mesh_config_filename,
+                            exception=True)
 
     if mesh.with_ice_shelf_cavities:
         config.set('global_ocean', 'prefix', '{}wISC'.format(

--- a/compass/ocean/tests/global_ocean/files_for_e3sm/diagnostics_files.py
+++ b/compass/ocean/tests/global_ocean/files_for_e3sm/diagnostics_files.py
@@ -74,7 +74,7 @@ def make_diagnostics_files(config, logger, mesh_short_name,
 
     Parameters
     ----------
-    config : configparser.ConfigParser
+    config : compass.config.CompassConfigParser
         Configuration options for this test case
 
     logger : logging.Logger

--- a/compass/ocean/tests/global_ocean/make_diagnostics_files/__init__.py
+++ b/compass/ocean/tests/global_ocean/make_diagnostics_files/__init__.py
@@ -1,6 +1,5 @@
 import os
 
-from compass.config import add_config
 from compass.io import symlink
 from compass.testcase import TestCase
 from compass.step import Step
@@ -30,9 +29,9 @@ class MakeDiagnosticsFiles(TestCase):
         """
         Modify the configuration options for this test case
         """
-        add_config(self.config,
-                   'compass.ocean.tests.global_ocean.make_diagnostics_files',
-                   'make_diagnostics_files.cfg', exception=True)
+        self.config.add_from_package(
+           'compass.ocean.tests.global_ocean.make_diagnostics_files',
+           'make_diagnostics_files.cfg', exception=True)
 
     def run(self):
         """

--- a/compass/ocean/tests/global_ocean/metadata.py
+++ b/compass/ocean/tests/global_ocean/metadata.py
@@ -13,7 +13,7 @@ def get_author_and_email_from_git(config):
 
     Parameters
     ----------
-    config : configparser.ConfigParser
+    config : compass.config.CompassConfigParser
         Configuration options for this test case
     """
     author = config.get('global_ocean', 'author')
@@ -49,7 +49,7 @@ def get_e3sm_mesh_names(config, levels):
 
     Parameters
     ----------
-    config : configparser.ConfigParser
+    config : compass.config.CompassConfigParser
         Configuration options for this test case
 
     levels : int
@@ -64,10 +64,10 @@ def get_e3sm_mesh_names(config, levels):
         The long E3SM name of the ocean and sea-ice mesh
     """
 
+    config.set('global_ocean', 'levels', '{}'.format(levels))
     mesh_prefix = config.get('global_ocean', 'prefix')
     min_res = config.get('global_ocean', 'min_res')
     max_res = config.get('global_ocean', 'max_res')
-    config.set('global_ocean', 'levels', '{}'.format(levels))
     e3sm_version = config.get('global_ocean', 'e3sm_version')
     mesh_revision = config.get('global_ocean', 'mesh_revision')
 
@@ -94,7 +94,7 @@ def add_mesh_and_init_metadata(output_filenames, config, init_filename):
     output_filenames : list
         A list of output files.
 
-    config : configparser.ConfigParser
+    config : compass.config.CompassConfigParser
         Configuration options for this test case
 
     init_filename : str

--- a/compass/ocean/tests/ice_shelf_2d/__init__.py
+++ b/compass/ocean/tests/ice_shelf_2d/__init__.py
@@ -36,7 +36,7 @@ def configure(resolution, coord_type, config):
     coord_type : str
         The type of vertical coordinate (``z-star``, ``z-level``, etc.)
 
-    config : configparser.ConfigParser
+    config : compass.config.CompassConfigParser
         Configuration options for this test case
     """
     res_params = {'5km': {'nx': 10, 'ny': 44, 'dc': 5e3}}

--- a/compass/ocean/tests/planar_convergence/conv_test_case.py
+++ b/compass/ocean/tests/planar_convergence/conv_test_case.py
@@ -1,6 +1,4 @@
-import configparser
-
-from compass.config import add_config
+from compass.config import CompassConfigParser
 from compass.testcase import TestCase
 from compass.ocean.tests.planar_convergence.forward import \
     Forward
@@ -31,10 +29,9 @@ class ConvTestCase(TestCase):
         self.resolutions = None
 
         # add the steps with default resolutions so they can be listed
-        config = configparser.ConfigParser(
-            interpolation=configparser.ExtendedInterpolation())
+        config = CompassConfigParser()
         module = 'compass.ocean.tests.planar_convergence'
-        add_config(config, module, 'planar_convergence.cfg')
+        config.add_from_package(module, 'planar_convergence.cfg')
         self._setup_steps(config)
 
     def configure(self):
@@ -104,7 +101,7 @@ class ConvTestCase(TestCase):
 
         Parameters
         ----------
-        config : configparser.ConfigParse
+        config : compass.config.CompassConfigParser
             The config options containing the resolutions
         """
 

--- a/compass/ocean/tests/planar_convergence/conv_test_case.py
+++ b/compass/ocean/tests/planar_convergence/conv_test_case.py
@@ -105,9 +105,8 @@ class ConvTestCase(TestCase):
             The config options containing the resolutions
         """
 
-        resolutions = config.get('planar_convergence', 'resolutions')
-        resolutions = [int(resolution) for resolution in
-                       resolutions.replace(',', ' ').split()]
+        resolutions = config.getlist('planar_convergence', 'resolutions',
+                                     dtype=int)
 
         if self.resolutions is not None and self.resolutions == resolutions:
             return

--- a/compass/ocean/tests/sphere_transport/correlated_tracers_2d/__init__.py
+++ b/compass/ocean/tests/sphere_transport/correlated_tracers_2d/__init__.py
@@ -36,11 +36,10 @@ class CorrelatedTracers2D(TestCase):
         Set config options for the test case
         """
         config = self.config
-        resolutions = config.get('correlated_tracers_2d', 'resolutions')
-        resolutions = [int(resolution) for resolution in
-                       resolutions.replace(',', ' ').split()]
-        dtmin = config.get('correlated_tracers_2d', 'timestep_minutes')
-        dtmin = [int(dt) for dt in dtmin.replace(',', ' ').split()]
+        resolutions = config.getlist('correlated_tracers_2d', 'resolutions',
+                                     dtype=int)
+        dtmin = config.getlist('correlated_tracers_2d', 'timestep_minutes',
+                               dtype=int)
 
         self.resolutions = resolutions
         self.timesteps = dtmin

--- a/compass/ocean/tests/sphere_transport/correlated_tracers_2d/__init__.py
+++ b/compass/ocean/tests/sphere_transport/correlated_tracers_2d/__init__.py
@@ -1,5 +1,3 @@
-import configparser
-
 from compass.testcase import TestCase
 
 from compass.ocean.tests.sphere_transport.correlated_tracers_2d.mesh \

--- a/compass/ocean/tests/sphere_transport/divergent_2d/__init__.py
+++ b/compass/ocean/tests/sphere_transport/divergent_2d/__init__.py
@@ -1,5 +1,3 @@
-import configparser
-
 from compass.testcase import TestCase
 
 from compass.ocean.tests.sphere_transport.divergent_2d.mesh import Mesh

--- a/compass/ocean/tests/sphere_transport/divergent_2d/__init__.py
+++ b/compass/ocean/tests/sphere_transport/divergent_2d/__init__.py
@@ -34,11 +34,8 @@ class Divergent2D(TestCase):
         Set config options for the test case
         """
         config = self.config
-        resolutions = config.get('divergent_2d', 'resolutions')
-        resolutions = [int(resolution) for resolution in
-                       resolutions.replace(',', ' ').split()]
-        dtmin = config.get('divergent_2d', 'timestep_minutes')
-        dtmin = [int(dt) for dt in dtmin.replace(',', ' ').split()]
+        resolutions = config.getlist('divergent_2d', 'resolutions', dtype=int)
+        dtmin = config.getlist('divergent_2d', 'timestep_minutes', dtype=int)
 
         self.resolutions = resolutions
         self.timesteps = dtmin

--- a/compass/ocean/tests/sphere_transport/nondivergent_2d/__init__.py
+++ b/compass/ocean/tests/sphere_transport/nondivergent_2d/__init__.py
@@ -34,11 +34,10 @@ class Nondivergent2D(TestCase):
         Set config options for the test case
         """
         config = self.config
-        resolutions = config.get('nondivergent_2d', 'resolutions')
-        resolutions = [int(resolution) for resolution in
-                       resolutions.replace(',', ' ').split()]
-        dtmin = config.get('nondivergent_2d', 'timestep_minutes')
-        dtmin = [int(dt) for dt in dtmin.replace(',', ' ').split()]
+        resolutions = config.getlist('nondivergent_2d', 'resolutions',
+                                     dtype=int)
+        dtmin = config.getlist('nondivergent_2d', 'timestep_minutes',
+                               dtype=int)
 
         self.resolutions = resolutions
         self.timesteps = dtmin

--- a/compass/ocean/tests/sphere_transport/nondivergent_2d/__init__.py
+++ b/compass/ocean/tests/sphere_transport/nondivergent_2d/__init__.py
@@ -1,5 +1,3 @@
-import configparser
-
 from compass.testcase import TestCase
 
 from compass.ocean.tests.sphere_transport.nondivergent_2d.mesh import Mesh

--- a/compass/ocean/tests/sphere_transport/rotation_2d/__init__.py
+++ b/compass/ocean/tests/sphere_transport/rotation_2d/__init__.py
@@ -33,11 +33,8 @@ class Rotation2D(TestCase):
         Set config options for the test case
         """
         config = self.config
-        resolutions = config.get('rotation_2d', 'resolutions')
-        resolutions = [int(resolution) for resolution in
-                       resolutions.replace(',', ' ').split()]
-        dtmin = config.get('rotation_2d', 'timestep_minutes')
-        dtmin = [int(dt) for dt in dtmin.replace(',', ' ').split()]
+        resolutions = config.getlist('rotation_2d', 'resolutions', dtype=int)
+        dtmin = config.getlist('rotation_2d', 'timestep_minutes', dtype=int)
 
         self.resolutions = resolutions
         self.timesteps = dtmin

--- a/compass/ocean/tests/sphere_transport/rotation_2d/__init__.py
+++ b/compass/ocean/tests/sphere_transport/rotation_2d/__init__.py
@@ -1,5 +1,3 @@
-import configparser
-
 from compass.testcase import TestCase
 
 from compass.ocean.tests.sphere_transport.rotation_2d.mesh import Mesh

--- a/compass/ocean/tests/ziso/__init__.py
+++ b/compass/ocean/tests/ziso/__init__.py
@@ -1,6 +1,5 @@
 from compass.testgroup import TestGroup
 from compass.ocean.tests.ziso.with_frazil import WithFrazil
-from compass.config import add_config
 from compass.ocean.tests.ziso.ziso_test_case import ZisoTestCase
 
 
@@ -42,7 +41,7 @@ def configure(name, resolution, config):
     resolution : str
         The resolution of the test case
 
-    config : configparser.ConfigParser
+    config : compass.config.CompassConfigParser
         Configuration options for this test case
     """
     res_params = {'20km': {'nx': 50,

--- a/compass/ocean/vertical/__init__.py
+++ b/compass/ocean/vertical/__init__.py
@@ -48,7 +48,7 @@ def init_vertical_coord(config, ds):
 
     Parameters
     ----------
-    config : configparser.ConfigParser
+    config : compass.config.CompassConfigParser
         Configuration options with parameters used to construct the vertical
         grid
 

--- a/compass/ocean/vertical/grid_1d.py
+++ b/compass/ocean/vertical/grid_1d.py
@@ -13,7 +13,7 @@ def generate_1d_grid(config):
 
     Parameters
     ----------
-    config : configparser.ConfigParser
+    config : compass.config.CompassConfigParser
         Configuration options with parameters used to construct the vertical
         grid
 
@@ -103,7 +103,7 @@ def add_1d_grid(config, ds):
 
     Parameters
     ----------
-    config : configparser.ConfigParser
+    config : compass.config.CompassConfigParser
         Configuration options with parameters used to construct the vertical
         grid
 

--- a/compass/ocean/vertical/partial_cells.py
+++ b/compass/ocean/vertical/partial_cells.py
@@ -9,7 +9,7 @@ def alter_bottom_depth(config, bottomDepth, refBottomDepth, maxLevelCell):
 
     Parameters
     ----------
-    config : configparser.ConfigParser
+    config : compass.config.CompassConfigParser
         Configuration options with parameters used to construct the vertical
         grid
 
@@ -58,7 +58,7 @@ def alter_ssh(config, ssh, refBottomDepth, minLevelCell):
 
     Parameters
     ----------
-    config : configparser.ConfigParser
+    config : compass.config.CompassConfigParser
         Configuration options with parameters used to construct the vertical
         grid
 

--- a/compass/ocean/vertical/zlevel.py
+++ b/compass/ocean/vertical/zlevel.py
@@ -48,7 +48,7 @@ def init_z_level_vertical_coord(config, ds):
 
     Parameters
     ----------
-    config : configparser.ConfigParser
+    config : compass.config.CompassConfigParser
         Configuration options with parameters used to construct the vertical
         grid
 

--- a/compass/ocean/vertical/zstar.py
+++ b/compass/ocean/vertical/zstar.py
@@ -50,7 +50,7 @@ def init_z_star_vertical_coord(config, ds):
 
     Parameters
     ----------
-    config : configparser.ConfigParser
+    config : compass.config.CompassConfigParser
         Configuration options with parameters used to construct the vertical
         grid
 

--- a/compass/parallel.py
+++ b/compass/parallel.py
@@ -10,7 +10,7 @@ def get_available_cores_and_nodes(config):
 
     Parameters
     ----------
-    config : configparser.ConfigParser
+    config : compass.config.CompassConfigParser
         Configuration options for the test case
 
     Returns
@@ -49,7 +49,7 @@ def check_parallel_system(config):
 
     Parameters
     ----------
-    config : configparser.ConfigParser
+    config : compass.config.CompassConfigParser
         Configuration options
 
     Raises
@@ -77,7 +77,7 @@ def set_cores_per_node(config):
 
     Parameters
     ----------
-    config : configparser.ConfigParser
+    config : compass.config.CompassConfigParser
         Configuration options
     """
     parallel_system = config.get('parallel', 'system')

--- a/compass/provenance.py
+++ b/compass/provenance.py
@@ -1,9 +1,8 @@
 import os
 import sys
 import subprocess
-import configparser
 
-from compass.config import add_config
+from compass.config import CompassConfigParser
 
 
 def write(work_dir, test_cases, mpas_core=None, config_filename=None,
@@ -114,13 +113,11 @@ def write(work_dir, test_cases, mpas_core=None, config_filename=None,
 def _get_mpas_git_version(mpas_core, config_filename, mpas_model_path):
 
     if mpas_model_path is None:
-        config = configparser.ConfigParser(
-            interpolation=configparser.ExtendedInterpolation())
+        config = CompassConfigParser()
         # add the config options for the MPAS core
-        add_config(config, 'compass.{}'.format(mpas_core),
-                   '{}.cfg'.format(mpas_core))
+        config.add_from_package(f'compass.{mpas_core}', f'{mpas_core}.cfg')
         if config_filename is not None:
-            config.read(config_filename)
+            config.add_user_config(config_filename)
         if not config.has_option('paths', 'mpas_model'):
             raise ValueError('Couldn\'t find MPAS model.  Not in user config '
                              'file or passed with -p flag.')

--- a/compass/run.py
+++ b/compass/run.py
@@ -2,7 +2,6 @@ import argparse
 import sys
 import os
 import pickle
-import configparser
 import time
 import glob
 
@@ -10,6 +9,7 @@ from mpas_tools.logging import LoggingContext
 import mpas_tools.io
 from compass.parallel import check_parallel_system, set_cores_per_node
 from compass.logging import log_method_call
+from compass.config import CompassConfigParser
 
 
 def run_suite(suite_name, quiet=False):
@@ -50,9 +50,8 @@ def run_suite(suite_name, quiet=False):
     test_case = next(iter(test_suite['test_cases'].values()))
     config_filename = os.path.join(test_case.work_dir,
                                    test_case.config_filename)
-    config = configparser.ConfigParser(
-        interpolation=configparser.ExtendedInterpolation())
-    config.read(config_filename)
+    config = CompassConfigParser()
+    config.add_from_file(config_filename)
     check_parallel_system(config)
 
     # start logging to stdout/stderr
@@ -92,9 +91,8 @@ def run_suite(suite_name, quiet=False):
 
                 os.chdir(test_case.work_dir)
 
-                config = configparser.ConfigParser(
-                    interpolation=configparser.ExtendedInterpolation())
-                config.read(test_case.config_filename)
+                config = CompassConfigParser()
+                config.add_from_file(test_case.config_filename)
                 test_case.config = config
                 set_cores_per_node(test_case.config)
 
@@ -216,9 +214,8 @@ def run_test_case(steps_to_run=None, steps_not_to_run=None):
     with open('test_case.pickle', 'rb') as handle:
         test_case = pickle.load(handle)
 
-    config = configparser.ConfigParser(
-        interpolation=configparser.ExtendedInterpolation())
-    config.read(test_case.config_filename)
+    config = CompassConfigParser()
+    config.add_from_file(test_case.config_filename)
 
     check_parallel_system(config)
 
@@ -278,9 +275,8 @@ def run_step():
     test_case.steps_to_run = [step.name]
     test_case.new_step_log_file = False
 
-    config = configparser.ConfigParser(
-        interpolation=configparser.ExtendedInterpolation())
-    config.read(step.config_filename)
+    config = CompassConfigParser()
+    config.add_from_file(step.config_filename)
 
     check_parallel_system(config)
 

--- a/compass/setup.py
+++ b/compass/setup.py
@@ -253,7 +253,7 @@ def setup_case(path, test_case, config_file, machine, work_dir, baseline_dir,
 
     # set the mpas_model path from the command line if provided
     if mpas_model_path is not None:
-        config.set('paths', 'mpas_model', mpas_model_path)
+        config.set('paths', 'mpas_model', mpas_model_path, user=True)
 
     config.set('test_case', 'steps_to_run', ' '.join(test_case.steps_to_run))
 

--- a/compass/setup.py
+++ b/compass/setup.py
@@ -215,7 +215,7 @@ def setup_case(path, test_case, config_file, machine, work_dir, baseline_dir,
 
     # add the E3SM config options from mache
     if machine is not None:
-        config.add_from_package('mache', f'{machine}.cfg')
+        config.add_from_package('mache.machines', f'{machine}.cfg')
 
     # add the compass machine config file
     if machine is None:

--- a/compass/step.py
+++ b/compass/step.py
@@ -1,6 +1,5 @@
 import os
 from lxml import etree
-import configparser
 from importlib.resources import path
 import shutil
 import numpy
@@ -94,7 +93,7 @@ class Step(ABC):
         a dictionary used internally to keep track of updates to the default
         streams from calls to :py:meth:`compass.Step.add_streams_file`
 
-    config : configparser.ConfigParser
+    config : compass.config.CompassConfigParser
         Configuration options for this test case, a combination of the defaults
         for the machine, core and configuration
 

--- a/compass/testcase.py
+++ b/compass/testcase.py
@@ -1,5 +1,4 @@
 import os
-import configparser
 
 from mpas_tools.logging import LoggingContext
 from compass.parallel import get_available_cores_and_nodes
@@ -38,7 +37,7 @@ class TestCase:
         the path within the base work directory of the test case, made up of
         ``mpas_core``, ``test_group``, and the test case's ``subdir``
 
-    config : configparser.ConfigParser
+    config : compass.config.CompassConfigParser
         Configuration options for this test case, a combination of the defaults
         for the machine, core and configuration
 

--- a/docs/developers_guide/api.rst
+++ b/docs/developers_guide/api.rst
@@ -169,10 +169,19 @@ config
 .. autosummary::
    :toctree: generated/
 
-   duplicate_config
-   add_config
-   ensure_absolute_paths
-   get_source_file
+   CompassConfigParser
+   CompassConfigParser.add_user_config
+   CompassConfigParser.add_from_file
+   CompassConfigParser.add_from_package
+   CompassConfigParser.get
+   CompassConfigParser.getint
+   CompassConfigParser.getfloat
+   CompassConfigParser.getboolean
+   CompassConfigParser.getlist
+   CompassConfigParser.has_option
+   CompassConfigParser.set
+   CompassConfigParser.write
+   CompassConfigParser.__getitem__
 
 io
 ^^

--- a/docs/users_guide/config_files.rst
+++ b/docs/users_guide/config_files.rst
@@ -143,96 +143,360 @@ looks like:
 
 .. code-block:: cfg
 
+    # Options related to the current test case
+    [test_case]
+
+    # source: /home/xylar/code/compass/customize_config_parser/compass/setup.py
+    steps_to_run = mesh
+
+
+    # Options related to downloading files
     [download]
+
+    # the base url for the server from which meshes, initial conditions, and other
+    # data sets can be downloaded
+    # source: /home/xylar/code/compass/customize_config_parser/compass/default.cfg
     server_base_url = https://web.lcrc.anl.gov/public/e3sm/mpas_standalonedata
+
+    # whether to download files during setup that have not been cached locally
+    # source: /home/xylar/code/compass/customize_config_parser/inej.cfg
     download = True
+
+    # whether to check the size of files that have been downloaded to make sure
+    # they are the right size
+    # source: /home/xylar/code/compass/customize_config_parser/inej.cfg
     check_size = False
+
+    # whether to verify SSL certificates for HTTPS requests
+    # source: /home/xylar/code/compass/customize_config_parser/compass/default.cfg
     verify = True
+
+    # the path on the server for MPAS-Ocean
+    # source: /home/xylar/code/compass/customize_config_parser/compass/ocean/ocean.cfg
     core_path = mpas-ocean
 
+
+    # The parallel section describes options related to running tests in parallel
     [parallel]
+
+    # the program to use for graph partitioning
+    # source: /home/xylar/code/compass/customize_config_parser/compass/default.cfg
     partition_executable = gpmetis
+
+    # parallel system of execution: slurm or single_node
+    # source: /home/xylar/code/compass/customize_config_parser/inej.cfg
     system = single_node
+
+    # whether to use mpirun or srun to run the model
+    # source: /home/xylar/code/compass/customize_config_parser/inej.cfg
     parallel_executable = mpirun
+
+    # cores per node on the machine
+    # source: /home/xylar/code/compass/customize_config_parser/inej.cfg
     cores_per_node = 8
+
+    # the number of multiprocessing or dask threads to use
+    # source: /home/xylar/code/compass/customize_config_parser/inej.cfg
     threads = 8
 
+
+    # The io section describes options related to file i/o
+    [io]
+
+    # the NetCDF file format: NETCDF4, NETCDF4_CLASSIC, NETCDF3_64BIT, or
+    # NETCDF3_CLASSIC
+    # source: /home/xylar/code/compass/customize_config_parser/compass/default.cfg
+    format = NETCDF3_64BIT
+
+    # the NetCDF output engine: netcdf4 or scipy
+    # the netcdf4 engine is not performing well on Chrysalis and Anvil, so we will
+    # try scipy for now.  If we can switch to NETCDF4 format, netcdf4 will be
+    # required
+    # source: /home/xylar/code/compass/customize_config_parser/compass/default.cfg
+    engine = scipy
+
+
+    # This file contains some common config options you might want to set
+    # if you're working with the compass ocean core and MPAS-Ocean.
+    # The paths section describes paths that are used within the ocean core test
+    # cases.
     [paths]
-    mpas_model = /home/xylar/code/mpas-work/compass/compass_1.0/E3SM-Project/components/mpas-ocean
+
+    # source: /home/xylar/code/compass/customize_config_parser/compass/setup.py
+    mpas_model = /home/xylar/code/compass/customize_config_parser/E3SM-Project/components/mpas-ocean
+
+    # The root to a location where the mesh_database, initial_condition_database,
+    # and bathymetry_database for MPAS-Ocean will be cached
+    # source: /home/xylar/code/compass/customize_config_parser/inej.cfg
     ocean_database_root = /home/xylar/data/mpas/mpas_standalonedata/mpas-ocean
+
+    # The root to a location where data files for MALI will be cached
+    # source: /home/xylar/code/compass/customize_config_parser/inej.cfg
     landice_database_root = /home/xylar/data/mpas/mpas_standalonedata/mpas-albany-landice
-    baseline_dir = /home/xylar/data/mpas/test_20210413/compass_classes/ocean/global_ocean/QU240/PHC/init
 
+
+    # The namelists section defines paths to example_compact namelists that will be used
+    # to generate specific namelists. By default, these point to the forward and
+    # init namelists in the default_inputs directory after a successful build of
+    # the ocean model.  Change these in a custom config file if you need a different
+    # example_compact.
     [namelists]
-    forward = /home/xylar/code/mpas-work/compass/compass_1.0/E3SM-Project/components/mpas-ocean/default_inputs/namelist.ocean.forward
-    init = /home/xylar/code/mpas-work/compass/compass_1.0/E3SM-Project/components/mpas-ocean/default_inputs/namelist.ocean.init
 
+    # source: /home/xylar/code/compass/customize_config_parser/compass/ocean/ocean.cfg
+    forward = /home/xylar/code/compass/customize_config_parser/E3SM-Project/components/mpas-ocean/default_inputs/namelist.ocean.forward
+
+    # source: /home/xylar/code/compass/customize_config_parser/compass/ocean/ocean.cfg
+    init = /home/xylar/code/compass/customize_config_parser/E3SM-Project/components/mpas-ocean/default_inputs/namelist.ocean.init
+
+
+    # The streams section defines paths to example_compact streams files that will be used
+    # to generate specific streams files. By default, these point to the forward and
+    # init streams files in the default_inputs directory after a successful build of
+    # the ocean model. Change these in a custom config file if you need a different
+    # example_compact.
     [streams]
-    forward = /home/xylar/code/mpas-work/compass/compass_1.0/E3SM-Project/components/mpas-ocean/default_inputs/streams.ocean.forward
-    init = /home/xylar/code/mpas-work/compass/compass_1.0/E3SM-Project/components/mpas-ocean/default_inputs/streams.ocean.init
 
+    # source: /home/xylar/code/compass/customize_config_parser/compass/ocean/ocean.cfg
+    forward = /home/xylar/code/compass/customize_config_parser/E3SM-Project/components/mpas-ocean/default_inputs/streams.ocean.forward
+
+    # source: /home/xylar/code/compass/customize_config_parser/compass/ocean/ocean.cfg
+    init = /home/xylar/code/compass/customize_config_parser/E3SM-Project/components/mpas-ocean/default_inputs/streams.ocean.init
+
+
+    # The executables section defines paths to required executables. These
+    # executables are provided for use by specific test cases.  Most tools that
+    # compass needs should be in the conda environment, so this is only the path
+    # to the MPAS-Ocean executable by default.
     [executables]
-    model = /home/xylar/code/mpas-work/compass/compass_1.0/E3SM-Project/components/mpas-ocean/ocean_model
 
+    # source: /home/xylar/code/compass/customize_config_parser/compass/ocean/ocean.cfg
+    model = /home/xylar/code/compass/customize_config_parser/E3SM-Project/components/mpas-ocean/ocean_model
+
+
+    # Options relate to adjusting the sea-surface height or land-ice pressure
+    # below ice shelves to they are dynamically consistent with one another
     [ssh_adjustment]
+
+    # the number of iterations of ssh adjustment to perform
+    # source: /home/xylar/code/compass/customize_config_parser/compass/ocean/ocean.cfg
     iterations = 10
 
-    [global_ocean]
-    mesh_cores = 1
-    mesh_min_cores = 1
-    mesh_max_memory = 1000
-    mesh_max_disk = 1000
-    init_cores = 4
-    init_min_cores = 1
-    init_max_memory = 1000
-    init_max_disk = 1000
-    init_threads = 1
-    forward_cores = 4
-    forward_min_cores = 1
-    forward_threads = 1
-    forward_max_memory = 1000
-    forward_max_disk = 1000
-    add_metadata = True
-    prefix = QU
-    mesh_description = MPAS quasi-uniform mesh for E3SM version ${e3sm_version} at
-        ${min_res}-km global resolution with ${levels} vertical
-        level
-    bathy_description = Bathymetry is from GEBCO 2019, combined with BedMachine Antarctica around Antarctica.
-    init_description = Polar science center Hydrographic Climatology (PHC)
-    e3sm_version = 2
-    mesh_revision = 1
-    min_res = 240
-    max_res = 240
-    max_depth = autodetect
-    levels = autodetect
-    creation_date = autodetect
-    author = Xylar Asay-Davis
-    email = xylar@lanl.gov
-    pull_request = https://github.com/MPAS-Dev/compass/pull/28
 
+    # options for global ocean testcases
+    [global_ocean]
+
+    ## each mesh should replace these with appropriate values in its config file
+    ## config options related to the mesh step
+    # number of cores to use
+    # source: /home/xylar/code/compass/customize_config_parser/compass/ocean/tests/global_ocean/global_ocean.cfg
+    mesh_cores = 18
+
+    # minimum of cores, below which the step fails
+    # source: /home/xylar/code/compass/customize_config_parser/compass/ocean/tests/global_ocean/global_ocean.cfg
+    mesh_min_cores = 1
+
+    # maximum memory usage allowed (in MB)
+    # source: /home/xylar/code/compass/customize_config_parser/compass/ocean/tests/global_ocean/global_ocean.cfg
+    mesh_max_memory = 1000
+
+    # maximum disk usage allowed (in MB)
+    # source: /home/xylar/code/compass/customize_config_parser/compass/ocean/tests/global_ocean/global_ocean.cfg
+    mesh_max_disk = 1000
+
+    ## config options related to the initial_state step
+    # number of cores to use
+    # source: /home/xylar/code/compass/customize_config_parser/compass/ocean/tests/global_ocean/mesh/qu240/qu240.cfg
+    init_cores = 4
+
+    # minimum of cores, below which the step fails
+    # source: /home/xylar/code/compass/customize_config_parser/compass/ocean/tests/global_ocean/mesh/qu240/qu240.cfg
+    init_min_cores = 1
+
+    # maximum memory usage allowed (in MB)
+    # source: /home/xylar/code/compass/customize_config_parser/compass/ocean/tests/global_ocean/mesh/qu240/qu240.cfg
+    init_max_memory = 1000
+
+    # maximum disk usage allowed (in MB)
+    # source: /home/xylar/code/compass/customize_config_parser/compass/ocean/tests/global_ocean/mesh/qu240/qu240.cfg
+    init_max_disk = 1000
+
+    # number of threads
+    # source: /home/xylar/code/compass/customize_config_parser/compass/ocean/tests/global_ocean/global_ocean.cfg
+    init_threads = 1
+
+    ## config options related to the forward steps
+    # number of cores to use
+    # source: /home/xylar/code/compass/customize_config_parser/compass/ocean/tests/global_ocean/mesh/qu240/qu240.cfg
+    forward_cores = 4
+
+    # minimum of cores, below which the step fails
+    # source: /home/xylar/code/compass/customize_config_parser/compass/ocean/tests/global_ocean/mesh/qu240/qu240.cfg
+    forward_min_cores = 1
+
+    # number of threads
+    # source: /home/xylar/code/compass/customize_config_parser/compass/ocean/tests/global_ocean/global_ocean.cfg
+    forward_threads = 1
+
+    # maximum memory usage allowed (in MB)
+    # source: /home/xylar/code/compass/customize_config_parser/compass/ocean/tests/global_ocean/mesh/qu240/qu240.cfg
+    forward_max_memory = 1000
+
+    # maximum disk usage allowed (in MB)
+    # source: /home/xylar/code/compass/customize_config_parser/compass/ocean/tests/global_ocean/mesh/qu240/qu240.cfg
+    forward_max_disk = 1000
+
+    ## metadata related to the mesh
+    # whether to add metadata to output files
+    # source: /home/xylar/code/compass/customize_config_parser/compass/ocean/tests/global_ocean/global_ocean.cfg
+    add_metadata = True
+
+    ## metadata related to the mesh
+    # the prefix (e.g. QU, EC, WC, SO)
+    # source: /home/xylar/code/compass/customize_config_parser/compass/ocean/tests/global_ocean/mesh/qu240/qu240.cfg
+    prefix = QU
+
+    # a description of the mesh
+    # source: /home/xylar/code/compass/customize_config_parser/compass/ocean/tests/global_ocean/mesh/qu240/qu240.cfg
+    mesh_description = MPAS quasi-uniform mesh for E3SM version 2 at
+        240-km global resolution with autodetect vertical
+        level
+
+    # source: /home/xylar/code/compass/customize_config_parser/compass/ocean/tests/global_ocean/configure.py
+    bathy_description = Bathymetry is from GEBCO 2019, combined with BedMachine Antarctica around Antarctica.
+
+    # a description of the mesh with ice-shelf cavities
+    # source: /home/xylar/code/compass/customize_config_parser/compass/ocean/tests/global_ocean/global_ocean.cfg
+    init_description = <<<Missing>>>
+
+    # E3SM version that the mesh is intended for
+    # source: /home/xylar/code/compass/customize_config_parser/compass/ocean/tests/global_ocean/mesh/qu240/qu240.cfg
+    e3sm_version = 2
+
+    # The revision number of the mesh, which should be incremented each time the
+    # mesh is revised
+    # source: /home/xylar/code/compass/customize_config_parser/compass/ocean/tests/global_ocean/mesh/qu240/qu240.cfg
+    mesh_revision = 1
+
+    # the minimum (finest) resolution in the mesh
+    # source: /home/xylar/code/compass/customize_config_parser/compass/ocean/tests/global_ocean/mesh/qu240/qu240.cfg
+    min_res = 240
+
+    # the maximum (coarsest) resolution in the mesh, can be the same as min_res
+    # source: /home/xylar/code/compass/customize_config_parser/compass/ocean/tests/global_ocean/mesh/qu240/qu240.cfg
+    max_res = 240
+
+    # the maximum depth of the ocean, always detected automatically
+    # source: /home/xylar/code/compass/customize_config_parser/compass/ocean/tests/global_ocean/global_ocean.cfg
+    max_depth = autodetect
+
+    # the number of vertical levels, always detected automatically
+    # source: /home/xylar/code/compass/customize_config_parser/compass/ocean/tests/global_ocean/global_ocean.cfg
+    levels = autodetect
+
+    # the date the mesh was created as YYMMDD, typically detected automatically
+    # source: /home/xylar/code/compass/customize_config_parser/compass/ocean/tests/global_ocean/global_ocean.cfg
+    creation_date = autodetect
+
+    # These options are used in the metadata for global ocean initial conditions.
+    # You can indicated that you are the "author" of a mesh and give your preferred
+    # email address for people to contact your if they have questions about the
+    # mesh.  Or you can let compass figure out who you are from your git
+    # configuration
+    # source: /home/xylar/code/compass/customize_config_parser/inej.cfg
+    author = Xylar Asay-Davis
+
+    # source: /home/xylar/code/compass/customize_config_parser/inej.cfg
+    email = xylar@lanl.gov
+
+    # The URL of the pull request documenting the creation of the mesh
+    # source: /home/xylar/code/compass/customize_config_parser/compass/ocean/tests/global_ocean/mesh/qu240/qu240.cfg
+    pull_request = <<<Missing>>>
+
+
+    # config options related to dynamic adjustment
+    [dynamic_adjustment]
+
+    # the maximum allowed value of temperatureMax in global statistics
+    # source: /home/xylar/code/compass/customize_config_parser/compass/ocean/tests/global_ocean/global_ocean.cfg
+    temperature_max = 33.0
+
+
+    # config options related to initial condition and diagnostics support files
+    # for E3SM
     [files_for_e3sm]
+
+    # whether to generate an ocean initial condition in E3SM
+    # source: /home/xylar/code/compass/customize_config_parser/compass/ocean/tests/global_ocean/global_ocean.cfg
     enable_ocean_initial_condition = true
+
+    # whether to generate graph partitions for different numbers of ocean cores in
+    # E3SM
+    # source: /home/xylar/code/compass/customize_config_parser/compass/ocean/tests/global_ocean/global_ocean.cfg
     enable_ocean_graph_partition = true
+
+    # whether to generate a sea-ice initial condition in E3SM
+    # source: /home/xylar/code/compass/customize_config_parser/compass/ocean/tests/global_ocean/global_ocean.cfg
     enable_seaice_initial_condition = true
+
+    # whether to generate SCRIP files for later use in creating E3SM mapping files
+    # source: /home/xylar/code/compass/customize_config_parser/compass/ocean/tests/global_ocean/global_ocean.cfg
     enable_scrip = true
+
+    # whether to generate region masks, transects and mapping files for use in both
+    # online analysis members and offline with MPAS-Analysis
+    # source: /home/xylar/code/compass/customize_config_parser/compass/ocean/tests/global_ocean/global_ocean.cfg
     enable_diagnostics_files = true
+
+    ## the following relate to the comparison grids in MPAS-Analysis to generate
+    ## mapping files for.  The default values are also the defaults in
+    ## MPAS-Analysis.  Coarser or finer resolution may be desirable for some MPAS
+    ## meshes.
+    # The comparison lat/lon grid resolution in degrees
+    # source: /home/xylar/code/compass/customize_config_parser/compass/ocean/tests/global_ocean/global_ocean.cfg
     comparisonlatresolution = 0.5
+
+    # source: /home/xylar/code/compass/customize_config_parser/compass/ocean/tests/global_ocean/global_ocean.cfg
     comparisonlonresolution = 0.5
+
+    # The comparison Antarctic polar stereographic grid size and resolution in km
+    # source: /home/xylar/code/compass/customize_config_parser/compass/ocean/tests/global_ocean/global_ocean.cfg
     comparisonantarcticstereowidth = 6000.
+
+    # source: /home/xylar/code/compass/customize_config_parser/compass/ocean/tests/global_ocean/global_ocean.cfg
     comparisonantarcticstereoresolution = 10.
+
+    # The comparison Arctic polar stereographic grid size and resolution in km
+    # source: /home/xylar/code/compass/customize_config_parser/compass/ocean/tests/global_ocean/global_ocean.cfg
     comparisonarcticstereowidth = 6000.
+
+    # source: /home/xylar/code/compass/customize_config_parser/compass/ocean/tests/global_ocean/global_ocean.cfg
     comparisonarcticstereoresolution = 10.
 
+
+    # Options related to the vertical grid
     [vertical_grid]
+
+    # the type of vertical grid
+    # source: /home/xylar/code/compass/customize_config_parser/compass/ocean/tests/global_ocean/mesh/qu240/qu240.cfg
     grid_type = tanh_dz
+
+    # Number of vertical levels
+    # source: /home/xylar/code/compass/customize_config_parser/compass/ocean/tests/global_ocean/mesh/qu240/qu240.cfg
     vert_levels = 16
+
+    # Depth of the bottom of the ocean
+    # source: /home/xylar/code/compass/customize_config_parser/compass/ocean/tests/global_ocean/mesh/qu240/qu240.cfg
     bottom_depth = 3000.0
+
+    # The minimum layer thickness
+    # source: /home/xylar/code/compass/customize_config_parser/compass/ocean/tests/global_ocean/mesh/qu240/qu240.cfg
     min_layer_thickness = 3.0
+
+    # The maximum layer thickness
+    # source: /home/xylar/code/compass/customize_config_parser/compass/ocean/tests/global_ocean/mesh/qu240/qu240.cfg
     max_layer_thickness = 500.0
 
-Unfortunately, all comments are lost in the process of combining config
-options.  Comments are not parsed by ``ConfigParser``, and there is not a
-standard for which comments are associated with which options.  So users
-will need to search through this documentation (or the code on the
-`compass repo <https://github.com/MPAS-Dev/compass>`_) to know what the config
-options are used for.
+The comments are retained (unlike in the previous version of compass) and the
+config file or python module where they were defined is also included as a
+a comment for provenance and to make it easier for users and developers to
+understand how the config file is built up.


### PR DESCRIPTION
This config parser can:
* keep track of comments from the original config files
* keep track of the source of each config option (and include a comment with the source when writing out a combined config file)
* prioritize "user" config options over all others

closes #247