### PR TITLE
Constrain mache version exactly

### DIFF
--- a/conda/compass_env/spec-file.template
+++ b/conda/compass_env/spec-file.template
@@ -15,7 +15,7 @@ jigsaw=0.9.14
 jigsawpy=0.3.3
 jupyter
 lxml
-mache >=1.3.2
+mache=1.3.2
 matplotlib-base
 metis
 mpas_tools=0.14.0

--- a/conda/configure_compass_env.py
+++ b/conda/configure_compass_env.py
@@ -53,7 +53,7 @@ def setup_install_env(env_name, activate_base, use_local, logger, recreate,
         channels = '--use-local'
     else:
         channels = ''
-    packages = 'progressbar2 jinja2 "mache>=1.3.2"'
+    packages = 'progressbar2 jinja2 "mache=1.3.2"'
     if recreate or not os.path.exists(env_path):
         print('Setting up a conda environment for installing compass\n')
         commands = '{}; ' \

--- a/conda/recipe/meta.yaml
+++ b/conda/recipe/meta.yaml
@@ -52,7 +52,7 @@ requirements:
     - jigsawpy 0.3.3
     - jupyter
     - lxml
-    - mache >=1.3.2
+    - mache 1.3.2
     - matplotlib-base
     - metis
     - mpas_tools 0.14.0


### PR DESCRIPTION
Before, we allowed updates to the latest `mache`, but this causes problems because shared Spack environments may not exist for that `mache` version yet.