### PR TITLE
Automatically get `cores_per_node` on single node

### DIFF
--- a/compass/machines/default.cfg
+++ b/compass/machines/default.cfg
@@ -1,4 +1,3 @@
-
 # The parallel section describes options related to running tests in parallel
 [parallel]
 
@@ -7,6 +6,3 @@ system = single_node
 
 # whether to use mpirun or srun to run the model
 parallel_executable = mpirun
-
-# cores per node on the machine
-cores_per_node = 4

--- a/docs/users_guide/machines/index.rst
+++ b/docs/users_guide/machines/index.rst
@@ -171,13 +171,10 @@ in your user config file:
     system = single_node
 
     # whether to use mpirun or srun to run the model
-    parallel_executable = mpirun
+    parallel_executable = mpirun -host localhost
 
-    # cores per node on the machine
-    cores_per_node = 4
-
-    # the number of multiprocessing or dask threads to use
-    threads = 4
+    # cores per node on the machine, detected automatically by default
+    # cores_per_node = 4
 
 The paths for the MPAS core "databases" can be any emtpy path to begin with.
 If the path doesn't exist, ``compass`` will create it.

--- a/docs/users_guide/quick_start.rst
+++ b/docs/users_guide/quick_start.rst
@@ -301,20 +301,17 @@ in the repository.
     # whether to use mpirun or srun to run the model
     parallel_executable = mpirun -host localhost
 
-    # cores per node on the machine
-    cores_per_node = 4
-
-    # the number of multiprocessing or dask threads to use
-    threads = 4
+    # cores per node on the machine, detected automatically by default
+    # cores_per_node = 4
 
 The two ``*_database_root`` directories can point to locations where you would
 like to download data for MALI and MPAS-Ocean.  This data is downloaded only
 once and cached for the next time you call ``compass setup`` or
 ``compass suite`` (see below).
 
-The ``cores_per_node`` and ``threads`` config options should be the number of
-CPUs on your computer.  You can set this to a smaller number if you want
-``compass``.
+The ``cores_per_node`` config option will default to the number of CPUs on your
+computer.  You can set this to a smaller number if you want ``compass`` to
+use fewer cores.
 
 In order to run regression testing that compares the output of the current run
 with that from a previous compass run, use ``-b <previous_workdir>`` to specify

--- a/example_configs/landice.cfg
+++ b/example_configs/landice.cfg
@@ -22,11 +22,8 @@ system = single_node
 # whether to use mpirun or srun to run the model
 parallel_executable = mpirun -host localhost
 
-# cores per node on the machine
-cores_per_node = 4
-
-# the number of multiprocessing or dask threads to use
-threads = 4
+# cores per node on the machine, detected automatically by default
+# cores_per_node = 4
 
 
 # Options related to downloading files

--- a/example_configs/ocean.cfg
+++ b/example_configs/ocean.cfg
@@ -23,11 +23,8 @@ system = single_node
 # whether to use mpirun or srun to run the model
 parallel_executable = mpirun -host localhost
 
-# cores per node on the machine
-cores_per_node = 4
-
-# the number of multiprocessing or dask threads to use
-threads = 4
+# cores per node on the machine, detected automatically by default
+# cores_per_node = 4
 
 
 # Options related to downloading files


### PR DESCRIPTION
For non-HPC machines, it's typically fine to just detect the number of available cores.

This should reduce the amount of information needed in a user config file.