### PR TITLE
Fix version import in compass load package

### DIFF
--- a/compass/load/__init__.py
+++ b/compass/load/__init__.py
@@ -3,7 +3,7 @@ import os
 import subprocess
 import sys
 
-from compass import __version__ as compass_version
+from compass.version import __version__ as compass_version
 from jinja2 import Template
 from importlib import resources
 

--- a/conda/recipe/meta.yaml
+++ b/conda/recipe/meta.yaml
@@ -96,6 +96,7 @@ test:
     - compass setup --help
     - compass suite --help
     - compass clean --help
+    - create_compass_load_script --help
     - pip check
 
 


### PR DESCRIPTION
This was not changed when the version migrated to its own module.

A test has also been added to the conda recipe (and therefore CI) that would have caught this.