### PR TITLE
Optionally build load scripts for multiple compilers/MPIs at the same time

### DIFF
--- a/conda/shared.py
+++ b/conda/shared.py
@@ -28,11 +28,11 @@ def parse_args(bootstrap):
                              " prefix")
     parser.add_argument("-p", "--python", dest="python", type=str,
                         help="The python version to deploy")
-    parser.add_argument("-i", "--mpi", dest="mpi", type=str,
-                        help="The MPI library to deploy, see the docs for "
-                             "details")
-    parser.add_argument("-c", "--compiler", dest="compiler", type=str,
-                        help="The name of the compiler")
+    parser.add_argument("-c", "--compiler", dest="compilers", type=str,
+                        nargs="*", help="The name of the compiler(s)")
+    parser.add_argument("-i", "--mpi", dest="mpis", type=str, nargs="*",
+                        help="The MPI library (or libraries) to deploy, see "
+                             "the docs for details")
     parser.add_argument("--env_only", dest="env_only", action='store_true',
                         help="Create only the compass environment, don't "
                              "install compilers or build SCORPIO")

--- a/conda/unsupported.txt
+++ b/conda/unsupported.txt
@@ -1,8 +1,10 @@
 # a list of unsupported machine, compiler and mpi combinations
 
-# don't compile
-badger, gnu, impi
+# no spack available
 anvil, gnu, impi
+badger, gnu, impi
+badger, intel, mvapich
+chrysalis, gnu, impi
 
 # compile but hang
 badger, intel, openmpi


### PR DESCRIPTION
When you configure the compass environment, you can pass a list of compilers and a corresponding list of MPI libraries, or you
can pass "all" for one or both of these.  If you leave either blank (or both), the default for the machine is used.  If you pass "all" for either or both, only supported compiler/MPI pairs are used.

This merge also adds some missing combination of machines, compiler and MPI libraries to the list of unsupported configurations.