### PR TITLE
Add data interpolation to Antarctica mesh generation case

### DIFF
--- a/compass/landice/mesh.py
+++ b/compass/landice/mesh.py
@@ -158,7 +158,10 @@ def set_cell_width(self, section, thk, vx=None, vy=None,
     high_dist = float(section.get('high_dist'))
     low_dist = float(section.get('low_dist'))
     # convert km to m
-    cull_distance = float(section.get('cull_distance')) * 1.e3
+    try:
+        cull_distance = float(section.get('cull_distance')) * 1.e3
+    except:
+        cull_distance = float(section.get('cull_cells')) * min_spac * 1.e3
 
     # Make cell spacing function mapping from log speed to cell spacing
     if section.get('use_speed') == 'True':
@@ -209,12 +212,12 @@ def set_cell_width(self, section, thk, vx=None, vy=None,
     cell_width = np.minimum(cell_width, spacing3)
 
     # Set large cell_width in areas we are going to cull anyway (speeds up
-    # whole process). Use 10x the cull_distance to avoid this affecting
+    # whole process). Use 3x the cull_distance to avoid this affecting
     # cell size in the final mesh. There may be a more rigorous way to set
     # that distance.
     if dist_to_edge is not None:
         mask = np.logical_and(
-            thk == 0.0, dist_to_edge > (10. * cull_distance))
+            thk == 0.0, dist_to_edge > (3. * cull_distance))
         cell_width[mask] = max_spac
 
     return cell_width

--- a/compass/landice/tests/antarctica/antarctica.cfg
+++ b/compass/landice/tests/antarctica/antarctica.cfg
@@ -1,6 +1,9 @@
 # config options for antarctica test cases
 [antarctica]
 
+# path to directory containing BedMachine and Measures datasets
+data_path = /usr/projects/climate/trhille/data/
+
 # number of levels in the mesh
 levels = 5
 

--- a/compass/landice/tests/antarctica/antarctica.cfg
+++ b/compass/landice/tests/antarctica/antarctica.cfg
@@ -9,8 +9,8 @@ nProcs = 360
 # distance from ice margin to cull (km).
 # Set to a value <= 0 if you do not want
 # to cull based on distance from margin.
-cull_distance = 70.0
-
+#cull_distance = 70.0
+cull_cells = 10.0
 # mesh density parameters
 # minimum cell spacing (meters)
 min_spac = 8.e3

--- a/compass/landice/tests/antarctica/antarctica.cfg
+++ b/compass/landice/tests/antarctica/antarctica.cfg
@@ -4,6 +4,8 @@
 # number of levels in the mesh
 levels = 5
 
+# number of processors to use for ESMF_RegridWeightGen
+nProcs = 360
 # distance from ice margin to cull (km).
 # Set to a value <= 0 if you do not want
 # to cull based on distance from margin.

--- a/compass/landice/tests/antarctica/antarctica.cfg
+++ b/compass/landice/tests/antarctica/antarctica.cfg
@@ -8,7 +8,7 @@ data_path = /usr/projects/climate/trhille/data/
 levels = 5
 
 # number of processors to use for ESMF_RegridWeightGen
-nProcs = 360
+nProcs = 180
 # Number of cells from ice margin to cull
 cull_cells = 10
 # mesh density parameters

--- a/compass/landice/tests/antarctica/antarctica.cfg
+++ b/compass/landice/tests/antarctica/antarctica.cfg
@@ -6,11 +6,8 @@ levels = 5
 
 # number of processors to use for ESMF_RegridWeightGen
 nProcs = 360
-# distance from ice margin to cull (km).
-# Set to a value <= 0 if you do not want
-# to cull based on distance from margin.
-#cull_distance = 70.0
-cull_cells = 10.0
+# Number of cells from ice margin to cull
+cull_cells = 10
 # mesh density parameters
 # minimum cell spacing (meters)
 min_spac = 8.e3

--- a/compass/landice/tests/antarctica/mesh.py
+++ b/compass/landice/tests/antarctica/mesh.py
@@ -60,7 +60,7 @@ class Mesh(Step):
         logger = self.logger
         config = self.config
         section = config['antarctica']
-        data_path = '/usr/projects/climate/trhille/data/'
+        data_path = section.get('data_path')
         nProcs = section.get('nProcs')
         logger.info('calling build_cell_width')
         cell_width, x1, y1, geom_points, geom_edges, floodFillMask = \

--- a/compass/landice/tests/antarctica/mesh.py
+++ b/compass/landice/tests/antarctica/mesh.py
@@ -157,8 +157,11 @@ class Mesh(Step):
         data.variables['vErr'][:] = np.sqrt(data.variables['ex'][:]**2
                                             + data.variables['ey'][:]**2)
 
-        data.variables['bheatflx'][:] *= -1.e-3  # correct units
+        data.variables['bheatflx'][:] *= -1.e-3  # correct units and sign
         data.variables['bheatflx'].units = 'W m-2'
+
+        data.variables['subm'][:] *= -1.0  # correct basal melting sign
+        data.variables['subm_ss'][:] *= -1.0 
 
         data.renameVariable('dhdt', 'dHdt')
         data.renameVariable('thkerr', 'topgerr')

--- a/compass/landice/tests/antarctica/mesh.py
+++ b/compass/landice/tests/antarctica/mesh.py
@@ -241,35 +241,35 @@ class Mesh(Step):
                 'Antarctica.nc', '-p', 'ais-bedmap2']
         check_call(args, logger=logger)
 
