### PR TITLE
Add Greenland mesh generation test case

### DIFF
--- a/compass/landice/tests/greenland/__init__.py
+++ b/compass/landice/tests/greenland/__init__.py
@@ -2,6 +2,7 @@ from compass.testgroup import TestGroup
 from compass.landice.tests.greenland.smoke_test import SmokeTest
 from compass.landice.tests.greenland.decomposition_test import DecompositionTest
 from compass.landice.tests.greenland.restart_test import RestartTest
+from compass.landice.tests.greenland.high_res_mesh import HighResMesh
 
 
 class Greenland(TestGroup):
@@ -24,3 +25,6 @@ class Greenland(TestGroup):
 
             self.add_test_case(
                 RestartTest(test_group=self, velo_solver=velo_solver))
+
+        self.add_test_case(
+            HighResMesh(test_group=self))

--- a/compass/landice/tests/greenland/high_res_mesh/__init__.py
+++ b/compass/landice/tests/greenland/high_res_mesh/__init__.py
@@ -4,7 +4,7 @@ from compass.landice.tests.greenland.mesh import Mesh
 
 class HighResMesh(TestCase):
     """
-    The high resolution test case for the thwaites test
+    The high resolution test case for the greenland test
     group simply creates the mesh and initial condition.
     The basal friction optimization occurs separately,
     outside of COMPASS.
@@ -15,7 +15,7 @@ class HighResMesh(TestCase):
         Create the test case
         Parameters
         ----------
-        test_group : compass.landice.tests.greenland.HighResMesh
+        test_group : compass.landice.tests.greenland.Greenland
             The test group that this test case belongs to
         """
         name = 'high_res_mesh'

--- a/compass/landice/tests/greenland/high_res_mesh/__init__.py
+++ b/compass/landice/tests/greenland/high_res_mesh/__init__.py
@@ -1,0 +1,27 @@
+from compass.testcase import TestCase
+from compass.landice.tests.greenland.mesh import Mesh
+
+
+class HighResMesh(TestCase):
+    """
+    The high resolution test case for the thwaites test
+    group simply creates the mesh and initial condition.
+    The basal friction optimization occurs separately,
+    outside of COMPASS.
+    """
+
+    def __init__(self, test_group):
+        """
+        Create the test case
+        Parameters
+        ----------
+        test_group : compass.landice.tests.greenland.HighResMesh
+            The test group that this test case belongs to
+        """
+        name = 'high_res_mesh'
+        subdir = name
+        super().__init__(test_group=test_group, name=name,
+                         subdir=subdir)
+
+        self.add_step(
+            Mesh(test_case=self))

--- a/compass/landice/tests/greenland/high_res_mesh/high_res_mesh.cfg
+++ b/compass/landice/tests/greenland/high_res_mesh/high_res_mesh.cfg
@@ -1,0 +1,29 @@
+# config options for high_res_mesh test case
+[high_res_mesh]
+
+# number of levels in the mesh
+levels = 10
+
+# distance from ice margin to cull (km).
+# Set to a value <= 0 if you do not want
+# to cull based on distance from margin.
+cull_distance = 10.0
+
+# mesh density parameters
+# minimum cell spacing (meters)
+min_spac = 3.e3
+# maximum cell spacing (meters)
+max_spac = 30.e3
+# log10 of max speed for cell spacing
+high_log_speed = 2.5
+# log10 of min speed for cell spacing
+low_log_speed = 0.75
+# distance at which cell spacing = max_spac
+high_dist = 1.e5
+# distance within which cell spacing = min_spac
+low_dist = 5.e4
+
+# mesh density functions
+use_speed = True
+use_dist_to_grounding_line = False
+use_dist_to_edge = True

--- a/compass/landice/tests/greenland/high_res_mesh/high_res_mesh.cfg
+++ b/compass/landice/tests/greenland/high_res_mesh/high_res_mesh.cfg
@@ -1,5 +1,5 @@
 # config options for high_res_mesh test case
-[high_res_mesh]
+[high_res_GIS_mesh]
 
 # number of levels in the mesh
 levels = 10

