### PR TITLE
Move run operations from `testcase` to `run/serial`

### DIFF
--- a/compass/run/serial.py
+++ b/compass/run/serial.py
@@ -123,18 +123,32 @@ def run_tests(suite_name, quiet=False, is_test_case=False, steps_to_run=None,
                     steps_to_run, steps_not_to_run, config, test_case.steps)
 
                 test_start = time.time()
-                log_function_call(function=_run_test, logger=test_logger)
+                log_method_call(method=test_case.run, logger=test_logger)
                 test_logger.info('')
-                test_list = ', '.join(test_case.steps_to_run)
-                test_logger.info(f'Running steps: {test_list}')
                 try:
-                    _run_test(test_case)
+                    test_case.run()
                     run_status = success_str
                     test_pass = True
                 except BaseException:
                     run_status = error_str
                     test_pass = False
-                    test_logger.exception('Exception raised in run_tests()')
+                    test_logger.exception('Exception raised in the test '
+                                          'case\'s run() method')
+
+                if test_pass:
+                    log_function_call(function=_run_test, logger=test_logger)
+                    test_logger.info('')
+                    test_list = ', '.join(test_case.steps_to_run)
+                    test_logger.info(f'Running steps: {test_list}')
+                    try:
+                        _run_test(test_case)
+                        run_status = success_str
+                        test_pass = True
+                    except BaseException:
+                        run_status = error_str
+                        test_pass = False
+                        test_logger.exception('Exception raised while running '
+                                              'the steps of the test case')
 
                 if test_pass:
                     test_logger.info('')
