### PR TITLE
Optionally run steps as subprocesses

### DIFF
--- a/compass/run/serial.py
+++ b/compass/run/serial.py
@@ -223,15 +223,23 @@ def run_tests(suite_name, quiet=False, is_test_case=False, steps_to_run=None,
             sys.exit(1)
 
 
-def run_step():
+def run_step(step_is_subprocess=False):
     """
     Used by the framework to run a step when ``compass run`` gets called in the
     step's work directory
+
+    Parameters
+    ----------
+    step_is_subprocess : bool, optional
+        Whether the step is being run as a subprocess of a test case or suite
     """
     with open('step.pickle', 'rb') as handle:
         test_case, step = pickle.load(handle)
     test_case.steps_to_run = [step.name]
     test_case.new_step_log_file = False
+
+    if step_is_subprocess:
+        step.run_as_subprocess = False
 
     config = CompassConfigParser()
     config.add_from_file(step.config_filename)
@@ -253,10 +261,13 @@ def run_step():
         logger.info('')
         test_case.run()
 
-        logger.info('')
-        log_method_call(method=test_case.validate, logger=logger)
-        logger.info('')
-        test_case.validate()
+        if not step_is_subprocess:
+            # only perform validation if the step is being run by a user on its
+            # own
+            logger.info('')
+            log_method_call(method=test_case.validate, logger=logger)
+            logger.info('')
+            test_case.validate()
 
 
 def main():
@@ -276,6 +287,10 @@ def main():
                              "output as the test suite progresses.  Has no "
                              "effect when running test cases or steps on "
                              "their own.")
+    parser.add_argument("--step_is_subprocess", dest="step_is_subprocess",
+                        action="store_true",
+                        help="Used internally by compass to indicate that"
+                             "a step is being run as a subprocess.")
     args = parser.parse_args(sys.argv[2:])
     if args.suite is not None:
         run_tests(args.suite, quiet=args.quiet)
@@ -283,7 +298,7 @@ def main():
         run_tests(suite_name='test_case', quiet=args.quiet, is_test_case=True,
                   steps_to_run=args.steps, steps_not_to_run=args.no_steps)
     elif os.path.exists('step.pickle'):
-        run_step()
+        run_step(args.step_is_subprocess)
     else:
         pickles = glob.glob('*.pickle')
         if len(pickles) == 1:

--- a/compass/step.py
+++ b/compass/step.py
@@ -121,10 +121,18 @@ class Step(ABC):
     cached : bool
         Whether to get all of the outputs for the step from the database of
         cached outputs for this MPAS core
+
+    run_as_subprocess : bool
+        Whether to run this step as a subprocess, rather than just running
+        it directly from the test case.  It is useful to run a step as a
+        subprocess if there is not a good way to redirect output to a log
+        file (e.g. if the step calls external code that, in turn, calls
+        additional subprocesses).
     """
 
     def __init__(self, test_case, name, subdir=None, cores=1, min_cores=1,
-                 threads=1, max_memory=1000, max_disk=1000, cached=False):
+                 threads=1, max_memory=1000, max_disk=1000, cached=False,
+                 run_as_subprocess=False):
         """
         Create a new test case
 
@@ -164,6 +172,13 @@ class Step(ABC):
         cached : bool, optional
             Whether to get all of the outputs for the step from the database of
             cached outputs for this MPAS core
