### PR TITLE
Update to scorpio 1.3.2

### DIFF
--- a/compass/version.py
+++ b/compass/version.py
@@ -1,1 +1,1 @@
-__version__ = '1.1.0-alpha.1'
+__version__ = '1.1.0-alpha.2'

--- a/conda/bootstrap.py
+++ b/conda/bootstrap.py
@@ -305,7 +305,7 @@ def build_spack_env(config, update_spack, machine, compiler, mpi, env_name,
     if esmf != 'None':
         specs.append(f'esmf@{esmf}+mpi+netcdf~pio+pnetcdf')
     if scorpio != 'None':
-        specs.append(f'scorpio@{scorpio}+pnetcdf~timing+internal-timing~tools+malloc')
+        specs.append(f'scorpio@{scorpio}+pnetcdf+timing+internal-timing~tools+malloc')
 
     if albany != 'None':
         specs.append(f'albany@{albany}+mpas')

--- a/conda/compass_env/spec-file.template
+++ b/conda/compass_env/spec-file.template
@@ -40,7 +40,7 @@ cxx-compiler
 fortran-compiler
 libnetcdf=4.8.1={{ mpi_prefix }}_*
 libpnetcdf=1.12.2={{ mpi_prefix }}_*
-scorpio=1.2.2={{ mpi_prefix }}_*
+scorpio=1.3.2={{ mpi_prefix }}_*
 m4
 make
 {{ mpi }}

--- a/conda/default.cfg
+++ b/conda/default.cfg
@@ -25,5 +25,5 @@ hdf5 = 1.12.1
 netcdf_c = 4.8.1
 netcdf_fortran = 4.5.3
 pnetcdf = 1.12.2
-scorpio = 1.2.2
+scorpio = 1.3.2
 albany = develop

--- a/conda/recipe/meta.yaml
+++ b/conda/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "compass" %}
-{% set version = "1.1.0alpha.1" %}
+{% set version = "1.1.0alpha.2" %}
 {% set build = 0 %}
 
 {% if mpi == "nompi" %}

--- a/conda/recipe/meta.yaml
+++ b/conda/recipe/meta.yaml
@@ -80,7 +80,7 @@ requirements:
     - make
     - {{ mpi }}
     - netcdf-fortran
-    - scorpio 1.2.2 {{ mpi_prefix }}_*
+    - scorpio 1.3.2 {{ mpi_prefix }}_*
 {% endif %}
 
 test:

--- a/conda/scorpio/recipe/build.sh
+++ b/conda/scorpio/recipe/build.sh
@@ -6,13 +6,15 @@ export PNETCDF_PATH=$(dirname $(dirname $(which pnetcdf-config)))
 
 mkdir build
 cd build
+# turning TESTS off temporarily because of a bug in 1.3.2
 FC=mpifort CC=mpicc CXX=mpicxx cmake \
     -DCMAKE_INSTALL_PREFIX=$PREFIX \
-    -DPIO_USE_MALLOC=ON \
-    -DPIO_ENABLE_TOOLS=OFF \
-    -DPIO_ENABLE_TESTS=ON \
-    -DPIO_ENABLE_TIMING=OFF \
-    -DPIO_ENABLE_INTERNAL_TIMING=ON \
+    -DPIO_USE_MALLOC:BOOL=ON \
+    -DPIO_ENABLE_TOOLS:BOOL=OFF \
+    -DPIO_ENABLE_TESTS:BOOL=OFF \
+    -DPIO_ENABLE_EXAMPLES:BOOL=OFF \
+    -DPIO_ENABLE_TIMING:BOOL=OFF \
+    -DPIO_ENABLE_INTERNAL_TIMING:BOOL=ON \
     -DNetCDF_C_PATH=$NETCDF_C_PATH \
     -DNetCDF_Fortran_PATH=$NETCDF_FORTRAN_PATH \
     -DPnetCDF_PATH=$PNETCDF_PATH ..

--- a/conda/scorpio/recipe/meta.yaml
+++ b/conda/scorpio/recipe/meta.yaml
@@ -1,5 +1,5 @@
-{% set version = "1.2.2" %}
-{% set build = 2 %}
+{% set version = "1.3.2" %}
+{% set build = 0 %}
 
 # recipe-lint fails if mpi is undefined
 {% set mpi = mpi or 'mpich' %}
@@ -14,7 +14,7 @@ package:
 
 source:
   url: https://github.com/E3SM-Project/scorpio/archive/refs/tags/scorpio-v{{ version }}.tar.gz
-  sha256: f944a8b8527b188cf474d9cd26c0aaae5d8a263c245eb67cad92d8dd02ca7bfb
+  sha256: 663805fa24e85c88509ecd7893264e3d7d2ff27efb304e0f75dd1f0c450b08a6
 
 build:
   number: {{ build }}


### PR DESCRIPTION
E3SM was updated to this version in https://github.com/E3SM-Project/E3SM/pull/4858

Because a new Spack build is required for this, the compass version has been updated to 1.1.0-alpha.2.  (This should be easy to deploy because most packages will be reused from the 1.1.0-alpha.1 Spack environments.)

closes #339