-        logger.info('creating scrip file for destination mesh')
-        scrip_from_mpas('Antarctica.nc', 'Antarctica.scrip.nc')
-        args = ['create_SCRIP_file_from_MPAS_mesh.py',
-                '-m', 'Antarctica.nc',
-                '-s', 'Antarctica.scrip.nc']
-        check_call(args, logger=logger)
-        # Testing shows 5 badger/grizzly nodes works well.
-        # 2 nodes is too few. I have not tested anything in between.
-        logger.info('generating gridded dataset -> MPAS weights')
-        args = ['srun', '-n', nProcs, 'ESMF_RegridWeightGen', '--source',
-                data_path+'BedMachineAntarctica_2020-07-15_v02.scrip.nc',
-                '--destination',
-                'Antarctica.scrip.nc',
-                '--weight', 'BedMachine_to_MPAS_weights.nc',
-                '--method', 'conserve',
-                "-i", "-64bit_offset",
-                "--dst_regional", "--src_regional", '--netcdf4']
-        check_call(args, logger=logger)
-
-        logger.info('generating gridded dataset -> MPAS weights')
-        args = ['srun', '-n', nProcs, 'ESMF_RegridWeightGen', '--source',
-                data_path+'antarctica_ice_velocity_450m_v2.scrip.nc',
-                '--destination',
-                'Antarctica.scrip.nc',
-                '--weight', 'measures_to_MPAS_weights.nc',
-                '--method', 'conserve',
-                "-i", "-64bit_offset", '--netcdf4',
-                "--dst_regional", "--src_regional", '--ignore_unmapped']
-        check_call(args, logger=logger)
+#        logger.info('creating scrip file for destination mesh')
+#        scrip_from_mpas('Antarctica.nc', 'Antarctica.scrip.nc')
+#        args = ['create_SCRIP_file_from_MPAS_mesh.py',
+#                '-m', 'Antarctica.nc',
+#                '-s', 'Antarctica.scrip.nc']
+#        check_call(args, logger=logger)
+#        # Testing shows 5 badger/grizzly nodes works well.
+#        # 2 nodes is too few. I have not tested anything in between.
+#        logger.info('generating gridded dataset -> MPAS weights')
+#        args = ['srun', '-n', nProcs, 'ESMF_RegridWeightGen', '--source',
+#                data_path+'BedMachineAntarctica_2020-07-15_v02.scrip.nc',
+#                '--destination',
+#                'Antarctica.scrip.nc',
+#                '--weight', 'BedMachine_to_MPAS_weights.nc',
+#                '--method', 'conserve',
+#                "-i", "-64bit_offset",
+#                "--dst_regional", "--src_regional", '--netcdf4']
+#        check_call(args, logger=logger)
+#
+#        logger.info('generating gridded dataset -> MPAS weights')
+#        args = ['srun', '-n', nProcs, 'ESMF_RegridWeightGen', '--source',
+#                data_path+'antarctica_ice_velocity_450m_v2.scrip.nc',
+#                '--destination',
+#                'Antarctica.scrip.nc',
+#                '--weight', 'measures_to_MPAS_weights.nc',
+#                '--method', 'conserve',
+#                "-i", "-64bit_offset", '--netcdf4',
+#                "--dst_regional", "--src_regional", '--ignore_unmapped']
+#        check_call(args, logger=logger)
         # Must add iceMask to interpolation script.
         # interpolate fields from composite dataset
         logger.info('calling interpolate_to_mpasli_grid.py')
