### PR TITLE
Fix docs deployment on tag

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -100,7 +100,7 @@ jobs:
         deploy=False
       fi
 
-      if [ -n ${branch} ]; then
+      if [ -n "${branch}" ]; then
         echo "This build is for branch $branch"
         if [[ ${branch} == "master" ]]; then
           export DOCS_VERSION="latest"


### PR DESCRIPTION
The v1.0.0 tag didn't create docs as it was supposed to.  These missing quotes should help.