### PR TITLE
Don't remove `esmf` from conda environment

### DIFF
--- a/conda/bootstrap.py
+++ b/conda/bootstrap.py
@@ -276,16 +276,6 @@ def build_spack_env(config, update_spack, machine, compiler, mpi, env_name,
     scorpio = config.get('deploy', 'scorpio')
     albany = config.get('deploy', 'albany')
 
-    if esmf != 'None':
-        # remove conda-forge esmf because we will use the system build
-        commands = '{}; conda remove -y --force -n {} esmf'.format(
-            activate_env, env_name)
-        try:
-            check_call(commands)
-        except subprocess.CalledProcessError:
-            # it could be that esmf was already removed
-            pass
-
     spack_branch_base = f'{spack_base}/spack_for_mache_{mache_version}'
 
     specs = list()


### PR DESCRIPTION
This update to the conda environment causes problems if it happens in the middle of running with the conda environment elsewhere.  (A likely time this might happen is when creating a build matrix with many compilers and/or MPI implementations, where you want to start running before all builds have completed.)  It was always intended as a "safety" measure to ensure that ESMF comes from spack when we want that.  There's no indication that isn't happening anyway.