### PR TITLE
Run steps as subprocesses by default

### DIFF
--- a/compass/default.cfg
+++ b/compass/default.cfg
@@ -22,6 +22,9 @@ verify = True
 # the program to use for graph partitioning
 partition_executable = gpmetis
 
+# run steps as subprocesses (e.g with srun)
+run_steps_as_subprocesses = True
+
 
 # The io section describes options related to file i/o
 [io]


### PR DESCRIPTION
This makes it easier to save content to log files for each step even when calling other subprocesses within the step that output to stdout/stderr (e.g. jigsaw).