@@ -278,28 +278,28 @@ class Mesh(Step):
                 '-d', 'Antarctica.nc', '-m', 'd', '-v',
                 'floatingBasalMassBal', 'basalHeatFlux', 'sfcMassBal',
                 'surfaceAirTemperature', 'observedThicknessTendency',
-                 'observedThicknessTendencyUncertainty']
+                 'observedThicknessTendencyUncertainty', 'thickness']
         check_call(args, logger=logger)
 
-        # interpoalte fields from BedMachine and Measures
-        # Using conservative remapping
-        logger.info('calling interpolate_to_mpasli_grid.py')
-        args = ['interpolate_to_mpasli_grid.py', '-s',
-                data_path+'BedMachineAntarctica_2020-07-15_v02_edits_floodFill_extrap_fillVostok.nc',
-                '-d', 'Antarctica.nc', '-m', 'e',
-                '-w', 'BedMachine_to_MPAS_weights.nc']
-        check_call(args, logger=logger)
-
-        logger.info('calling interpolate_to_mpasli_grid.py')
-        args = ['interpolate_to_mpasli_grid.py', '-s',
-                data_path+'antarctica_ice_velocity_450m_v2_edits_extrap.nc',
-                '-d', 'Antarctica.nc', '-m', 'e',
-                '-w', 'measures_to_MPAS_weights.nc',
-                '-v', 'observedSurfaceVelocityX',
-                'observedSurfaceVelocityY',
-                'observedSurfaceVelocityUncertainty']
-        check_call(args, logger=logger)
-
+#        # interpoalte fields from BedMachine and Measures
+#        # Using conservative remapping
+#        logger.info('calling interpolate_to_mpasli_grid.py')
+#        args = ['interpolate_to_mpasli_grid.py', '-s',
+#                data_path+'BedMachineAntarctica_2020-07-15_v02_edits_floodFill_extrap_fillVostok.nc',
+#                '-d', 'Antarctica.nc', '-m', 'e',
+#                '-w', 'BedMachine_to_MPAS_weights.nc']
+#        check_call(args, logger=logger)
+#
+#        logger.info('calling interpolate_to_mpasli_grid.py')
+#        args = ['interpolate_to_mpasli_grid.py', '-s',
+#                data_path+'antarctica_ice_velocity_450m_v2_edits_extrap.nc',
+#                '-d', 'Antarctica.nc', '-m', 'e',
+#                '-w', 'measures_to_MPAS_weights.nc',
+#                '-v', 'observedSurfaceVelocityX',
+#                'observedSurfaceVelocityY',
+#                'observedSurfaceVelocityUncertainty']
+#        check_call(args, logger=logger)
+#
         logger.info('Marking domain boundaries dirichlet')
         args = ['mark_domain_boundaries_dirichlet.py',
                 '-f', 'Antarctica.nc']
@@ -314,19 +314,19 @@ class Mesh(Step):
 
         # Clean up: trim to iceMask and set large velocity
         # uncertainties where appropriate.
