### PR TITLE
Add a flag to prevent the compass package from being reinstalled with the load script

### DIFF
--- a/conda/bootstrap.py
+++ b/conda/bootstrap.py
@@ -502,7 +502,8 @@ def write_load_compass(template_path, activ_path, conda_base, env_type,
     if env_type == 'dev':
         update_compass = \
             """
-            if [[ -f "./setup.py" && -d "compass" ]]; then
+            if [[ -z "${NO_COMPASS_REINSTALL}" && -f "./setup.py" && \\
+                  -d "compass" ]]; then
                # safe to assume we're in the compass repo
                # update the compass installation to point here
                mkdir -p conda/logs

--- a/utils/matrix/setup_matrix.py
+++ b/utils/matrix/setup_matrix.py
@@ -285,7 +285,8 @@ def compass_setup(script_name, setup_command, mpas_path, mpas_model, work_base,
 
     work_dir = '{}/{}'.format(work_base, suffix)
 
-    args = 'source {}; ' \
+    args = 'export NO_COMPASS_REINSTALL=true;' \
+           'source {}; ' \
            '{} ' \
            '-p {} ' \
            '-w {} ' \


### PR DESCRIPTION
This merge adds a check for an environment variable `$NO_COMPASS_REINSTALL` before reinstalling compass in edit mode from the current branch.

This is used in calls to `compass setup` within a matrix build.  Without this change, some runs might get disrupted because the `compass` executable or package is not available for a short time during reinstallation.