### PR TITLE
Copy MPAS model executable to work directory

### DIFF
--- a/compass/default.cfg
+++ b/compass/default.cfg
@@ -1,3 +1,9 @@
+# The setup section defines options related to setting pu test cases or suites
+[setup]
+
+# whether to copy the executable to the work directory
+copy_executable = False
+
 # Options related to downloading files
 [download]
 

--- a/compass/step.py
+++ b/compass/step.py
@@ -552,22 +552,28 @@ class Step(ABC):
             copy = entry['copy']
 
             if filename == '<<<model>>>':
-                # make a copy of the model executable, then link to that
                 model = self.config.get('executables', 'model')
                 filename = os.path.basename(model)
-                mpas_subdir = os.path.basename(
-                    self.config.get('paths', 'mpas_model'))
-                mpas_workdir = os.path.join(self.base_work_dir, mpas_subdir)
-                target = os.path.join(mpas_workdir, filename)
-                try:
-                    os.makedirs(mpas_workdir)
-                except FileExistsError:
-                    pass
+                copy_executable = self.config.getboolean('setup',
+                                                         'copy_executable')
+                if copy_executable:
+                    # make a copy of the model executable, then link to that
+                    mpas_subdir = os.path.basename(
+                        self.config.get('paths', 'mpas_model'))
+                    mpas_workdir = os.path.join(self.base_work_dir,
+                                                mpas_subdir)
+                    target = os.path.join(mpas_workdir, filename)
+                    try:
+                        os.makedirs(mpas_workdir)
+                    except FileExistsError:
+                        pass
 
-                try:
-                    shutil.copy(model, target)
-                except FileExistsError:
-                    pass
+                    try:
+                        shutil.copy(model, target)
+                    except FileExistsError:
+                        pass
+                else:
+                    target = os.path.abspath(model)
 
             if package is not None:
                 if target is None:

--- a/compass/step.py
+++ b/compass/step.py
@@ -552,9 +552,22 @@ class Step(ABC):
             copy = entry['copy']
 
             if filename == '<<<model>>>':
+                # make a copy of the model executable, then link to that
                 model = self.config.get('executables', 'model')
                 filename = os.path.basename(model)
-                target = os.path.abspath(model)
+                mpas_subdir = os.path.basename(
+                    self.config.get('paths', 'mpas_model'))
+                mpas_workdir = os.path.join(self.base_work_dir, mpas_subdir)
+                target = os.path.join(mpas_workdir, filename)
+                try:
+                    os.makedirs(mpas_workdir)
+                except FileExistsError:
+                    pass
+
+                try:
+                    shutil.copy(model, target)
+                except FileExistsError:
+                    pass
 
             if package is not None:
                 if target is None:

--- a/compass/suite.py
+++ b/compass/suite.py
@@ -7,7 +7,8 @@ from compass.clean import clean_cases
 
 
 def setup_suite(mpas_core, suite_name, config_file=None, machine=None,
-                work_dir=None, baseline_dir=None, mpas_model_path=None):
+                work_dir=None, baseline_dir=None, mpas_model_path=None,
+                copy_executable=False):
     """
     Set up a test suite
 
@@ -39,6 +40,9 @@ def setup_suite(mpas_core, suite_name, config_file=None, machine=None,
     mpas_model_path : str, optional
         The relative or absolute path to the root of a branch where the MPAS
         model has been built
+
+    copy_executable : bool, optional
+        Whether to copy the MPAS executable to the work directory
     """
     text = resources.read_text('compass.{}.suites'.format(mpas_core),
                                '{}.txt'.format(suite_name))
@@ -48,7 +52,7 @@ def setup_suite(mpas_core, suite_name, config_file=None, machine=None,
     setup_cases(tests, config_file=config_file, machine=machine,
                 work_dir=work_dir, baseline_dir=baseline_dir,
                 mpas_model_path=mpas_model_path, suite_name=suite_name,
-                cached=cached)
+                cached=cached, copy_executable=copy_executable)
 
 
 def clean_suite(mpas_core, suite_name, work_dir=None):
@@ -110,6 +114,10 @@ def main():
                         help="The path to the build of the MPAS model for the "
                              "core.",
                         metavar="PATH")
+    parser.add_argument("--copy_executable", dest="copy_executable",
+                        action="store_true",
+                        help="If the MPAS executable should be copied to the "
+                             "work directory")
     args = parser.parse_args(sys.argv[2:])
 
     if not args.clean and not args.setup:
@@ -124,7 +132,8 @@ def main():
         setup_suite(mpas_core=args.core, suite_name=args.test_suite,
                     config_file=args.config_file, machine=args.machine,
                     work_dir=args.work_dir, baseline_dir=args.baseline_dir,
-                    mpas_model_path=args.mpas_model)
+                    mpas_model_path=args.mpas_model,
+                    copy_executable=args.copy_executable)
 
 
 def _parse_suite(text):

--- a/docs/users_guide/quick_start.rst
+++ b/docs/users_guide/quick_start.rst
@@ -311,6 +311,16 @@ name with the ``--suite_name`` flag.)  You can run all the test cases in
 sequence with one command as described in :ref:`suite_overview` or run them
 one at a time as follows.
 
+If you want to copy the MPAS executable over to the work directory, you can
+use the ``--copy_executable`` flag or set the config option
+``copy_executable = True`` in the ``[setup]`` section of your user config
+file.  One use of this capability for compass simulations that are used in
+a paper.  In that case, it would be better to have a copy of the executable
+that will not be changed even if the E3SM branch is modified, recompiled or
+deleted.  Another use might be to maintain a long-lived baseline test.
+Again, it is safer to have the executable used to produce the baseline
+preserved.
+
 Running a test case
 -------------------
 


### PR DESCRIPTION
A directory (either `mpas-ocean` or `mpas-albany-landice`) is made within the base of the work directory and the MPAS model executable (`ocean_model` or `landice_model`) is copied there.  Symlinks within the work directory are to that copy.

This is useful if you want to delete the E3SM branch used to set up test cases or suites but you still want the ability to run the code after the fact.

closes #345 