### PR TITLE
Fix automatic choice of compiler and MPI for OSX

### DIFF
--- a/compass/machines/conda-osx.cfg
+++ b/compass/machines/conda-osx.cfg
@@ -6,4 +6,4 @@
 compiler = clang
 
 # the system MPI library to use for gnu compiler
-mpi_gnu = mpich
+mpi_clang = mpich

--- a/conda/bootstrap.py
+++ b/conda/bootstrap.py
@@ -67,7 +67,7 @@ def get_compilers_mpis(config, machine, compilers, mpis, source_path):
         all_compilers = ['gfortran']
         all_mpis = ['mpich', 'openmpi']
     elif machine == 'conda-osx':
-        all_compilers = ['gfortran-clang']
+        all_compilers = ['clang']
         all_mpis = ['mpich', 'openmpi']
     else:
         machine_info = MachineInfo(machine)


### PR DESCRIPTION
Previously, there was confusion between just "clang" and "gfortran-clang" as the compiler choice.  Now, we just stick with "clang" everywhere (with the understanding that gfortran is still used as the Fortran compiler).

closes #399