### PR TITLE
Update MALI submodule & adjust EISMINT2 test case

### DIFF
--- a/compass/landice/tests/eismint2/namelist.landice
+++ b/compass/landice/tests/eismint2/namelist.landice
@@ -10,6 +10,7 @@ config_block_decomp_file_prefix = 'graph.info.part.'
 config_velocity_solver = "sia"
 config_flowParamA_calculation = "PB1982"
 config_tracer_advection = 'fo'
+config_zero_sfcMassBalApplied_over_bare_land = .false.
 config_thermal_solver = 'temperature'
 config_thermal_calculate_bmb = .false.
 config_surface_air_temperature_source = 'file'


### PR DESCRIPTION
This merge updates the MALI submodule to bring in the newly merged PR
https://github.com/MALI-Dev/E3SM/pull/26
This change necessitated a namelist change to the EISMINT2 tests to
maintain the existing (correct) functionality for those tests. This change 
is included in this PR.

Note that the MALI update changes answers for the greenland tests, but
in that case we want to switch to the new functionality (ignoring
positive SMB in ice-free areas).