-        data = netCDF4.Dataset('Antarctica.nc', 'r+')
-        data.set_auto_mask(False)
-        data.variables['thickness'][:] *= (data.variables['iceMask'][:] > 1.5)
-        
-        mask = np.logical_or(
-                np.isnan(
-                    data.variables['observedSurfaceVelocityUncertainty'][:]),
-                data.variables['thickness'][:] < 1.0)
-        mask = np.logical_or(
-                mask,
-                data.variables['observedSurfaceVelocityUncertainty'][:] == 0.0)
-        data.variables['observedSurfaceVelocityUncertainty'][0,mask[0,:]] = 1.0
-        data.close()
+#        data = netCDF4.Dataset('Antarctica.nc', 'r+')
+#        data.set_auto_mask(False)
+#        data.variables['thickness'][:] *= (data.variables['iceMask'][:] > 1.5)
+#        
+#        mask = np.logical_or(
+#                np.isnan(
+#                    data.variables['observedSurfaceVelocityUncertainty'][:]),
+#                data.variables['thickness'][:] < 1.0)
+#        mask = np.logical_or(
+#                mask,
+#                data.variables['observedSurfaceVelocityUncertainty'][:] == 0.0)
+#        data.variables['observedSurfaceVelocityUncertainty'][0,mask[0,:]] = 1.0
+#        data.close()
 
     def build_cell_width(self):
         """
@@ -365,7 +365,7 @@ class Mesh(Step):
         # Calculate distance from each grid point to ice edge
         # and grounding line, for use in cell spacing functions.
         distToEdge, distToGL = get_dist_to_edge_and_GL(self, thk, topg, x1,
-                                                       y1, window_size=1.e5)
+                                                       y1, section='antarctica')
         # optional - plot distance calculation
         # plt.pcolor(distToEdge/1000.0); plt.colorbar(); plt.show()
 

--- a/compass/landice/tests/antarctica/mesh.py
+++ b/compass/landice/tests/antarctica/mesh.py
@@ -241,35 +241,35 @@ class Mesh(Step):
                 'Antarctica.nc', '-p', 'ais-bedmap2']
         check_call(args, logger=logger)
 
-#        logger.info('creating scrip file for destination mesh')
-#        scrip_from_mpas('Antarctica.nc', 'Antarctica.scrip.nc')
-#        args = ['create_SCRIP_file_from_MPAS_mesh.py',
-#                '-m', 'Antarctica.nc',
-#                '-s', 'Antarctica.scrip.nc']
-#        check_call(args, logger=logger)
-#        # Testing shows 5 badger/grizzly nodes works well.
-#        # 2 nodes is too few. I have not tested anything in between.
-#        logger.info('generating gridded dataset -> MPAS weights')
-#        args = ['srun', '-n', nProcs, 'ESMF_RegridWeightGen', '--source',
-#                data_path+'BedMachineAntarctica_2020-07-15_v02.scrip.nc',
-#                '--destination',
-#                'Antarctica.scrip.nc',
-#                '--weight', 'BedMachine_to_MPAS_weights.nc',
-#                '--method', 'conserve',
-#                "-i", "-64bit_offset",
-#                "--dst_regional", "--src_regional", '--netcdf4']
-#        check_call(args, logger=logger)
-#
-#        logger.info('generating gridded dataset -> MPAS weights')
-#        args = ['srun', '-n', nProcs, 'ESMF_RegridWeightGen', '--source',
-#                data_path+'antarctica_ice_velocity_450m_v2.scrip.nc',
-#                '--destination',
-#                'Antarctica.scrip.nc',
-#                '--weight', 'measures_to_MPAS_weights.nc',
-#                '--method', 'conserve',
-#                "-i", "-64bit_offset", '--netcdf4',
-#                "--dst_regional", "--src_regional", '--ignore_unmapped']
-#        check_call(args, logger=logger)
+        logger.info('creating scrip file for destination mesh')
+        scrip_from_mpas('Antarctica.nc', 'Antarctica.scrip.nc')
+        args = ['create_SCRIP_file_from_MPAS_mesh.py',
+                '-m', 'Antarctica.nc',
+                '-s', 'Antarctica.scrip.nc']
+        check_call(args, logger=logger)
+        # Testing shows 5 badger/grizzly nodes works well.
+        # 2 nodes is too few. I have not tested anything in between.
+        logger.info('generating gridded dataset -> MPAS weights')
+        args = ['srun', '-n', nProcs, 'ESMF_RegridWeightGen', '--source',
+                data_path+'BedMachineAntarctica_2020-07-15_v02.scrip.nc',
+                '--destination',
+                'Antarctica.scrip.nc',
+                '--weight', 'BedMachine_to_MPAS_weights.nc',
+                '--method', 'conserve',
+                "-i", "-64bit_offset",
+                "--dst_regional", "--src_regional", '--netcdf4']
+        check_call(args, logger=logger)
+
+        logger.info('generating gridded dataset -> MPAS weights')
+        args = ['srun', '-n', nProcs, 'ESMF_RegridWeightGen', '--source',
+                data_path+'antarctica_ice_velocity_450m_v2.scrip.nc',
+                '--destination',
+                'Antarctica.scrip.nc',
+                '--weight', 'measures_to_MPAS_weights.nc',
+                '--method', 'conserve',
+                "-i", "-64bit_offset", '--netcdf4',
+                "--dst_regional", "--src_regional", '--ignore_unmapped']
+        check_call(args, logger=logger)
         # Must add iceMask to interpolation script.
         # interpolate fields from composite dataset
         logger.info('calling interpolate_to_mpasli_grid.py')
@@ -281,25 +281,25 @@ class Mesh(Step):
                  'observedThicknessTendencyUncertainty', 'thickness']
         check_call(args, logger=logger)
 
-#        # interpoalte fields from BedMachine and Measures
-#        # Using conservative remapping
-#        logger.info('calling interpolate_to_mpasli_grid.py')
-#        args = ['interpolate_to_mpasli_grid.py', '-s',
-#                data_path+'BedMachineAntarctica_2020-07-15_v02_edits_floodFill_extrap_fillVostok.nc',
-#                '-d', 'Antarctica.nc', '-m', 'e',
-#                '-w', 'BedMachine_to_MPAS_weights.nc']
-#        check_call(args, logger=logger)
-#
-#        logger.info('calling interpolate_to_mpasli_grid.py')
-#        args = ['interpolate_to_mpasli_grid.py', '-s',
-#                data_path+'antarctica_ice_velocity_450m_v2_edits_extrap.nc',
-#                '-d', 'Antarctica.nc', '-m', 'e',
-#                '-w', 'measures_to_MPAS_weights.nc',
-#                '-v', 'observedSurfaceVelocityX',
-#                'observedSurfaceVelocityY',
-#                'observedSurfaceVelocityUncertainty']
-#        check_call(args, logger=logger)
-#
+        # interpoalte fields from BedMachine and Measures
+        # Using conservative remapping
+        logger.info('calling interpolate_to_mpasli_grid.py')
+        args = ['interpolate_to_mpasli_grid.py', '-s',
+                data_path+'BedMachineAntarctica_2020-07-15_v02_edits_floodFill_extrap_fillVostok.nc',
+                '-d', 'Antarctica.nc', '-m', 'e',
+                '-w', 'BedMachine_to_MPAS_weights.nc']
+        check_call(args, logger=logger)
+
+        logger.info('calling interpolate_to_mpasli_grid.py')
+        args = ['interpolate_to_mpasli_grid.py', '-s',
+                data_path+'antarctica_ice_velocity_450m_v2_edits_extrap.nc',
+                '-d', 'Antarctica.nc', '-m', 'e',
+                '-w', 'measures_to_MPAS_weights.nc',
+                '-v', 'observedSurfaceVelocityX',
+                'observedSurfaceVelocityY',
+                'observedSurfaceVelocityUncertainty']
+        check_call(args, logger=logger)
+
         logger.info('Marking domain boundaries dirichlet')
         args = ['mark_domain_boundaries_dirichlet.py',
                 '-f', 'Antarctica.nc']
@@ -314,19 +314,19 @@ class Mesh(Step):
 
         # Clean up: trim to iceMask and set large velocity
         # uncertainties where appropriate.
-#        data = netCDF4.Dataset('Antarctica.nc', 'r+')
-#        data.set_auto_mask(False)
-#        data.variables['thickness'][:] *= (data.variables['iceMask'][:] > 1.5)
-#        
-#        mask = np.logical_or(
-#                np.isnan(
-#                    data.variables['observedSurfaceVelocityUncertainty'][:]),
-#                data.variables['thickness'][:] < 1.0)
-#        mask = np.logical_or(
-#                mask,
-#                data.variables['observedSurfaceVelocityUncertainty'][:] == 0.0)
-#        data.variables['observedSurfaceVelocityUncertainty'][0,mask[0,:]] = 1.0
-#        data.close()
+        data = netCDF4.Dataset('Antarctica.nc', 'r+')
+        data.set_auto_mask(False)
+        data.variables['thickness'][:] *= (data.variables['iceMask'][:] > 1.5)
+        
+        mask = np.logical_or(
+                np.isnan(
+                    data.variables['observedSurfaceVelocityUncertainty'][:]),
+                data.variables['thickness'][:] < 1.0)
+        mask = np.logical_or(
+                mask,
+                data.variables['observedSurfaceVelocityUncertainty'][:] == 0.0)
+        data.variables['observedSurfaceVelocityUncertainty'][0,mask[0,:]] = 1.0
+        data.close()
 
     def build_cell_width(self):
         """