@@ -146,7 +160,8 @@ def run_tests(suite_name, quiet=False, is_test_case=False, steps_to_run=None,
                     except BaseException:
                         run_status = error_str
                         test_pass = False
-                        test_logger.exception('Exception raised in validate()')
+                        test_logger.exception('Exception raised in the test '
+                                              'case\'s validate() method')
 
                 baseline_status = None
                 internal_status = None

--- a/compass/run/serial.py
+++ b/compass/run/serial.py
@@ -329,6 +329,9 @@ def main():
 
 
 def _update_steps_to_run(steps_to_run, steps_not_to_run, config, steps):
+    """
+    Update the steps to run
+    """
     if steps_to_run is None:
         steps_to_run = config.get('test_case',
                                   'steps_to_run').replace(',', ' ').split()
@@ -356,8 +359,7 @@ def _update_steps_to_run(steps_to_run, steps_not_to_run, config, steps):
 
 def _print_to_stdout(test_case, message):
     """
-    write out a message to stdout if we're not running a single step on its
-    own
+    Write out a message to stdout if we're not running a single step
     """
     if test_case.stdout_logger is not None:
         test_case.stdout_logger.info(message)
@@ -368,14 +370,7 @@ def _print_to_stdout(test_case, message):
 
 def _run_test(test_case):
     """
-    Run each step of the test case.  Test cases can override this method
-    to perform additional operations in addition to running the test case's
-    steps
-    Developers need to make sure they call ``super().run()`` at some point
-    in the overridden ``run()`` method to actually call the steps of the
-    run.  The developer will need to decide where in the overridden method
-    to make the call to ``super().run()``, after any updates to steps
-    based on config options, typically at the end of the new method.
+    Run each step of the test case
     """
     logger = test_case.logger
     cwd = os.getcwd()
@@ -405,14 +400,6 @@ def _run_test(test_case):
 def _run_step(test_case, step, new_log_file):
     """
     Run the requested step
-
-    Parameters
-    ----------
-    step : compass.Step
-        The step to run
-
-    new_log_file : bool
-        Whether to log to a new log file
     """
     logger = test_case.logger
     config = test_case.config
@@ -463,14 +450,6 @@ def _run_step(test_case, step, new_log_file):
 def _run_step_as_subprocess(test_case, step, new_log_file):
     """
     Run the requested step as a subprocess
-
-    Parameters
-    ----------
-    step : compass.Step
-        The step to run
-
-    new_log_file : bool
-        Whether to log to a new log file
     """
     logger = test_case.logger
     cwd = os.getcwd()

--- a/compass/testcase.py
+++ b/compass/testcase.py
@@ -132,8 +132,8 @@ class TestCase:
 
     def run(self):
         """
-        Run the test case.  This can be used to configure steps (e.g.,
-        setting ``ntasks`` or ``cpus_per_task``) before running them.
+        This method is deprecated. Use ``step.constrain_resources()`` and
+        ``step.runtime_setup()`` instead
         """
         self.logger.warn('The testcase run() method is deprecated, please use '
                          'step.runtime_setup()')

--- a/compass/testcase.py
+++ b/compass/testcase.py
@@ -135,8 +135,7 @@ class TestCase:
         This method is deprecated. Use ``step.constrain_resources()`` and
         ``step.runtime_setup()`` instead
         """
-        self.logger.warn('The testcase run() method is deprecated, please use '
-                         'step.runtime_setup()')
+        pass
 
     def validate(self):
         """

--- a/compass/testcase.py
+++ b/compass/testcase.py
@@ -130,6 +130,14 @@ class TestCase:
         """
         pass
 
+    def run(self):
+        """
+        Run the test case.  This can be used to configure steps (e.g.,
+        setting ``ntasks`` or ``cpus_per_task``) before running them.
+        """
+        self.logger.warn('The testcase run() method is deprecated, please use '
+                         'step.runtime_setup()')
+
     def validate(self):
         """
         Test cases can override this method to perform validation of variables

--- a/compass/testcase.py
+++ b/compass/testcase.py
@@ -1,9 +1,5 @@
 import os
 
-from mpas_tools.logging import LoggingContext, check_call
-from compass.parallel import get_available_cores_and_nodes
-from compass.logging import log_method_call
-
 
 class TestCase:
     """
@@ -134,41 +130,6 @@ class TestCase:
         """
         pass
 
-    def run(self):
-        """
-        Run each step of the test case.  Test cases can override this method
-        to perform additional operations in addition to running the test case's
-        steps
-
-        Developers need to make sure they call ``super().run()`` at some point
-        in the overridden ``run()`` method to actually call the steps of the
-        run.  The developer will need to decide where in the overridden method
-        to make the call to ``super().run()``, after any updates to steps
-        based on config options, typically at the end of the new method.
-        """
-        logger = self.logger
-        cwd = os.getcwd()
-        for step_name in self.steps_to_run:
-            step = self.steps[step_name]
-            if step.cached:
-                logger.info('  * Cached step: {}'.format(step_name))
-                continue
-            step.config = self.config
-            if self.log_filename is not None:
-                step.log_filename = self.log_filename
-
-            self._print_to_stdout('  * step: {}'.format(step_name))
-
-            try:
-                if step.run_as_subprocess:
-                    self._run_step_as_subprocess(step, self.new_step_log_file)
-                else:
-                    self._run_step(step, self.new_step_log_file)
-            except BaseException:
-                self._print_to_stdout('      Failed')
-                raise
-            os.chdir(cwd)
-
     def validate(self):
         """
         Test cases can override this method to perform validation of variables
@@ -218,100 +179,3 @@ class TestCase:
 
             if both_pass:
                 raise ValueError('Comparison failed, see above.')
-
-    def _print_to_stdout(self, message):
-        """
-        write out a message to stdout if we're not running a single step on its
-        own
-        """
-        if self.stdout_logger is not None:
-            self.stdout_logger.info(message)
-            if self.logger != self.stdout_logger:
-                # also write it to the log file
-                self.logger.info(message)
-
-    def _run_step(self, step, new_log_file):
-        """
-        Run the requested step
-
-        Parameters
-        ----------
-        step : compass.Step
-            The step to run
-
-        new_log_file : bool
-            Whether to log to a new log file
-        """
-        logger = self.logger
-        config = self.config
-        cwd = os.getcwd()
-        available_cores, _ = get_available_cores_and_nodes(config)
-        step.constrain_resources(available_cores)
-
-        missing_files = list()
-        for input_file in step.inputs:
-            if not os.path.exists(input_file):
-                missing_files.append(input_file)
-
-        if len(missing_files) > 0:
-            raise OSError(
-                'input file(s) missing in step {} of {}/{}/{}: {}'.format(
-                    step.name, step.mpas_core.name, step.test_group.name,
-                    step.test_case.subdir, missing_files))
-
-        test_name = step.path.replace('/', '_')
-        if new_log_file:
-            log_filename = '{}/{}.log'.format(cwd, step.name)
-            step.log_filename = log_filename
-            step_logger = None
-        else:
-            step_logger = logger
-            log_filename = None
-        with LoggingContext(name=test_name, logger=step_logger,
-                            log_filename=log_filename) as step_logger:
-            step.logger = step_logger
-            os.chdir(step.work_dir)
-            step_logger.info('')
-            log_method_call(method=step.run, logger=step_logger)
-            step_logger.info('')
-            step.run()
-
-        missing_files = list()
-        for output_file in step.outputs:
-            if not os.path.exists(output_file):
-                missing_files.append(output_file)
-
-        if len(missing_files) > 0:
-            raise OSError(
-                'output file(s) missing in step {} of {}/{}/{}: {}'.format(
-                    step.name, step.mpas_core.name, step.test_group.name,
-                    step.test_case.subdir, missing_files))
-
-    def _run_step_as_subprocess(self, step, new_log_file):
-        """
-        Run the requested step as a subprocess
-
-        Parameters
-        ----------
-        step : compass.Step
-            The step to run
-
-        new_log_file : bool
-            Whether to log to a new log file
-        """
-        logger = self.logger
-        cwd = os.getcwd()
-        test_name = step.path.replace('/', '_')
-        if new_log_file:
-            log_filename = '{}/{}.log'.format(cwd, step.name)
-            step.log_filename = log_filename
-            step_logger = None
-        else:
-            step_logger = logger
-            log_filename = None
-        with LoggingContext(name=test_name, logger=step_logger,
-                            log_filename=log_filename) as step_logger:
-
-            os.chdir(step.work_dir)
-            step_args = ['compass', 'run', '--step_is_subprocess']
-            check_call(step_args, step_logger)

--- a/docs/developers_guide/api.rst
+++ b/docs/developers_guide/api.rst
@@ -86,7 +86,7 @@ run
    :toctree: generated/
 
    run_tests
-   run_step
+   run_single_step
 
 
 cache

--- a/docs/developers_guide/framework.rst
+++ b/docs/developers_guide/framework.rst
@@ -79,12 +79,16 @@ run.serial module
 
 The function :py:func:`compass.run.serial.run_tests()` is used to run a
 test suite or test case and :py:func:`compass.run.serial.run_single_step()` is
-used to run a single step using ``compass run``.  Suites run from the base work
-directory with a pickle file starting with the suite name, or ``custom.pickle``
-if a suite name was not given. Test cases or steps run from their respective
-subdirectories with a ``testcase.pickle`` or ``step.pickle`` file in them.
-Both of these functions reads the local pickle file to retrieve information
-about the test suite, test case and/or step that was stored during setup.
+used to run a single step using ``compass run``.  ``run_tests()`` performs
+setup operations like creating a log file and figuring out the number of tasks
+and CPUs per task for each step, then it calls each step's ``run()`` method.
+
+Suites run from the base work directory with a pickle file starting with the
+suite name, or ``custom.pickle`` if a suite name was not given. Test cases or
+steps run from their respective subdirectories with a ``testcase.pickle`` or
+``step.pickle`` file in them. Both of these functions reads the local pickle
+file to retrieve information about the test suite, test case and/or step that
+was stored during setup.
 
 If :py:func:`compass.run.serial.run_tests()` is used for a test suite, it will
 run each test case in the test suite in the order that they are given in the

--- a/docs/developers_guide/framework.rst
+++ b/docs/developers_guide/framework.rst
@@ -78,10 +78,10 @@ run.serial module
 ~~~~~~~~~~~~~~~~~
 
 The function :py:func:`compass.run.serial.run_tests()` is used to run a
-test suite or test case and :py:func:`compass.run.serial.run_step()` is used to
-run a step using ``compass run``.  Suites run from the base work directory
-with a pickle file starting with the suite name, or ``custom.pickle`` if a
-suite name was not given. Test cases or steps run from their respective
+test suite or test case and :py:func:`compass.run.serial.run_single_step()` is
+used to run a single step using ``compass run``.  Suites run from the base work
+directory with a pickle file starting with the suite name, or ``custom.pickle``
+if a suite name was not given. Test cases or steps run from their respective
 subdirectories with a ``testcase.pickle`` or ``step.pickle`` file in them.
 Both of these functions reads the local pickle file to retrieve information
 about the test suite, test case and/or step that was stored during setup.
@@ -99,9 +99,9 @@ within the test case or suite and validation against a baseline (depending on
 the implementation of the ``validate()`` method in the test case and whether a
 baseline was provided during setup).
 
-:py:func:`compass.run.run_step()` runs only the selected step from a given
-test case, skipping any others, displaying the output in the terminal window
-rather than a log file.
+:py:func:`compass.run.run_single_step()` runs only the selected step from a
+given test case, skipping any others, displaying the output in the terminal
+window rather than a log file.
 
 .. _dev_cache:
 
@@ -208,12 +208,12 @@ as well as the APIs for :py:class:`mpas_tools.logging.LoggingContext` and
 
 For the most part, the ``compass`` framework handles logging for you, so
 test-case developers won't have to create their own ``logger`` objects.  They
-are arguments to the test case's :ref:`dev_test_case_run` or step's
-:ref:`dev_step_run`.  If you run a step on its own, no log file is created
-and logging happens to ``stdout``/``stderr``.  If you run the full test case,
-each step gets logged to its own log file within the test case's work
-directory.  If you run a test suite, each test case and its steps get logged
-to a file in the ``case_output`` directory of the suite's work directory.
+are attributes that belong to the step or test case.  If you run a step on its
+own, no log file is created and logging happens to ``stdout``/``stderr``.  If
+you run a full test case, each step gets logged to its own log file within the
+test case's work directory.  If you run a test suite, each test case and its
+steps get logged to a file in the ``case_output`` directory of the suite's work
+directory.
 
 Although the logger will capture ``print`` statements, anywhere with a
 ``run()`` function or the functions called inside that function, it is a good
@@ -222,12 +222,12 @@ expectation that the output may go to a log file.
 
 Even more important, subprocesses that produce output should always be called
 with :py:func:`mpas_tools.logging.check_call`, passing in the ``logger`` that
-is an argument to the ``run()`` function.  Otherwise, output will go to
-``stdout``/``stderr`` even when the intention is to write all output to a
-log file.  Whereas logging can capture ``stdout``/``stderr`` to make sure that
-the ``print`` statements actually go to log files when desired, there is no
-similar trick for automatically capturing the output from direct calls to
-``subprocess`` functions.  Here is a code snippet from
+belongs to the step.  Otherwise, output will go to ``stdout``/``stderr`` even
+when the intention is to write all output to a log file.  Whereas logging can
+capture ``stdout``/``stderr`` to make sure that the ``print`` statements
+actually go to log files when desired, there is no similar trick for
+automatically capturing the output from direct calls to ``subprocess``
+functions.  Here is a code snippet from
 :py:meth:`compass.landice.tests.dome.setup_mesh.SetupMesh.run()`:
 
 .. code-block:: python

--- a/docs/developers_guide/organization.rst
+++ b/docs/developers_guide/organization.rst
@@ -1166,6 +1166,12 @@ runtime_setup()
 
 The ``runtime_setup()`` method is used to modify any behaviors of the step at
 runtime, in the way that :py:meth:`compass.TestCase.run()` was previously used.
+This includes things like partitioning an MPAS mesh across processors and
+computing a times step based on config options that might have been modified
+by the user.  It must not include modifying the ``ntasks``, ``min_tasks``,
+``cpus_per_task``, ``min_cpus_per_task`` or ``openmp_threads`` attributes.
+These attributes must be altered by overriding
+:ref:`dev_step_constrain_resources`.
 
 .. _dev_step_run:
 

--- a/docs/developers_guide/organization.rst
+++ b/docs/developers_guide/organization.rst
@@ -358,8 +358,14 @@ A test case can be a module but is usually a python package so it can
 incorporate modules for its steps and/or config files, namelists, and streams
 files.  The test case must include a class that descends from
 :py:class:`compass.TestCase`.  In addition to a constructor (``__init__()``),
-the class will often override the ``configure()``, ``run()`` and ``validate()``
-methods of the base class, as described below.
+the class will often override the ``configure()`` and ``validate()`` methods of
+the base class, as described below.
+
+The ``run()`` method in :py:class:`compass.TestCase` is deprecated; behaviors
+at runtime can instead be handled by individual steps by overriding the
+:py:meth:`compass.Step.constrain_resources()` and
+:py:meth:`compass.Step.runtime_setup()` methods.  Details about these methods
+are described further in :ref:`dev_steps`.
 
 .. _dev_test_case_class:
 
@@ -396,10 +402,10 @@ case:
     A dictionary of steps in the test case with step names as keys
 
 ``self.steps_to_run``
-    A list of the steps to run when ``run()`` gets called.  This list
-    includes all steps by default but can be replaced with a list of only
-    those tests that should run by default if some steps are optional and
-    should be run manually by the user.
+    A list of the steps to run when :py:func:`compass.run.serial.run_tests()`
+    gets called.  This list includes all steps by default but can be replaced
+    with a list of only those tests that should run by default if some steps
+    are optional and should be run manually by the user.
 
 Another set of attributes is not useful until ``configure()`` is called by the
 ``compass`` framework:
@@ -422,11 +428,12 @@ Another set of attributes is not useful until ``configure()`` is called by the
 These can be used to make further alterations to the config options or to add
 symlinks files in the test case's work directory.
 
-Finally, one attribute is available only when the ``run()`` method gets called
-by the framework:
+Finally, one attribute is available only when the
+:py:func:`compass.run.serial.run_tests()` function gets called by the
+framework:
 
 ``self.logger``
-    A logger for output from the test case.  This gets passed on to other
+    A logger for output from the test case.  This gets accessed by other
     methods and functions that use the logger to write their output to the log
     file.
 
@@ -690,8 +697,7 @@ as in :py:meth:`compass.ocean.tests.global_ocean.files_for_e3sm.FilesForE3SM.con
 
 The ``configure()`` method is not the right place for adding or modifying steps
 that belong to a test case.  Steps should be added during init and altered only
-in their own ``setup()`` method or at the beginning of the test case's
-``run()`` method before running the steps themselves.
+in their own ``setup()`` or ``runtime_setup()`` methods.
 
 Test cases that don't need to change config options don't need to override
 ``configure()`` at all.
@@ -1179,6 +1185,23 @@ As an example, here is
 Some parts of the mesh computation (creating masks for culling) are done using
 python multiprocessing, so the ``cpus_per_task`` and ``min_cpus_per_task``
 attributes are set to appropriate values based on config options.
+
+.. _dev_step_constrain_resources:
+
+constrain_resources()
+^^^^^^^^^^^^^^^^^^^^^
+
+The ``constrain_resources()`` method is used to update the ``ntasks``,
+``min_tasks``, ``cpus_per_task``, and ``min_cpus_per_task`` when these options
+are set in the config file.
+
+.. _dev_step_runtime_setup:
+
+runtime_setup()
+^^^^^^^^^^^^^^^
+
+The ``runtime_setup()`` method is used to modify any behaviors of the step at
+runtime, in the way that :py:meth:`compass.TestCase.run()` was previously used.
 
 .. _dev_step_run:
 

--- a/docs/developers_guide/organization.rst
+++ b/docs/developers_guide/organization.rst
@@ -707,59 +707,12 @@ Test cases that don't need to change config options don't need to override
 run()
 ^^^^^
 
-The base class's :py:meth:`compass.TestCase.run()` performs some
-framework-level operations like creating a log file and figuring out the number
-of tasks and CPUs per task for each step, then it calls each step's ``run()``
-method.  It is important that child classes remember to call the base class'
-version of the method with ``super().run()`` as part of overriding the
-``run()`` method. Test case that just need to run their steps don't need to
-override the ``run()`` method at all.
-
-In some circumstances, it will be appropriate to update properties of the steps
-in the test case based on config options that the user may have changed.  This
-should only be necessary for config options related to the resources used by
-the step: the target number of tasks, the minimum number of tasks, the
-target number of CPUs per task, the minimum number of CPUs per task, and the
-number of OpenMP threads.  Other config options can simply be read in from
-within the step's ``run()`` function as needed, but these performance-related
-config options affect how the step runs and must be set *before* the step can
-run.
-
-In :py:meth:`compass.ocean.tests.global_ocean.init.Init.run()`, we see examples
-of updating the steps' attributes based on config options:
-
-.. code-block:: python
-
-    def run(self):
-        """
-        Run each step of the testcase
-        """
-        config = self.config
-        steps = self.steps_to_run
-        if 'initial_state' in steps:
-            step = self.steps['initial_state']
-            # get the these properties from the config options
-            step.ntasks = config.getint('global_ocean', 'init_ntasks')
-            step.min_tasks = config.getint('global_ocean', 'init_min_tasks')
-            step.threads = config.getint('global_ocean', 'init_threads')
-
-        if 'ssh_adjustment' in steps:
-            step = self.steps['ssh_adjustment']
-            # get the these properties from the config options
-            step.ntasks = config.getint('global_ocean', 'forward_ntasks')
-            step.min_tasks = config.getint('global_ocean', 'forward_min_tasks')
-            step.threads = config.getint('global_ocean', 'forward_threads')
-
-        # run the steps
-        super().run()
-
-As mentioned in :ref:`dev_test_case_class`, the ``self.steps_to_run`` attribute
-may either be the full list of steps that would typically be run to complete
-the test case (the value given to it at init) or it may be a single test case
-because the user is running the steps manually, one at a time.  For this
-reason, it is always a good idea to check if a given step is being run before
-altering the entries any of its attributes based on config options, as shown
-in the example.
+The functionality of :py:meth:`compass.TestCase.run()` has been moved to the
+:py:func:`compass.run.serial.run_tests()` function.  The ``run`` method is now
+deprecated and should not be used to modify runtime processes;
+:py:meth:`compass.Step.constrain_resources()` and
+:py:meth:`compass.Step.runtime_setup()` should be used instead.  These methods
+are further explained in :ref:`dev_steps`.
 
 .. _dev_test_case_validate:
 
@@ -1136,6 +1089,26 @@ for later processing).
 
 Finally, two input and one output file are added.
 
+.. _dev_step_constrain_resources:
+
+constrain_resources()
+^^^^^^^^^^^^^^^^^^^^^
+
+The ``constrain_resources()`` method is used to update the ``ntasks``,
+``min_tasks``, ``cpus_per_task``, and ``min_cpus_per_task`` attributes prior to
+running the step, in case the user has modified these in the config options.
+These performance-related attributes affect how the step runs and must be set
+prior to runtime, whereas other options can be set within ``runtime_setup()``.
+
+``constrain_resources()`` is called within
+:py:func:`compass.run.serial.run_tests()`, but can be overridden if desired.
+The typical reason to override this function would be to get config options for
+``ntasks``, ``min_tasks``, ``cpus_per_task``, etc. and set the corresponding
+attributes.  Another reason might be to set these attributes using an algorithm
+(e.g. based on the number of cells in the mesh used in the step.)
+When overriding ``constrain_resources``, it is important to also call the base
+class' version of the method with ``super().constrain_resources()``.
+
 .. _dev_step_setup:
 
 setup()
@@ -1185,15 +1158,6 @@ As an example, here is
 Some parts of the mesh computation (creating masks for culling) are done using
 python multiprocessing, so the ``cpus_per_task`` and ``min_cpus_per_task``
 attributes are set to appropriate values based on config options.
-
-.. _dev_step_constrain_resources:
-
-constrain_resources()
-^^^^^^^^^^^^^^^^^^^^^
-
-The ``constrain_resources()`` method is used to update the ``ntasks``,
-``min_tasks``, ``cpus_per_task``, and ``min_cpus_per_task`` when these options
-are set in the config file.
 
 .. _dev_step_runtime_setup:
 


### PR DESCRIPTION
I moved all run operations from `testcase.run()` and various other internal methods to `run/serial`. This will allow future task parallel modifications to be limited to the run module. The `run()` method in `testcase` will be deprecated in favor of using `step.runtime_setup()` for custom setup operations at runtime. 

I have tested this change by running the `nightly` suite against the baseline without any issues. I'll be making some changes to the documentation as well to account for the changes to the framework. 