### PR TITLE
Disable timing in scorpio build

### DIFF
--- a/compass/version.py
+++ b/compass/version.py
@@ -1,1 +1,1 @@
-__version__ = '1.1.0-alpha.2'
+__version__ = '1.1.0-alpha.3'

--- a/conda/bootstrap.py
+++ b/conda/bootstrap.py
@@ -305,7 +305,7 @@ def build_spack_env(config, update_spack, machine, compiler, mpi, env_name,
     if esmf != 'None':
         specs.append(f'esmf@{esmf}+mpi+netcdf~pio+pnetcdf')
     if scorpio != 'None':
-        specs.append(f'scorpio@{scorpio}+pnetcdf+timing+internal-timing~tools+malloc')
+        specs.append(f'scorpio@{scorpio}+pnetcdf~timing+internal-timing~tools+malloc')
 
     if albany != 'None':
         specs.append(f'albany@{albany}+mpas')

--- a/conda/recipe/meta.yaml
+++ b/conda/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "compass" %}
-{% set version = "1.1.0alpha.2" %}
+{% set version = "1.1.0alpha.3" %}
 {% set build = 0 %}
 
 {% if mpi == "nompi" %}


### PR DESCRIPTION
This seems to be a problem with standalone MPAS builds.  It was introduced in #359, apparently with insufficient testing.

Part of this fix is some patching of SCORPIO 1.3.2 in our spack branch.