--- a/compass/landice/tests/antarctica/mesh.py
+++ b/compass/landice/tests/antarctica/mesh.py
@@ -221,19 +221,20 @@ class Mesh(Step):
         data.variables['iceMask'][:] = 0.
         data.close()
 
-        logger.info('creating scrip file for BedMachine dataset')
-        args = ['create_SCRIP_file_from_planar_rectangular_grid.py',
-                '-i', data_path+'BedMachineAntarctica_2020-07-15_v02.nc',
-                '-s', 'BedMachineAntarctica_2020-07-15_v02.scrip.nc',
-                '-p', 'ais-bedmap2', '-r', '2']
-        check_call(args, logger=logger)
+        # Uncomment below if you need to create scrip files.
+        #logger.info('creating scrip file for BedMachine dataset')
+        #args = ['create_SCRIP_file_from_planar_rectangular_grid.py',
+        #        '-i', data_path+'BedMachineAntarctica_2020-07-15_v02_edits_floodFill_extrap_fillVostok.nc',
+        #        '-s', data_paht+'BedMachineAntarctica_2020-07-15_v02.scrip.nc',
+        #        '-p', 'ais-bedmap2', '-r', '2']
+        #check_call(args, logger=logger)
 
-        logger.info('creating scrip file for velocity dataset')
-        args = ['create_SCRIP_file_from_planar_rectangular_grid.py',
-                '-i', data_path+'antarctica_ice_velocity_450m_v2_edits.nc',
-                '-s', 'antarctica_ice_velocity_450m_v2.scrip.nc',
-                '-p', 'ais-bedmap2', '-r', '2']
-        check_call(args, logger=logger)
+        #logger.info('creating scrip file for velocity dataset')
+        #args = ['create_SCRIP_file_from_planar_rectangular_grid.py',
+        #        '-i', data_path+'antarctica_ice_velocity_450m_v2_edits_extrap.nc',
+        #        '-s', data_path+'antarctica_ice_velocity_450m_v2.scrip.nc',
+        #        '-p', 'ais-bedmap2', '-r', '2']
+        #check_call(args, logger=logger)
 
         logger.info('calling set_lat_lon_fields_in_planar_grid.py')
         args = ['set_lat_lon_fields_in_planar_grid.py', '-f',
@@ -246,11 +247,11 @@ class Mesh(Step):
                 '-m', 'Antarctica.nc',
                 '-s', 'Antarctica.scrip.nc']
         check_call(args, logger=logger)