--- a/compass/landice/tests/greenland/mesh.py
+++ b/compass/landice/tests/greenland/mesh.py
@@ -1,0 +1,209 @@
+import numpy as np
+import netCDF4
+import xarray
+from matplotlib import pyplot as plt
+
+from mpas_tools.mesh.creation import build_planar_mesh
+from mpas_tools.mesh.conversion import convert, cull
+from mpas_tools.planar_hex import make_planar_hex_mesh
+from mpas_tools.io import write_netcdf
+from mpas_tools.logging import check_call
+
+from compass.step import Step
+from compass.model import make_graph_file
+from compass.landice.mesh import gridded_flood_fill, \
+                                 set_rectangular_geom_points_and_edges, \
+                                 set_cell_width, get_dist_to_edge_and_GL
+
+
+class Mesh(Step):
+    """
+    A step for creating a mesh and initial condition for greenland test cases
+
+    Attributes
+    ----------
+    mesh_type : str
+        The resolution or mesh type of the test case
+    """
+    def __init__(self, test_case):
+        """
+        Create the step
+
+        Parameters
+        ----------
+        test_case : compass.TestCase
+            The test case this step belongs to
+
+        mesh_type : str
+            The resolution or mesh type of the test case
+        """
+        super().__init__(test_case=test_case, name='mesh')
+
+        self.add_output_file(filename='graph.info')
+        self.add_output_file(filename='GIS.nc')
+        self.add_input_file(
+                filename='greenland_1km_2020_04_20.epsg3413.icesheetonly.nc',
+                target='greenland_1km_2020_04_20.epsg3413.icesheetonly.nc',
+                database='')
+        self.add_input_file(filename='greenland_8km_2020_04_20.epsg3413.nc',
+                            target='greenland_8km_2020_04_20.epsg3413.nc',
+                            database='')
+
+    # no setup() method is needed
+
+    def run(self):
+        """
+        Run this step of the test case
+        """
+        logger = self.logger
+        config = self.config
+        section = config['high_res_mesh']
+
+        logger.info('calling build_cell_wdith')
+        cell_width, x1, y1, geom_points, geom_edges = self.build_cell_width()
+        logger.info('calling build_planar_mesh')
+        build_planar_mesh(cell_width, x1, y1, geom_points,
+                          geom_edges, logger=logger)
+        dsMesh = xarray.open_dataset('base_mesh.nc')
+        logger.info('culling mesh')
+        dsMesh = cull(dsMesh, logger=logger)
+        logger.info('converting to MPAS mesh')
+        dsMesh = convert(dsMesh, logger=logger)
+        logger.info('writing grid_converted.nc')
+        write_netcdf(dsMesh, 'grid_converted.nc')
+        # If no number of levels specified in config file, use 10
+        levels = section.get('levels')
+        logger.info('calling create_landice_grid_from_generic_MPAS_grid.py')
+        args = ['create_landice_grid_from_generic_MPAS_grid.py',
+                '-i', 'grid_converted.nc',
+                '-o', 'gis_1km_preCull.nc',
+                '-l', levels, '-v', 'glimmer']
+        check_call(args, logger=logger)
+
+        # This step uses a subset of the whole Greenland dataset trimmed to
+        # the region around GIS Glacier, to speed up interpolation.
+        # This could also be replaced with the full Greenland Ice Sheet
+        # dataset.
+        logger.info('calling interpolate_to_mpasli_grid.py')
+        args = ['interpolate_to_mpasli_grid.py', '-s',
+                'greenland_1km_2020_04_20.epsg3413.icesheetonly.nc', '-d',
+                'gis_1km_preCull.nc', '-m', 'b', '-t']
+
+        check_call(args, logger=logger)
+
+        # This step is only necessary if you wish to cull a certain
+        # distance from the ice margin, within the bounds defined by
+        # the GeoJSON file.
+        cullDistance = section.get('cull_distance')
+        if float(cullDistance) > 0.:
+            logger.info('calling define_cullMask.py')
+            args = ['define_cullMask.py', '-f',
+                    'gis_1km_preCull.nc', '-m'
+                    'distance', '-d', cullDistance]
+
+            check_call(args, logger=logger)
+        else:
+            logger.info('cullDistance <= 0 in config file. '
+                        'Will not cull by distance to margin. \n')
+
+        # This step is only necessary because the GeoJSON region
+        # is defined by lat-lon.
+        logger.info('calling set_lat_lon_fields_in_planar_grid.py')
+        args = ['set_lat_lon_fields_in_planar_grid.py', '-f',
+                'gis_1km_preCull.nc', '-p', 'gis-gimp']
+
+        check_call(args, logger=logger)
+
+        dsMesh = xarray.open_dataset('gis_1km_preCull.nc')
+        dsMesh = cull(dsMesh, logger=logger)
+        write_netcdf(dsMesh, 'greenland_culled.nc')
+
+        logger.info('Marking horns for culling')
+        args = ['mark_horns_for_culling.py', '-f', 'greenland_culled.nc']
+        check_call(args, logger=logger)
+
+        logger.info('culling and converting')
+        dsMesh = xarray.open_dataset('greenland_culled.nc')
+        dsMesh = cull(dsMesh, logger=logger)
+        dsMesh = convert(dsMesh, logger=logger)
+        write_netcdf(dsMesh, 'greenland_dehorned.nc')
+
+        logger.info('calling create_landice_grid_from_generic_MPAS_grid.py')
+        args = ['create_landice_grid_from_generic_MPAS_grid.py', '-i',
+                'greenland_dehorned.nc', '-o',
+                'GIS.nc', '-l', levels, '-v', 'glimmer',
+                '--beta', '--thermal', '--obs', '--diri']
+
+        check_call(args, logger=logger)
+
+        logger.info('calling interpolate_to_mpasli_grid.py')
+        args = ['interpolate_to_mpasli_grid.py', '-s',
+                'greenland_1km_2020_04_20.epsg3413.icesheetonly.nc',
+                '-d', 'GIS.nc', '-m', 'b', '-t']
+        check_call(args, logger=logger)
+
+        logger.info('Marking domain boundaries dirichlet')
+        args = ['mark_domain_boundaries_dirichlet.py',
+                '-f', 'GIS.nc']
+        check_call(args, logger=logger)
+
+        logger.info('calling set_lat_lon_fields_in_planar_grid.py')
+        args = ['set_lat_lon_fields_in_planar_grid.py', '-f',
+                'GIS.nc', '-p', 'gis-gimp']
+        check_call(args, logger=logger)
+
+        logger.info('creating graph.info')
+        make_graph_file(mesh_filename='GIS.nc',
+                        graph_filename='graph.info')
+
+    def build_cell_width(self):
+        """
+        Determine MPAS mesh cell size based on user-defined density function.
+
+        This includes hard-coded definition of the extent of the regional
+        mesh and user-defined mesh density functions based on observed flow
+        speed and distance to the ice margin. In the future, this function
+        and its components will likely be separated into separate generalized
+        functions to be reusable by multiple test groups.
+        """
+        # get needed fields from GIS dataset
+        f = netCDF4.Dataset('greenland_8km_2020_04_20.epsg3413.nc', 'r')
+        f.set_auto_mask(False)  # disable masked arrays
+
+        x1 = f.variables['x1'][:]
+        y1 = f.variables['y1'][:]
+        thk = f.variables['thk'][0, :, :]
+        topg = f.variables['topg'][0, :, :]
+        vx = f.variables['vx'][0, :, :]
+        vy = f.variables['vy'][0, :, :]
+
+        # Define extent of region to mesh.
+        # These coords are specific to the GIS mesh.
+        xx0 = np.min(x1)
+        xx1 = np.max(x1)
+        yy0 = np.min(y1)
+        yy1 = np.max(y1)
+        geom_points, geom_edges = set_rectangular_geom_points_and_edges(
+                                                           xx0, xx1, yy0, yy1)
+
+        # Remove ice not connected to the ice sheet.
+        floodMask = gridded_flood_fill(thk)
+        thk[floodMask == 0] = 0.0
+        vx[floodMask == 0] = 0.0
+        vy[floodMask == 0] = 0.0
+
+        # Calculate distance from each grid point to ice edge
+        # and grounding line, for use in cell spacing functions.
+        distToEdge, distToGL = get_dist_to_edge_and_GL(self, thk, topg, x1,
+                                                       y1, window_size=1.e5)
+        # optional - plot distance calculation
+        # plt.pcolor(distToEdge/1000.0); plt.colorbar(); plt.show()
+
+        # Set cell widths based on mesh parameters set in config file
+        cell_width = set_cell_width(self, section='high_res_mesh', thk=thk,
+                                    vx=vx, vy=vy, dist_to_edge=distToEdge,
+                                    dist_to_grounding_line=None)
+        # plt.pcolor(cell_width); plt.colorbar(); plt.show()
+
+        return (cell_width.astype('float64'), x1.astype('float64'),
+                y1.astype('float64'), geom_points, geom_edges)

