### PR TITLE
Ignore fill values during variable validation

### DIFF
--- a/compass/validate.py
+++ b/compass/validate.py
@@ -299,6 +299,8 @@ def _compute_norms(da1, da2, quiet, max_l1_norm, max_l2_norm, max_linf_norm,
 
     result = True
     diff = numpy.abs(da1 - da2).values.ravel()
+    # skip entries where one field or both are a fill value
+    diff = diff[numpy.isfinite(diff)]
 
     l1_norm = numpy.linalg.norm(diff, ord=1)
     l2_norm = numpy.linalg.norm(diff, ord=2)


### PR DESCRIPTION
The consequence is that validation will not notice situations where one array has fill values and the other does not.