### PR TITLE
A few deployment fixes

### DIFF
--- a/conda/configure_compass_env.py
+++ b/conda/configure_compass_env.py
@@ -90,7 +90,7 @@ def main():
         'conda activate {}'.format(base_activation_script, env_name)
     try:
         os.makedirs('conda/logs')
-    except FileExistsError:
+    except OSError:
         pass
 
     logger = get_logger(log_filename='conda/logs/prebootstrap.log',

--- a/conda/shared.py
+++ b/conda/shared.py
@@ -173,7 +173,7 @@ def get_logger(name, log_filename):
     print('Logging to: {}\n'.format(log_filename))
     try:
         os.remove(log_filename)
-    except FileNotFoundError:
+    except OSError:
         pass
     logger = logging.getLogger(name)
     handler = logging.FileHandler(log_filename)

--- a/conda/unsupported.txt
+++ b/conda/unsupported.txt
@@ -5,6 +5,9 @@ anvil, gnu, impi
 badger, gnu, impi
 badger, intel, mvapich
 chrysalis, gnu, impi
+compy, intel, mvapich2
+compy, pgi, impi
+compy, pgi, mvapich2
 
 # compile but hang
 badger, intel, openmpi


### PR DESCRIPTION
* Add 3 configs on Compy to unsupported: These got missed in a recent PR.
* Fix python 2.7 compatibility: Python 2 doesn't have a `FileNotFoundError` or `FileExistsError` so we use the more generic
`OSError`