--- a/docs/developers_guide/landice/api.rst
+++ b/docs/developers_guide/landice/api.rst
@@ -149,6 +149,13 @@ greenland
    run_model.RunModel.setup
    run_model.RunModel.run
 
+   mesh.Mesh
+   mesh.Mesh.run
+   mesh.Mesh.build_cell_width
+
+   high_res_mesh.HighResMesh
+   high_res_mesh.HighResMesh.run
+
 hydro_radial
 ~~~~~~~~~~~~
 

--- a/docs/developers_guide/landice/test_groups/greenland.rst
+++ b/docs/developers_guide/landice/test_groups/greenland.rst
@@ -73,3 +73,17 @@ The restart step works by creating two different namelist and streams files,
 one each with ``landice`` as the suffix and one each with ``landice.rst`` as
 the suffix.  The former perform a 3-day run from the initial condition, while
 the latter perform a 2-day restart run beginning with the end of the first.
+
+mesh
+~~
+
+The class :py:class:`compass.landice.tests.greenland.mesh.Mesh`
+defines a step for creating a variable resolution Greenland Ice Sheet mesh.
+This is used by the ``high_res_mesh`` test case.
+
+high_res_mesh
+-------------
+
+The :py:class:`compass.landice.tests.greenland.high_res_mesh.HighResMesh`
+calls the :py:class:`compass.landice.tests.greenland.mesh.Mesh` to create
+the variable resolution Greenland Ice Sheet mesh.

