### PR TITLE
Write out a job script for suite and test cases during setup

### DIFF
--- a/compass/default.cfg
+++ b/compass/default.cfg
@@ -41,7 +41,7 @@ engine = scipy
 [job]
 
 # the name of the parallel job
-job_name = compass
+job_name = <<<default>>>
 
 # wall-clock time
 wall_time = 1:00:00

--- a/compass/default.cfg
+++ b/compass/default.cfg
@@ -36,3 +36,24 @@ format = NETCDF3_64BIT
 # required
 engine = scipy
 
+
+# Config options related to creating a job script
+[job]
+
+# the name of the parallel job
+job_name = compass
+
+# wall-clock time
+wall_time = 1:00:00
+
+# The job partition to use, by default, taken from the first partition (if any)
+# provided for the machine by mache
+partition = <<<default>>>
+
+# The job quality of service (QOS) to use, by default, taken from the first
+# qos (if any) provided for the machine by mache
+qos = <<<default>>>
+
+# The job constraint to use, by default, taken from the first constraint (if
+# any) provided for the  machine by mache
+constraint = <<<default>>>

--- a/compass/job/__init__.py
+++ b/compass/job/__init__.py
@@ -4,7 +4,8 @@ import os
 import numpy as np
 
 
-def write_job_script(config, machine, target_cores, min_cores, work_dir):
+def write_job_script(config, machine, target_cores, min_cores, work_dir,
+                     suite=''):
     """
 
     Parameters
@@ -24,6 +25,9 @@ def write_job_script(config, machine, target_cores, min_cores, work_dir):
 
     work_dir : str
         The work directory where the job script should be written
+
+    suite : str, optional
+        The name of the suite
     """
 
     if config.has_option('parallel', 'account'):
@@ -70,6 +74,11 @@ def write_job_script(config, machine, target_cores, min_cores, work_dir):
             constraint = ''
 
     job_name = config.get('job', 'job_name')