+
+        run_as_subprocess : bool
+            Whether to run this step as a subprocess, rather than just running
+            it directly from the test case.  It is useful to run a step as a
+            subprocess if there is not a good way to redirect output to a log
+            file (e.g. if the step calls external code that, in turn, calls
+            additional subprocesses).
         """
         self.name = name
         self.test_case = test_case
@@ -182,6 +197,8 @@ class Step(ABC):
 
         self.path = os.path.join(self.mpas_core.name, self.test_group.name,
                                  test_case.subdir, self.subdir)
+
+        self.run_as_subprocess = run_as_subprocess
 
         # child steps (or test cases) will add to these
         self.input_data = list()

--- a/compass/testcase.py
+++ b/compass/testcase.py
@@ -1,6 +1,6 @@
 import os
 
-from mpas_tools.logging import LoggingContext
+from mpas_tools.logging import LoggingContext, check_call
 from compass.parallel import get_available_cores_and_nodes
 from compass.logging import log_method_call
 
@@ -53,7 +53,7 @@ class TestCase:
         The base work directory
 
     baseline_dir : str, optional
-        Location of the same test case within the basesline work directory,
+        Location of the same test case within the baseline work directory,
         for use in comparing variables and timers
 
     stdout_logger : logging.Logger
@@ -158,8 +158,12 @@ class TestCase:
                 step.log_filename = self.log_filename
 
             self._print_to_stdout('  * step: {}'.format(step_name))
+
             try:
-                self._run_step(step, self.new_step_log_file)
+                if step.run_as_subprocess:
+                    self._run_step_as_subprocess(step, self.new_step_log_file)
+                else:
+                    self._run_step(step, self.new_step_log_file)
             except BaseException:
                 self._print_to_stdout('      Failed')
                 raise
@@ -287,3 +291,32 @@ class TestCase:
                 'output file(s) missing in step {} of {}/{}/{}: {}'.format(
                     step.name, step.mpas_core.name, step.test_group.name,
                     step.test_case.subdir, missing_files))
+
+    def _run_step_as_subprocess(self, step, new_log_file):
+        """
+        Run the requested step as a subprocess
+
+        Parameters
+        ----------
+        step : compass.Step
+            The step to run
+
+        new_log_file : bool
+            Whether to log to a new log file
+        """
+        logger = self.logger
+        cwd = os.getcwd()
+        test_name = step.path.replace('/', '_')
+        if new_log_file:
+            log_filename = '{}/{}.log'.format(cwd, step.name)
+            step.log_filename = log_filename
+            step_logger = None
+        else:
+            step_logger = logger
+            log_filename = None
+        with LoggingContext(name=test_name, logger=step_logger,
+                            log_filename=log_filename) as step_logger:
+
+            os.chdir(step.work_dir)
+            step_args = ['compass', 'run', '--step_is_subprocess']
+            check_call(step_args, step_logger)

--- a/docs/developers_guide/organization.rst
+++ b/docs/developers_guide/organization.rst
@@ -860,6 +860,20 @@ Some attributes are available after calling the base class' constructor
     subprocess if there is not a good way to redirect output to a log
     file (e.g. if the step calls external code that, in turn, calls
     additional subprocesses).
+    
+    The default behavior when python code calls one of the ``subprocess``
+    functions is that the output goes to ``stdout``/``stderr`` 
+    (i.e. the terminal).  When python code outside of compass 
+    (e.g. ``jigsawpy``) calls a ``subprocess`` function (e.g. to call
+    JIGSAW), that output goes to the terminal rather than a log file.  
+    For most output to ``stdout``/``stderr`` like ``print()`` statements,
+    ``check_call()`` in MPAS-Tools employs a "trick" to redirect that
+    output to a log file instead.  But that doesn't work with 
+    ``subprocess`` calls.  They continue to go to the terminal.  However,
+    if we call a given compass step as a subprocess while redirecting its
+    output to a log file, we can prevent unwanted output from ending up
+    in the terminal (the "outer" subprocess call gets redirected to a log
+    file even when the inner one does not).
 
 Another set of attributes is not useful until ``setup()`` is called by the
 ``compass`` framework:

--- a/docs/developers_guide/organization.rst
+++ b/docs/developers_guide/organization.rst
@@ -854,6 +854,13 @@ Some attributes are available after calling the base class' constructor
     Whether to get all of the outputs for the step from the database of
     cached outputs for the MPAS core that this step belongs to
 
+``self.run_as_subprocess``
+    Whether to run this step as a subprocess, rather than just running
+    it directly from the test case.  It is useful to run a step as a
+    subprocess if there is not a good way to redirect output to a log
+    file (e.g. if the step calls external code that, in turn, calls
+    additional subprocesses).
+
 Another set of attributes is not useful until ``setup()`` is called by the
 ``compass`` framework:
 


### PR DESCRIPTION
This will enable calls to external packages that may, in turn, call subprocess.  If this functionality is called directly, there is no obvious way to capture stdout/stderr in a log file.  One example of this is jigsawpy's functionality for creating icosahedral meshes.