-        # Testing shows 5 to 10 badger/grizzly nodes works well.
+        # Testing shows 5 badger/grizzly nodes works well.
         # 2 nodes is too few. I have not tested anything in between.
         logger.info('generating gridded dataset -> MPAS weights')
         args = ['srun', '-n', nProcs, 'ESMF_RegridWeightGen', '--source',
-                'BedMachineAntarctica_2020-07-15_v02.scrip.nc',
+                data_path+'BedMachineAntarctica_2020-07-15_v02.scrip.nc',
                 '--destination',
                 'Antarctica.scrip.nc',
                 '--weight', 'BedMachine_to_MPAS_weights.nc',
@@ -261,7 +262,7 @@ class Mesh(Step):
 
         logger.info('generating gridded dataset -> MPAS weights')
         args = ['srun', '-n', nProcs, 'ESMF_RegridWeightGen', '--source',
-                'antarctica_ice_velocity_450m_v2.scrip.nc',
+                data_path+'antarctica_ice_velocity_450m_v2.scrip.nc',
                 '--destination',
                 'Antarctica.scrip.nc',
                 '--weight', 'measures_to_MPAS_weights.nc',
@@ -284,7 +285,7 @@ class Mesh(Step):
         # Using conservative remapping
         logger.info('calling interpolate_to_mpasli_grid.py')
         args = ['interpolate_to_mpasli_grid.py', '-s',
-                data_path+'BedMachineAntarctica_2020-07-15_v02_edits_floodFill_extrap.nc',
+                data_path+'BedMachineAntarctica_2020-07-15_v02_edits_floodFill_extrap_fillVostok.nc',
                 '-d', 'Antarctica.nc', '-m', 'e',
                 '-w', 'BedMachine_to_MPAS_weights.nc']
         check_call(args, logger=logger)

--- a/compass/landice/tests/antarctica/mesh.py
+++ b/compass/landice/tests/antarctica/mesh.py
@@ -175,13 +175,6 @@ class Mesh(Step):
 
         data.close()
 
-        logger.info('creating scrip file for gridded dataset')
-        args = ['create_SCRIP_file_from_planar_rectangular_grid.py',
-                '-i', 'antarctica_8km_2020_10_20_floodFillMask_filledFields.nc',
-                '-s', 'antarctica_8km_2020_10_20_floodFillMask_filledFields.scrip.nc',
-                '-p', 'ais-bedmap2', '-r', '2']
-        check_call(args, logger=logger)
-
         logger.info('calling interpolate_to_mpasli_grid.py')
         args = ['interpolate_to_mpasli_grid.py', '-s',
                 'antarctica_8km_2020_10_20_floodFillMask.nc', '-d',
@@ -189,15 +182,12 @@ class Mesh(Step):
 
         check_call(args, logger=logger)
 
-        # Cull a certain distance from the ice margin
-        cullDistance = section.get('cull_distance')
-        if float(cullDistance) > 0.:
-            logger.info('calling define_cullMask.py')
-            args = ['define_cullMask.py', '-f',
-                    'ais_8km_preCull.nc', '-m',
-                    'distance', '-d', cullDistance]
-
-        check_call(args, logger=logger)
+       # Cull a certain distance from the ice margin
+        cullCells = section.get('cull_cells')
+        logger.info('calling define_cullMask.py')
+        args = ['define_cullMask.py', '-f',
+                'ais_8km_preCull.nc', '-m',
+                'numCells', '-n', cullCells]
 
         check_call(args, logger=logger)
 
@@ -327,7 +317,7 @@ class Mesh(Step):
                 np.isnan(
                     data.variables['observedSurfaceVelocityUncertainty'][:]),
                 data.variables['thickness'][:] < 1.0)
-        data.variables['observedSurfaceVelocityUncertainty'][mask] = 1.0
+        data.variables['observedSurfaceVelocityUncertainty'][0,mask[0,:]] = 1.0
         data.close()
 
     def build_cell_width(self):

--- a/compass/landice/tests/antarctica/mesh.py
+++ b/compass/landice/tests/antarctica/mesh.py
@@ -296,7 +296,7 @@ class Mesh(Step):
         args = ['interpolate_to_mpasli_grid.py', '-s',
                 data_path+'BedMachineAntarctica_2020-07-15_v02_edits.nc',
                 '-d', 'Antarctica.nc', '-m', 'e',
-                 '-w', 'BedMachine_to_MPAS_weights.nc']
+                '-w', 'BedMachine_to_MPAS_weights.nc']
         check_call(args, logger=logger)
 
         logger.info('calling interpolate_to_mpasli_grid.py')
@@ -321,9 +321,12 @@ class Mesh(Step):
         # Clean up: trim to iceMask
         data = netCDF4.Dataset('Antarctica.nc', 'r+')
         data.set_auto_mask(False)
-        data.variables['thickness'][:] *= (data.variables['iceMask'][:] > 0.5)
+        #data.variables['thickness'][:] *= (data.variables['iceMask'][:] > 0.5)
         
-        mask = np.where(np.isnan(data.variables['observedSurfaceVelocityUncertainty'][:]))
+        mask = np.logical_or(
+                np.isnan(
+                    data.variables['observedSurfaceVelocityUncertainty'][:]),
+                data.variables['thickness'][:] < 1.0)
         data.variables['observedSurfaceVelocityUncertainty'][mask] = 1.0
         data.close()
 

--- a/compass/landice/tests/greenland/mesh.py
+++ b/compass/landice/tests/greenland/mesh.py
@@ -173,8 +173,8 @@ class Mesh(Step):
 
         # Calculate distance from each grid point to ice edge
         # and grounding line, for use in cell spacing functions.
-        distToEdge, distToGL = get_dist_to_edge_and_GL(self, thk, topg, x1,
-                                                       y1, window_size=1.e5)
+        distToEdge, distToGL = get_dist_to_edge_and_GL(
+                self, thk, topg, x1, y1, section='high_res_GIS_mesh')
         # optional - plot distance calculation
         # plt.pcolor(distToEdge/1000.0); plt.colorbar(); plt.show()
 

--- a/compass/landice/tests/humboldt/mesh.py
+++ b/compass/landice/tests/humboldt/mesh.py
@@ -206,8 +206,9 @@ class Mesh(Step):
 
         # Calculate distance from each grid point to ice edge
         # and grounding line, for use in cell spacing functions.
-        distToEdge, distToGL = get_dist_to_edge_and_GL(self, thk, topg, x1,
-                                                       y1, window_size=1.e5)
+        distToEdge, distToGL = get_dist_to_edge_and_GL(
+                                            self, thk, topg, x1,
+                                            y1, section='humboldt_mesh')
         # optional - plot distance calculation
         # plt.pcolor(distToEdge/1000.0); plt.colorbar(); plt.show()
 

--- a/compass/landice/tests/kangerlussuaq/mesh.py
+++ b/compass/landice/tests/kangerlussuaq/mesh.py
@@ -200,8 +200,9 @@ class Mesh(Step):
 
         # Calculate distance from each grid point to ice edge
         # and grounding line, for use in cell spacing functions.
-        distToEdge, distToGL = get_dist_to_edge_and_GL(self, thk, topg, x1,
-                                                       y1, window_size=1.e5)
+        distToEdge, distToGL = get_dist_to_edge_and_GL(
+                                self, thk, topg, x1,
+                                y1, section='high_res_Kangerlussuaq_mesh')
         # optional - plot distance calculation
         # plt.pcolor(distToEdge/1000.0); plt.colorbar(); plt.show()
 


### PR DESCRIPTION
Interpolate data from gridded datasets to Antarctic mesh within COMPASS. This takes care of the peculiarities of the current gridded compilation dataset (antarctica_8km_2020_10_20.nc), as well as using conservative remapping directly from the high-resolution BedMachineAntarctica and MeASUReS velocity datasets. There is a fairly heavy degree of pre-processing done to get the BedMachine and MeASUReS datasets ready to be used here. The pre-processing includes renaming variables, setting reasonable _FillValue and missing_value attributes, extrapolating fields to avoid interpolation ramps at ice margins, updating mask values, and raising the bed topography at Lake Vostok to ensure a flat ice surface. Those data files and processing scripts currently live here on Badger: `/usr/projects/climate/trhille/data`. Eventually that pre-processing could be integrated into a new step in COMPASS, or the processed data files could be added to the server on Anvil and downloaded as needed.

The conservative remapping step using ESMF_RegridWeightGen requires multiple nodes in order to not run out of memory. This is a major short-coming of the current set up for this test-case, which runs the entire case on five Badger nodes, even though four of those nodes are only used for a small fraction of the total run time. This should probably be updated to be a separate step in the future in order to save on cost.

This currently requires use of a branch of MPAS-Tools to interpolate the `iceMask` variable: https://github.com/trhille/MPAS-Tools/tree/add_iceMask_to_interp_script. The steps to use this are:
        1. Create your compass environment as normal and source the load script
        2. Go to your MPAS-Tools directory and checkout https://github.com/trhille/MPAS-Tools/tree/add_iceMask_to_interp_script
        3. Still from MPAS-Tools directory  python -m pip install -e conda_package
        4. Proceed setting up test case as normal

This can take a long time to run because the conservative remapping is slow. I recommend at least a 4 hour job on 5 nodes for medium resolution (~6–30km).