+    if job_name == '<<<default>>>':
+        if suite == '':
+            job_name = 'compass'
+        else:
+            job_name = f'compass_{suite}'
     wall_time = config.get('job', 'wall_time')
 
     template = Template(resources.read_text(
@@ -77,7 +86,12 @@ def write_job_script(config, machine, target_cores, min_cores, work_dir):
 
     text = template.render(job_name=job_name, account=account,
                            nodes=f'{nodes}', wall_time=wall_time, qos=qos,
-                           partition=partition, constraint=constraint)
-    script_filename = os.path.join(work_dir, 'job_script.sh')
+                           partition=partition, constraint=constraint,
+                           suite=suite)
+    if suite == '':
+        script_filename = 'compass_job_script.sh'
+    else:
+        script_filename = f'compass_job_script.{suite}.sh'
+    script_filename = os.path.join(work_dir, script_filename)
     with open(script_filename, 'w') as handle:
         handle.write(text)

--- a/compass/job/__init__.py
+++ b/compass/job/__init__.py
@@ -88,6 +88,7 @@ def write_job_script(config, machine, target_cores, min_cores, work_dir,
                            nodes=f'{nodes}', wall_time=wall_time, qos=qos,
                            partition=partition, constraint=constraint,
                            suite=suite)
+    text = _clean_up_whitespace(text)
     if suite == '':
         script_filename = 'compass_job_script.sh'
     else:
@@ -95,3 +96,27 @@ def write_job_script(config, machine, target_cores, min_cores, work_dir,
     script_filename = os.path.join(work_dir, script_filename)
     with open(script_filename, 'w') as handle:
         handle.write(text)
+
+
+def _clean_up_whitespace(text):
+    prev_line = None
+    lines = text.split('\n')
+    trimmed = list()
+    # remove extra blank lines
+    for line in lines:
+        if line != '' or prev_line != '':
+            trimmed.append(line)
+            prev_line = line
+
+    line = ''
+    lines = list()
+    # remove blank lines between comments
+    for next_line in trimmed:
+        if line != '' or not next_line.startswith('#'):
+            lines.append(line)
+        line = next_line
+
+    # add the last line that we missed and an extra blank line
+    lines.extend([trimmed[-1], ''])
+    text = '\n'.join(lines)
+    return text

--- a/compass/job/template.sh
+++ b/compass/job/template.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+#SBATCH  --job-name={{ job_name }}
+{% if account != '' -%}
+#SBATCH  --account={{ account}}
+{%- endif %}
+#SBATCH  --nodes={{ nodes }}
+#SBATCH  --output={{ job_name }}.o%j
+#SBATCH  --exclusive
+#SBATCH  --time={{ wall_time }}
+{% if qos != '' -%}
+#SBATCH  --qos={{ qos }}
+{%- endif %}
+{% if partition != '' -%}
+#SBATCH  --partition={{ partition }}
+{%- endif %}
+{% if constraint != '' -%}
+#SBATCH  --constraint={{ constraint }}
+{%- endif %}
+
+source load_compass_env.sh
+compass run
+

--- a/compass/job/template.sh
+++ b/compass/job/template.sh
@@ -18,5 +18,5 @@
 {%- endif %}
 
 source load_compass_env.sh
-compass run
+compass run {{suite}}
 

--- a/compass/machines/badger.cfg
+++ b/compass/machines/badger.cfg
@@ -37,6 +37,13 @@ spack = /usr/projects/climate/SHARED_CLIMATE/compass/badger/spack
 use_e3sm_hdf5_netcdf = False
 
 
+# The parallel section describes options related to running jobs in parallel
+[parallel]
+
+# account for running diagnostics jobs
+account = t22_ocean_time_step
+
+
 # Config options related to creating a job script
 [job]
 

--- a/compass/machines/badger.cfg
+++ b/compass/machines/badger.cfg
@@ -41,7 +41,7 @@ use_e3sm_hdf5_netcdf = False
 [parallel]
 
 # account for running diagnostics jobs
-account = t22_ocean_time_step
+account =
 
 
 # Config options related to creating a job script

--- a/compass/machines/badger.cfg
+++ b/compass/machines/badger.cfg
@@ -35,3 +35,10 @@ spack = /usr/projects/climate/SHARED_CLIMATE/compass/badger/spack
 # whether to use the same modules for hdf5, netcdf-c, netcdf-fortran and
 # pnetcdf as E3SM (spack modules are used otherwise)
 use_e3sm_hdf5_netcdf = False
+
+
+# Config options related to creating a job script
+[job]
+
+# The job quality of service (QOS) to use
+qos =

--- a/compass/machines/cori-haswell.cfg
+++ b/compass/machines/cori-haswell.cfg
@@ -38,3 +38,11 @@ use_e3sm_hdf5_netcdf = True
 
 # the version of ESMF to build if using system compilers and MPI (don't build)
 esmf = None
+
+
+# Config options related to creating a job script
+[job]
+
+# The job constraint to use, by default, taken from the first constraint (if
+# any) provided for the  machine by mache
+constraint = haswell

--- a/compass/setup.py
+++ b/compass/setup.py
@@ -10,6 +10,7 @@ from compass.mpas_cores import get_mpas_cores
 from compass.config import CompassConfigParser
 from compass.io import symlink
 from compass import provenance
+from compass.job import write_job_script
 
 
 def setup_cases(tests=None, numbers=None, config_file=None, machine=None,
@@ -163,8 +164,12 @@ def setup_cases(tests=None, numbers=None, config_file=None, machine=None,
 
     max_cores, max_of_min_cores = _get_required_cores(test_cases)
 
-    print('target cores: {}'.format(max_cores))
-    print('minimum cores: {}'.format(max_of_min_cores))
+    print(f'target cores: {max_cores}')
+    print(f'minimum cores: {max_of_min_cores}')
+
+    if machine is not None:
+        write_job_script(basic_config, machine, max_cores, max_of_min_cores,
+                         work_dir)
 
     return test_cases
 
@@ -309,6 +314,11 @@ def setup_case(path, test_case, config_file, machine, work_dir, baseline_dir,
         # make a symlink to the script for loading the compass conda env.
         symlink(script_filename, os.path.join(test_case_dir,
                                               'load_compass_env.sh'))
+
+    if machine is not None:
+        max_cores, max_of_min_cores = _get_required_cores({path: test_case})
+        write_job_script(config, machine, max_cores, max_of_min_cores,
+                         work_dir)
 
 
 def main():

--- a/compass/setup.py
+++ b/compass/setup.py
@@ -169,7 +169,7 @@ def setup_cases(tests=None, numbers=None, config_file=None, machine=None,
 
     if machine is not None:
         write_job_script(basic_config, machine, max_cores, max_of_min_cores,
-                         work_dir)
+                         work_dir, suite=suite_name)
 
     return test_cases
 
@@ -318,7 +318,7 @@ def setup_case(path, test_case, config_file, machine, work_dir, baseline_dir,
     if machine is not None:
         max_cores, max_of_min_cores = _get_required_cores({path: test_case})
         write_job_script(config, machine, max_cores, max_of_min_cores,
-                         work_dir)
+                         test_case_dir)
 
 
 def main():

--- a/docs/users_guide/quick_start.rst
+++ b/docs/users_guide/quick_start.rst
@@ -332,6 +332,69 @@ should contain a file ``test_case.pickle`` that contains the information
 ``load_compass_env.sh`` is a link to whatever load script you sourced before
 setting up the test case (see :ref:`conda_env`).
 
+Running with a job script
+-------------------------
+
+Alternatively, on supported machines, you can run the test case or suite with
+a job script generated automatically during setup, for example:
+
+.. code-block:: bash
+
+    cd <workdir>/<test_subdir>
+    sbatch job_script.sh
+
+You can edit the job script to change the wall-clock time (1 hour by default)
+or the number of nodes (scaled according to the number of cores require by the
+test cases by default).
+
+.. code-block:: bash
+    #!/bin/bash
+    #SBATCH  --job-name=compass
+    #SBATCH  --account=condo
+    #SBATCH  --nodes=5
+    #SBATCH  --output=compass.o%j
+    #SBATCH  --exclusive
+    #SBATCH  --time=1:00:00
+    #SBATCH  --qos=regular
+    #SBATCH  --partition=acme-small
+
+
+    source load_compass_env.sh
+    compass run
+
+You can also use config options, passed to ``compass suite`` or
+``compass setup`` with ``-f`` in a user config file to control the job script.
+The following are the config options that are relevant to job scripts:
+
+.. code-block:: cfg
+    # The parallel section describes options related to running jobs in parallel
+    [parallel]
+
+    # account for running diagnostics jobs
+    account = condo
+
+    # Config options related to creating a job script
+    [job]
+
+    # the name of the parallel job
+    job_name = compass
+
+    # wall-clock time
+    wall_time = 1:00:00
+
+    # The job partition to use, by default, taken from the first partition (if any)
+    # provided for the machine by mache
+    partition = acme-small
+
+    # The job quality of service (QOS) to use, by default, taken from the first
+    # qos (if any) provided for the machine by mache
+    qos = regular
+
+    # The job constraint to use, by default, taken from the first constraint (if
+    # any) provided for the  machine by mache
+    constraint =
+
+
 .. _suite_overview:
 
 Test Suites


### PR DESCRIPTION
On supported machines, write out a job script during setup.  The job script uses `mache` to figure out what account, partition, QOS and constraint to use.  It defaults to 1 hour wall-clock time (typically, more than enough) and determines the number of nodes based on the geometric mean (often a practical compromise) of the minimum and target number of cores required for a test case or suite.

Users (and developers) can alter the defaults with a config file, as detailed in the updated User's Guide.