--- a/docs/developers_guide/landice/test_groups/greenland.rst
+++ b/docs/developers_guide/landice/test_groups/greenland.rst
@@ -4,9 +4,9 @@ greenland
 =========
 
 The ``greenland`` test group (:py:class:`compass.landice.tests.greenland.Greenland`)
-performs short (5-day) forward runs on a coarse (20-km) Greenland mesh
-(see :ref:`landice_greenland`).  Here, we describe the shared framework for
-this test group and the 3 test cases.
+performs short (5-day) forward runs on a coarse (20-km) Greenland mesh, and creates
+a variable resolution mesh based on user inputs (see :ref:`landice_greenland`).
+Here, we describe the shared framework for this test group and the 4 test cases.
 
 .. _dev_landice_greenland_framework:
 
@@ -38,6 +38,13 @@ different namelist and streams files.  To support this functionality, this step
 has an attribute ``suffixes``, which is a list of suffixes for the these
 namelist and streams files.  The model runs once for each suffix.  The default
 is just ``landice``.
+
+mesh
+~~~~
+
+The class :py:class:`compass.landice.tests.greenland.mesh.Mesh`
+defines a step for creating a variable resolution Greenland Ice Sheet mesh.
+This is used by the ``high_res_mesh`` test case.
 
 .. _dev_landice_greenland_smoke_test:
 
@@ -74,12 +81,7 @@ one each with ``landice`` as the suffix and one each with ``landice.rst`` as
 the suffix.  The former perform a 3-day run from the initial condition, while
 the latter perform a 2-day restart run beginning with the end of the first.
 
-mesh
-~~
-
-The class :py:class:`compass.landice.tests.greenland.mesh.Mesh`
-defines a step for creating a variable resolution Greenland Ice Sheet mesh.
-This is used by the ``high_res_mesh`` test case.
+.. _dev_landice_greenland_high_res_mesh:
 
 high_res_mesh
 -------------

