### PR TITLE
Add error check for cores not set

### DIFF
--- a/compass/setup.py
+++ b/compass/setup.py
@@ -401,6 +401,9 @@ def _get_required_cores(test_cases):
     for test_case in test_cases.values():
         for step_name in test_case.steps_to_run:
             step = test_case.steps[step_name]
+            if step.cores is None:
+                raise ValueError(f'The number of cores was never set for '
+                                 f'{test_case.path} step {step_name}')
             max_cores = max(max_cores, step.cores)
             max_of_min_cores = max(max_of_min_cores, step.min_cores)
 


### PR DESCRIPTION
If the number of cores for a step hasn't been set, raise a useful error that gives the test case and step.