--- a/docs/users_guide/landice/test_groups/greenland.rst
+++ b/docs/users_guide/landice/test_groups/greenland.rst
@@ -90,6 +90,6 @@ high_res_mesh
 
 ``landice/greenland/high_res_mesh`` creates a variable resolution mesh based
 on the the config options listed above. This will not be the same as the
-pre-generated 4-14km mesh used in the other three test cases because it uses
+pre-generated 20 km mesh used in the other three test cases because it uses
 a newer version of Jigsaw. Note that the basal friction optimization is
 performed separately and is not part of this test case.

--- a/docs/users_guide/landice/test_groups/greenland.rst
+++ b/docs/users_guide/landice/test_groups/greenland.rst
@@ -15,17 +15,51 @@ The ``landice/greenland`` test group runs tests with a coarse (20-km)
 The test group includes 3 test cases, each of which has one or more steps
 that are variants on ``run_model`` (given other names in the decomposition and
 restart test cases to distinguish multiple model runs), which performs time
-integration of the model.
+integration of the model. There is a fourth test case, ``high_res_mesh``, that
+creates a variable resolution Greenland Ice Sheet mesh, with the step ``mesh``.
 
 The test cases in this test group can run with either the SIA or FO velocity
 solvers. Running with the FO solver requires a build of MALI that includes
 Albany, but the SIA variant of the test can be run without Albany.  The FO
-version uses no-slip basal boundary condition.
+version uses no-slip basal boundary condition. There is no integration step
+for the test case ``high_res_mesh``.
 
 config options
 --------------
 
-There are no config options specific to this test group.
+The ``high_res_mesh`` test case uses the default config options below.
+The other test cases do not use config options.
+
+.. code-block:: cfg
+
+    [high_res_mesh]
+
+    # number of levels in the mesh
+    levels = 10
+
+    # distance from ice margin to cull (km).
+    # Set to a value <= 0 if you do not want
+    # to cull based on distance from margin.
+    cull_distance = 10.0
+
+    # mesh density parameters
+    # minimum cell spacing (meters)
+    min_spac = 3.e3
+    # maximum cell spacing (meters)
+    max_spac = 30.e3
+    # log10 of max speed for cell spacing
+    high_log_speed = 2.5
+    # log10 of min speed for cell spacing
+    low_log_speed = 0.75
+    # distance at which cell spacing = max_spac
+    high_dist = 1.e5
+    # distance within which cell spacing = min_spac
+    low_dist = 5.e4
+
+    # mesh density functions
+    use_speed = True
+    use_dist_to_grounding_line = False
+    use_dist_to_edge = True
 
 smoke_test
 ----------
@@ -50,3 +84,12 @@ of the model forward in time (``full_run`` step).  Then, a second step
 from a restart file saved by the first. Prognostic variables are compared
 between the "full" and "restart" runs at year 2 to make sure they are
 bit-for-bit identical.
+
+high_res_mesh
+-------------
+
+``landice/greenland/high_res_mesh`` creates a variable resolution mesh based
+on the the config options listed above. This will not be the same as the
+pre-generated 4-14km mesh used in the other three test cases because it uses
+a newer version of Jigsaw. Note that the basal friction optimization is
+performed separately and is not part of this test case.


### PR DESCRIPTION
Add a test case `landice/greenland/high_res_mesh` that creates a variable resolution Greenland Ice Sheet mesh. Default settings are for 3–30km resolution, mesh density based on observed ice speed and distance to ice margin, and culling ice-free cells >10 km from the ice sheet margin. Resolution, mesh density functions, and cull distance can be set by the user in `high_res_mesh.cfg`. This is based on the `landice/humboldt/default` and `landice/thwaites/high_res_mesh` test cases.

![image](https://user-images.githubusercontent.com/17446278/161642561-30daac15-3bdb-4d3d-818b-b8248a2f1076.png)
![image](https://user-images.githubusercontent.com/17446278/161642761-7967e107-67b2-4cfa-bed0-432d337f75fd.png)
