### PR TITLE
Add command-line args to the Step class and a ModelStep base class

### DIFF
--- a/compass/model.py
+++ b/compass/model.py
@@ -4,6 +4,208 @@ import xarray
 from mpas_tools.logging import check_call
 from compass.parallel import run_command
 
+from compass.step import Step
+
+
+class ModelStep(Step):
+    """
+    Attributes
+    ----------
+
+    namelist : str
+        The name of the namelist file
+
+    streams : str
+        The name of the streams file
+
+    update_pio : bool
+        Whether to modify the namelist so the number of PIO tasks and the
+        stride between them is consistent with the number of nodes and
+        cores (one PIO task per node).
+
+    make_graph : bool
+        Whether to make a graph file from the given MPAS mesh file.  If
+        ``True``, ``mesh_filename`` must be given.
+
+    mesh_filename : str
+        The name of an MPAS mesh file to use to make the graph file
+
+    partition_graph : bool
+        Whether to partition the domain for the requested number of cores.
+        If so, the partitioning executable is taken from the ``partition``
+        option of the ``[executables]`` config section.
+
+    graph_filename : str
+        The name of the graph file to partition
+
+    """
+    def __init__(self, test_case, name, subdir=None, ntasks=None,
+                 min_tasks=None, openmp_threads=None, max_memory=None,
+                 cached=False, namelist=None, streams=None, update_pio=True,
+                 make_graph=False, mesh_filename=None, partition_graph=True,
+                 graph_filename='graph.info'):
+        """
+        Make a step for running the model
+
+        Parameters
+        ----------
+        test_case : compass.TestCase
+            The test case this step belongs to
+
+        name : str
+            The name of the step
+
+        subdir : str, optional
+            the subdirectory for the step.  The default is ``name``
+
+        ntasks : int, optional
+            the target number of tasks the step would ideally use.  If too
+            few cores are available on the system to accommodate the number of
+            tasks and the number of cores per task, the step will run on
+            fewer tasks as long as as this is not below ``min_tasks``
+
+        min_tasks : int, optional
+            the number of tasks the step requires.  If the system has too
+            few cores to accommodate the number of tasks and cores per task,
+            the step will fail
+
+        openmp_threads : int, optional
+            the number of OpenMP threads to use
+
+        max_memory : int, optional
+            the amount of memory that the step is allowed to use in MB.
+            This is currently just a placeholder for later use with task
+            parallelism
+
+        cached : bool, optional
+            Whether to get all of the outputs for the step from the database of
+            cached outputs for this MPAS core
+
+        namelist : str, optional
+            The name of the namelist file, default is ``namelist.<mpas_core>``
+
+        streams : str, optional
+            The name of the streams file, default is ``streams.<mpas_core>``
+
+        update_pio : bool, optional
+            Whether to modify the namelist so the number of PIO tasks and the
+            stride between them is consistent with the number of nodes and
+            cores (one PIO task per node).
+
+        make_graph : bool, optional
+            Whether to make a graph file from the given MPAS mesh file.  If
+            ``True``, ``mesh_filename`` must be given.
+
+        mesh_filename : str, optional
+            The name of an MPAS mesh file to use to make the graph file
+
+        partition_graph : bool, optional
+            Whether to partition the domain for the requested number of cores.
+            If so, the partitioning executable is taken from the ``partition``
+            option of the ``[executables]`` config section.
+
+        graph_filename : str, optional
+            The name of the graph file to partition
+        """
+        super().__init__(test_case=test_case, name=name, subdir=subdir,
+                         cpus_per_task=openmp_threads,
+                         min_cpus_per_task=openmp_threads, ntasks=ntasks,
+                         min_tasks=min_tasks, openmp_threads=openmp_threads,
+                         max_memory=max_memory, cached=cached)
+
+        mpas_core = test_case.mpas_core.name
+        if namelist is None:
+            namelist = 'namelist.{}'.format(mpas_core)
+
+        if streams is None:
+            streams = 'streams.{}'.format(mpas_core)
+
+        self.namelist = namelist
+        self.streams = streams
+        self.update_pio = update_pio
+        self.make_graph = make_graph
+        self.mesh_filename = mesh_filename
+        self.partition_graph = partition_graph
+        self.graph_filename = graph_filename
+
+        self.add_input_file(filename='<<<model>>>')
+
+    def setup(self):
+        """ Setup the command-line arguments """
+        config = self.config
+        model = config.get('executables', 'model')
+        model_basename = os.path.basename(model)
+        self.args = [f'./{model_basename}', '-n', self.namelist,
+                     '-s', self.streams]
+
+    def set_model_resources(self, ntasks=None, min_tasks=None,
+                            openmp_threads=None, max_memory=None):
+        """
+        Update the resources for the step.  This can be done within init,
+        ``setup()`` or ``runtime_setup()`` for the step that this step
+        belongs to, or init, ``configure()`` or ``run()`` for the test case
+        that this step belongs to.
+        Parameters
+        ----------
+        ntasks : int, optional
+            the number of tasks the step would ideally use.  If too few
+            cores are available on the system to accommodate the number of
+            tasks and the number of cores per task, the step will run on
+            fewer tasks as long as as this is not below ``min_tasks``
+
+        min_tasks : int, optional
+            the number of tasks the step requires.  If the system has too
+            few cores to accommodate the number of tasks and cores per task,
+            the step will fail
+
+        openmp_threads : int, optional
+            the number of OpenMP threads to use
+
+        max_memory : int, optional
+            the amount of memory that the step is allowed to use in MB.
+            This is currently just a placeholder for later use with task
+            parallelism
+        """
+        self.set_resources(cpus_per_task=openmp_threads,
+                           min_cpus_per_task=openmp_threads, ntasks=ntasks,
+                           min_tasks=min_tasks, openmp_threads=openmp_threads,
+                           max_memory=max_memory)
+
+    def runtime_setup(self):
+        """
+        Update PIO namelist options, make graph file, and partition graph file
+        (if any of these are requested)
+        """
+
+        namelist = self.namelist
+        cores = self.ntasks
+        config = self.config
+        logger = self.logger
+
+        if self.update_pio:
+            self.update_namelist_pio(namelist)
+
+        if self.make_graph:
+            make_graph_file(mesh_filename=self.mesh_filename,
+                            graph_filename=self.graph_filename)
+
+        if self.partition_graph:
+            partition(cores, config, logger, graph_file=self.graph_filename)
+
+    def process_inputs_and_outputs(self):
+        """
+        Process the model as an input, then call the parent class' version
+        """
+        for entry in self.input_data:
+            filename = entry['filename']
+
+            if filename == '<<<model>>>':
+                model = self.config.get('executables', 'model')
+                entry['filename'] = os.path.basename(model)
+                entry['target'] = os.path.abspath(model)
+
+        super().process_inputs_and_outputs()
+
 
 def run_model(step, update_pio=True, partition_graph=True,
               graph_file='graph.info', namelist=None, streams=None):

--- a/compass/ocean/tests/baroclinic_channel/forward.py
+++ b/compass/ocean/tests/baroclinic_channel/forward.py
@@ -1,8 +1,7 @@
-from compass.model import run_model
-from compass.step import Step
+from compass.model import ModelStep
 
 
-class Forward(Step):
+class Forward(ModelStep):
     """
     A step for performing forward MPAS-Ocean runs as part of baroclinic
     channel test cases.
@@ -58,7 +57,7 @@ class Forward(Step):
                                'namelist.{}.forward'.format(resolution))
         if nu is not None:
             # update the viscosity to the requested value
-            options = {'config_mom_del2': '{}'.format(nu)}
+            options = {'config_mom_del2': f'{nu}'}
             self.add_namelist_options(options)
 
         # make sure output is double precision
@@ -72,14 +71,4 @@ class Forward(Step):
         self.add_input_file(filename='graph.info',
                             target='../initial_state/culled_graph.info')
 
-        self.add_model_as_input()
-
         self.add_output_file(filename='output.nc')
-
-    # no setup() is needed
-
-    def run(self):
-        """
-        Run this step of the test case
-        """
-        run_model(self)

--- a/compass/ocean/tests/drying_slope/default/__init__.py
+++ b/compass/ocean/tests/drying_slope/default/__init__.py
@@ -1,4 +1,5 @@
 from compass.testcase import TestCase
+from compass.ocean.tests.drying_slope.mesh import Mesh
 from compass.ocean.tests.drying_slope.initial_state import InitialState
 from compass.ocean.tests.drying_slope.forward import Forward
 from compass.ocean.tests.drying_slope.viz import Viz
@@ -14,8 +15,8 @@ class Default(TestCase):
     resolution : float
         The resolution of the test case in km
 
-    coord_type : str
-        The type of vertical coordinate (``sigma``, ``single_layer``, etc.)
+    coord_type : {'sigma', 'single_layer'}
+        The type of vertical coordinate
     """
 
     def __init__(self, test_group, resolution, coord_type):
@@ -30,8 +31,8 @@ class Default(TestCase):
         resolution : float
             The resolution of the test case in km
 
-        coord_type : str
-            The type of vertical coordinate (``sigma``, ``single_layer``)
+        coord_type : {'sigma', 'single_layer'}
+            The type of vertical coordinate
         """
         name = 'default'
 
@@ -44,6 +45,8 @@ class Default(TestCase):
         subdir = f'{res_name}/{coord_type}/{name}'
         super().__init__(test_group=test_group, name=name,
                          subdir=subdir)
+
+        self.add_step(Mesh(test_case=self, coord_type=coord_type))
         self.add_step(InitialState(test_case=self, coord_type=coord_type))
         if coord_type == 'single_layer':
             self.add_step(Forward(test_case=self, resolution=resolution,

--- a/compass/ocean/tests/drying_slope/forward.py
+++ b/compass/ocean/tests/drying_slope/forward.py
@@ -1,8 +1,7 @@
-from compass.model import run_model
-from compass.step import Step
+from compass.model import ModelStep
 
 
-class Forward(Step):
+class Forward(ModelStep):
     """
     A step for performing forward MPAS-Ocean runs as part of drying slope
     test cases.
@@ -70,28 +69,17 @@ class Forward(Step):
         self.add_streams_file('compass.ocean.tests.drying_slope',
                               'streams.forward')
 
-        input_path = '../initial_state'
         self.add_input_file(filename='mesh.nc',
-                            target=f'{input_path}/culled_mesh.nc')
+                            target=f'../mesh/culled_mesh.nc')
 
+        self.add_input_file(filename='graph.info',
+                            target=f'../mesh/culled_graph.info')
+
+        input_path = '../initial_state'
         self.add_input_file(filename='init.nc',
                             target=f'{input_path}/ocean.nc')
 
         self.add_input_file(filename='forcing.nc',
                             target=f'{input_path}/init_mode_forcing_data.nc')
 
-        self.add_input_file(filename='graph.info',
-                            target=f'{input_path}/culled_graph.info')
-
-        self.add_model_as_input()
-
         self.add_output_file(filename='output.nc')
-
-    # no setup() is needed
-
-    def run(self):
-        """
-        Run this step of the test case
-        """
-
-        run_model(self)

--- a/compass/ocean/tests/drying_slope/initial_state.py
+++ b/compass/ocean/tests/drying_slope/initial_state.py
@@ -1,20 +1,11 @@
-import xarray
-import numpy
-
-from mpas_tools.planar_hex import make_planar_hex_mesh
-from mpas_tools.io import write_netcdf
-from mpas_tools.mesh.conversion import convert, cull
-
-from compass.step import Step
-from compass.model import run_model
+from compass.model import ModelStep
 
 
-class InitialState(Step):
+class InitialState(ModelStep):
     """
-    A step for creating a mesh and initial condition for drying slope test
-    cases
+    A step for creating an initial condition for drying slope test cases
     """
-    def __init__(self, test_case, coord_type='sigma'):
+    def __init__(self, test_case, coord_type):
         """
         Create the step
 
@@ -22,6 +13,9 @@ class InitialState(Step):
         ----------
         test_case : compass.ocean.tests.drying_slope.default.Default
             The test case this step belongs to
+
+        coord_type : {'sigma', 'single_layer'}
+            The type of vertical coordinate
         """
         super().__init__(test_case=test_case, name='initial_state', ntasks=1,
                          min_tasks=1, openmp_threads=1)
@@ -34,21 +28,21 @@ class InitialState(Step):
         self.add_streams_file('compass.ocean.tests.drying_slope',
                               'streams.init', mode='init')
 
-        for file in ['base_mesh.nc', 'culled_mesh.nc', 'culled_graph.info',
-                     'ocean.nc']:
-            self.add_output_file(file)
+        self.add_input_file(filename='culled_mesh.nc',
+                            target=f'../mesh/culled_mesh.nc')
 
-        self.add_model_as_input()
+        self.add_input_file(filename='graph.info',
+                            target=f'../mesh/culled_graph.info')
 
-    def run(self):
+        self.add_output_file('ocean.nc')
+        self.add_output_file('init_mode_forcing_data.nc')
+
+    def runtime_setup(self):
         """
-        Run this step of the test case
+        Set the number of layers based on the coordinate type
         """
-        config = self.config
-        logger = self.logger
-
-        config = self.config
-        section = config['vertical_grid']
+        super().runtime_setup()
+        section = self.config['vertical_grid']
         coord_type = self.coord_type
         if coord_type == 'single_layer':
             options = {'config_tidal_boundary_vert_levels': '1'}
@@ -58,24 +52,3 @@ class InitialState(Step):
             options = {'config_tidal_boundary_vert_levels': f'{vert_levels}',
                        'config_tidal_boundary_layer_type': f"'{coord_type}'"}
             self.update_namelist_at_runtime(options)
-
-        section = config['drying_slope']
-        nx = section.getint('nx')
-        ny = section.getint('ny')
-        dc = section.getfloat('dc')
-
-        logger.info(' * Make planar hex mesh')
-        dsMesh = make_planar_hex_mesh(nx=nx, ny=ny, dc=dc, nonperiodic_x=False,
-                                      nonperiodic_y=True)
-        logger.info(' * Completed Make planar hex mesh')
-        write_netcdf(dsMesh, 'base_mesh.nc')
-
-        logger.info(' * Cull mesh')
-        dsMesh = cull(dsMesh, logger=logger)
-        logger.info(' * Convert mesh')
-        dsMesh = convert(dsMesh, graphInfoFileName='culled_graph.info',
-                         logger=logger)
-        logger.info(' * Completed Convert mesh')
-        write_netcdf(dsMesh, 'culled_mesh.nc')
-        run_model(self, namelist='namelist.ocean',
-                  streams='streams.ocean')

--- a/compass/ocean/tests/drying_slope/mesh.py
+++ b/compass/ocean/tests/drying_slope/mesh.py
@@ -1,0 +1,62 @@
+from mpas_tools.planar_hex import make_planar_hex_mesh
+from mpas_tools.io import write_netcdf
+from mpas_tools.mesh.conversion import convert, cull
+
+from compass.step import Step
+
+
+class Mesh(Step):
+    """
+    A step for creating a mesh for drying slope test cases
+
+    Attributes
+    ----------
+    coord_type : {'sigma', 'single_layer'}
+        The type of vertical coordinate
+    """
+    def __init__(self, test_case, coord_type):
+        """
+        Create the step
+
+        Parameters
+        ----------
+        test_case : compass.ocean.tests.drying_slope.default.Default
+            The test case this step belongs to
+
+        coord_type : {'sigma', 'single_layer'}
+            The type of vertical coordinate
+        """
+        super().__init__(test_case=test_case, name='mesh', ntasks=1,
+                         min_tasks=1, openmp_threads=1)
+        self.coord_type = coord_type
+
+        for file in ['base_mesh.nc', 'culled_mesh.nc', 'culled_graph.info']:
+            self.add_output_file(file)
+
+    def run(self):
+        """
+        Run this step of the test case
+        """
+        logger = self.logger
+
+        config = self.config
+
+        section = config['drying_slope']
+        nx = section.getint('nx')
+        ny = section.getint('ny')
+        dc = section.getfloat('dc')
+
+        logger.info(' * Make planar hex mesh')
+        ds_mesh = make_planar_hex_mesh(nx=nx, ny=ny, dc=dc,
+                                       nonperiodic_x=False,
+                                       nonperiodic_y=True)
+        logger.info(' * Completed Make planar hex mesh')
+        write_netcdf(ds_mesh, 'base_mesh.nc')
+
+        logger.info(' * Cull mesh')
+        ds_mesh = cull(ds_mesh, logger=logger)
+        logger.info(' * Convert mesh')
+        ds_mesh = convert(ds_mesh, graphInfoFileName='culled_graph.info',
+                          logger=logger)
+        logger.info(' * Completed Convert mesh')
+        write_netcdf(ds_mesh, 'culled_mesh.nc')

--- a/compass/ocean/tests/global_convergence/cosine_bell/__init__.py
+++ b/compass/ocean/tests/global_convergence/cosine_bell/__init__.py
@@ -72,25 +72,6 @@ class CosineBell(TestCase):
 
         self.update_cores()
 
-    def run(self):
-        """
-        Run each step of the testcase
-        """
-        config = self.config
-        for resolution in self.resolutions:
-            if self.icosahedral:
-                mesh_name = f'Icos{resolution}'
-            else:
-                mesh_name = f'QU{resolution}'
-            ntasks = config.getint('cosine_bell', f'{mesh_name}_ntasks')
-            min_tasks = config.getint('cosine_bell', f'{mesh_name}_min_tasks')
-            step = self.steps[f'{mesh_name}_forward']
-            step.ntasks = ntasks
-            step.min_tasks = min_tasks
-
-        # run the step
-        super().run()
-
     def update_cores(self):
         """ Update the number of cores and min_tasks for each forward step """
 

--- a/compass/ocean/tests/global_convergence/cosine_bell/init.py
+++ b/compass/ocean/tests/global_convergence/cosine_bell/init.py
@@ -1,8 +1,7 @@
-from compass.model import run_model
-from compass.step import Step
+from compass.model import ModelStep
 
 
-class Init(Step):
+class Init(ModelStep):
     """
     A step for an initial condition for for the cosine bell test case
     """
@@ -22,7 +21,7 @@ class Init(Step):
         super().__init__(test_case=test_case,
                          name=f'{mesh_name}_init',
                          subdir=f'{mesh_name}/init',
-                         ntasks=36, min_tasks=1)
+                         ntasks=36, min_tasks=1, openmp_threads=1)
 
         package = 'compass.ocean.tests.global_convergence.cosine_bell'
 
@@ -33,13 +32,5 @@ class Init(Step):
 
         self.add_input_file(filename='graph.info', target='../mesh/graph.info')
 
-        self.add_model_as_input()
-
         self.add_output_file(filename='namelist.ocean')
         self.add_output_file(filename='initial_state.nc')
-
-    def run(self):
-        """
-        Run this step of the testcase
-        """
-        run_model(self)

--- a/compass/ocean/tests/gotm/default/__init__.py
+++ b/compass/ocean/tests/gotm/default/__init__.py
@@ -1,4 +1,5 @@
 from compass.testcase import TestCase
+from compass.ocean.tests.gotm.default.mesh import Mesh
 from compass.ocean.tests.gotm.default.init import Init
 from compass.ocean.tests.gotm.default.forward import Forward
 from compass.ocean.tests.gotm.default.analysis import Analysis
@@ -24,6 +25,7 @@ class Default(TestCase):
         """
         super().__init__(test_group=test_group, name='default')
 
+        self.add_step(Mesh(test_case=self))
         self.add_step(Init(test_case=self))
         self.add_step(Forward(test_case=self))
         self.add_step(Analysis(test_case=self))

--- a/compass/ocean/tests/gotm/default/forward.py
+++ b/compass/ocean/tests/gotm/default/forward.py
@@ -1,8 +1,7 @@
-from compass.model import run_model
-from compass.step import Step
+from compass.model import ModelStep
 
 
-class Forward(Step):
+class Forward(ModelStep):
     """
     A step for performing forward MPAS-Ocean runs as part of General Ocean
     Turbulence Model (GOTM) test cases.
@@ -28,22 +27,12 @@ class Forward(Step):
         self.add_streams_file('compass.ocean.tests.gotm.default',
                               'streams.forward')
 
-        self.add_input_file(filename='mesh.nc', target='../init/mesh.nc')
+        self.add_input_file(filename='mesh.nc', target='../mesh/mesh.nc')
         self.add_input_file(filename='init.nc', target='../init/ocean.nc')
-        self.add_input_file(filename='graph.info', target='../init/graph.info')
+        self.add_input_file(filename='graph.info', target='../mesh/graph.info')
 
         self.add_input_file(filename='gotmturb.nml', target='gotmturb.nml',
                             package='compass.ocean.tests.gotm.default',
                             copy=True)
 
-        self.add_model_as_input()
-
         self.add_output_file(filename='output.nc')
-
-    # no setup() is needed
-
-    def run(self):
-        """
-        Run this step of the test case
-        """
-        run_model(self)

--- a/compass/ocean/tests/gotm/default/init.py
+++ b/compass/ocean/tests/gotm/default/init.py
@@ -1,12 +1,7 @@
-from mpas_tools.planar_hex import make_planar_hex_mesh
-from mpas_tools.io import write_netcdf
-from mpas_tools.mesh.conversion import convert, cull
-
-from compass.step import Step
-from compass.model import run_model
+from compass.model import ModelStep
 
 
-class Init(Step):
+class Init(ModelStep):
     """
     A step for creating a mesh and initial condition for General Ocean
     Turbulence Model (GOTM) test cases
@@ -29,37 +24,19 @@ class Init(Step):
         self.add_streams_file('compass.ocean.tests.gotm.default',
                               'streams.init', mode='init')
 
-        self.add_model_as_input()
+        self.add_input_file(filename='mesh.nc', target='../mesh/mesh.nc')
+        self.add_input_file(filename='graph.info', target='../mesh/graph.info')
 
-        for file in ['mesh.nc', 'graph.info', 'ocean.nc']:
-            self.add_output_file(file)
+        self.add_output_file('ocean.nc')
 
-    def run(self):
+    def runtime_setup(self):
         """
-        Run this step of the test case
+        Update some namelist options from config options
         """
         config = self.config
-        logger = self.logger
-
-        section = config['gotm']
-        nx = section.getint('nx')
-        ny = section.getint('ny')
-        dc = section.getfloat('dc')
-
-        dsMesh = make_planar_hex_mesh(nx=nx, ny=ny, dc=dc, nonperiodic_x=False,
-                                      nonperiodic_y=False)
-        write_netcdf(dsMesh, 'grid.nc')
-
-        dsMesh = cull(dsMesh, logger=logger)
-        dsMesh = convert(dsMesh, graphInfoFileName='graph.info',
-                         logger=logger)
-        write_netcdf(dsMesh, 'mesh.nc')
-
         replacements = dict()
         replacements['config_periodic_planar_vert_levels'] = \
             config.get('gotm', 'vert_levels')
         replacements['config_periodic_planar_bottom_depth'] = \
             config.get('gotm', 'bottom_depth')
         self.update_namelist_at_runtime(options=replacements)
-
-        run_model(self)

--- a/compass/ocean/tests/gotm/default/mesh.py
+++ b/compass/ocean/tests/gotm/default/mesh.py
@@ -1,0 +1,54 @@
+from mpas_tools.planar_hex import make_planar_hex_mesh
+from mpas_tools.io import write_netcdf
+from mpas_tools.mesh.conversion import convert, cull
+
+from compass.step import Step
+
+
+class Mesh(Step):
+    """
+    A step for creating a mesh for General Ocean Turbulence Model (GOTM) test
+    cases
+    """
+    def __init__(self, test_case):
+        """
+        Create the step
+
+        Parameters
+        ----------
+        test_case : compass.ocean.tests.gotm.default.Default
+            The test case this step belongs to
+        """
+        super().__init__(test_case=test_case, name='mesh', ntasks=1,
+                         min_tasks=1, openmp_threads=1)
+
+        self.add_namelist_file('compass.ocean.tests.gotm.default',
+                               'namelist.init', mode='init')
+
+        self.add_streams_file('compass.ocean.tests.gotm.default',
+                              'streams.init', mode='init')
+
+        for file in ['mesh.nc', 'graph.info']:
+            self.add_output_file(file)
+
+    def run(self):
+        """
+        Run this step of the test case
+        """
+        config = self.config
+        logger = self.logger
+
+        section = config['gotm']
+        nx = section.getint('nx')
+        ny = section.getint('ny')
+        dc = section.getfloat('dc')
+
+        ds_mesh = make_planar_hex_mesh(nx=nx, ny=ny, dc=dc,
+                                       nonperiodic_x=False,
+                                       nonperiodic_y=False)
+        write_netcdf(ds_mesh, 'grid.nc')
+
+        ds_mesh = cull(ds_mesh, logger=logger)
+        ds_mesh = convert(ds_mesh, graphInfoFileName='graph.info',
+                          logger=logger)
+        write_netcdf(ds_mesh, 'mesh.nc')

--- a/compass/ocean/tests/hurricane/forward/forward.py
+++ b/compass/ocean/tests/hurricane/forward/forward.py
@@ -1,8 +1,7 @@
-from compass.model import run_model
-from compass.step import Step
+from compass.model import ModelStep
 
 
-class ForwardStep(Step):
+class ForwardStep(ModelStep):
     """
     A step for performing forward MPAS-Ocean runs as part of hurricane test
     cases.
@@ -38,7 +37,7 @@ class ForwardStep(Step):
         """
         self.mesh = mesh
         self.init = init
-        super().__init__(test_case=test_case, name=name)
+        super().__init__(test_case=test_case, name=name, openmp_threads=1)
 
         self.add_namelist_file(
             'compass.ocean.tests.hurricane.forward', 'namelist.ocean')
@@ -62,8 +61,6 @@ class ForwardStep(Step):
             filename='graph.info',
             work_dir_target=f'{init.path}/initial_state/graph.info')
 
-        self.add_model_as_input()
-
     def setup(self):
         """
         Set up the test case in the work directory, including downloading any
@@ -73,9 +70,3 @@ class ForwardStep(Step):
         self.min_tasks = self.config.getint('hurricane', 'forward_min_tasks')
         self.openmp_threads = self.config.getint('hurricane',
                                                  'forward_threads')
-
-    def run(self):
-        """
-        Run this step of the testcase
-        """
-        run_model(self)

--- a/compass/ocean/tests/hurricane/init/initial_state.py
+++ b/compass/ocean/tests/hurricane/init/initial_state.py
@@ -1,8 +1,7 @@
-from compass.model import run_model
-from compass.step import Step
+from compass.model import ModelStep
 
 
-class InitialState(Step):
+class InitialState(ModelStep):
     """
     A step for creating a mesh and initial condition for hurricane
     test cases
@@ -27,7 +26,8 @@ class InitialState(Step):
 
         """
 
-        super().__init__(test_case=test_case, name='initial_state')
+        super().__init__(test_case=test_case, name='initial_state',
+                         openmp_threads=1)
         self.mesh = mesh
 
         package = 'compass.ocean.tests.hurricane.init'
@@ -48,8 +48,6 @@ class InitialState(Step):
             filename='graph.info',
             work_dir_target=f'{mesh_path}/culled_graph.info')
 
-        self.add_model_as_input()
-
         for file in ['ocean.nc', 'graph.info']:
             self.add_output_file(filename=file)
 
@@ -63,9 +61,3 @@ class InitialState(Step):
         self.ntasks = config.getint('hurricane', 'init_ntasks')
         self.min_tasks = config.getint('hurricane', 'init_min_tasks')
         self.openmp_threads = config.getint('hurricane', 'init_threads')
-
-    def run(self):
-        """
-        Run this step of the testcase
-        """
-        run_model(self)

--- a/compass/ocean/tests/internal_wave/forward.py
+++ b/compass/ocean/tests/internal_wave/forward.py
@@ -1,8 +1,7 @@
-from compass.model import run_model
-from compass.step import Step
+from compass.model import ModelStep
 
 
-class Forward(Step):
+class Forward(ModelStep):
     """
     A step for performing forward MPAS-Ocean runs as part of internal wave
     test cases.
@@ -47,7 +46,7 @@ class Forward(Step):
                                'namelist.forward')
         if nu is not None:
             # update the viscosity to the requested value
-            options = {'config_mom_del2': '{}'.format(nu)}
+            options = {'config_mom_del2': f'{nu}'}
             self.add_namelist_options(options)
 
         self.add_streams_file('compass.ocean.tests.internal_wave',
@@ -60,14 +59,6 @@ class Forward(Step):
         self.add_input_file(filename='graph.info',
                             target='../initial_state/culled_graph.info')
 
-        self.add_model_as_input()
-
         self.add_output_file(filename='output.nc')
 
     # no setup() is needed
-
-    def run(self):
-        """
-        Run this step of the test case
-        """
-        run_model(self)

--- a/compass/ocean/tests/soma/base_mesh.py
+++ b/compass/ocean/tests/soma/base_mesh.py
@@ -1,0 +1,56 @@
+import xarray
+
+from mpas_tools.io import write_netcdf
+from mpas_tools.mesh.conversion import convert
+
+from compass.step import Step
+
+
+class BaseMesh(Step):
+    """
+    A step for converting a base mesh to MPAS format for SOMA test cases
+
+    Attributes
+    ----------
+    resolution : str
+        The resolution of the test case
+    """
+
+    def __init__(self, test_case, resolution):
+        """
+        Create the step
+
+        Parameters
+        ----------
+        test_case : compass.TestCase
+            The test case this step belongs to
+
+        resolution : str
+            The resolution of the test case
+        """
+        self.resolution = resolution
+
+        super().__init__(test_case=test_case, name='base_mesh')
+
+        mesh_filenames = {'32km': 'SOMA_32km_grid.161202.nc',
+                          '16km': 'SOMA_16km_grid.161202.nc',
+                          '8km': 'SOMA_8km_grid.161202.nc',
+                          '4km': 'SOMA_4km_grid.161202.nc'}
+        if resolution not in mesh_filenames:
+            raise ValueError(f'Unexpected SOMA resolution: {resolution}')
+
+        self.add_input_file(filename='base_mesh.nc',
+                            target=mesh_filenames[resolution],
+                            database='mesh_database')
+
+        for file in ['mesh.nc', 'base_graph.info']:
+            self.add_output_file(filename=file)
+
+    def run(self):
+        """
+        Convert the base mesh to MPAS format
+        """
+        ds_mesh = convert(xarray.open_dataset('base_mesh.nc'),
+                          graphInfoFileName='base_graph.info',
+                          logger=self.logger)
+        write_netcdf(ds_mesh, 'mesh.nc')

--- a/compass/ocean/tests/soma/culled_mesh.py
+++ b/compass/ocean/tests/soma/culled_mesh.py
@@ -1,0 +1,38 @@
+import xarray
+
+from mpas_tools.io import write_netcdf
+from mpas_tools.mesh.conversion import cull
+
+from compass.step import Step
+
+
+class CulledMesh(Step):
+    """
+    A step for culling the base mesh for SOMA test cases
+    """
+
+    def __init__(self, test_case):
+        """
+        Create the step
+
+        Parameters
+        ----------
+        test_case : compass.TestCase
+            The test case this step belongs to
+        """
+        super().__init__(test_case=test_case, name='culled_mesh')
+
+        self.add_input_file(filename='masked_initial_state.nc',
+                            target='../init_on_base_mesh/initial_state.nc')
+
+        for file in ['culled_mesh.nc', 'culled_graph.info']:
+            self.add_output_file(filename=file)
+
+    def run(self):
+        """
+        Run this step of the test case
+        """
+        ds_mesh = cull(xarray.open_dataset('masked_initial_state.nc'),
+                       graphInfoFileName='culled_graph.info',
+                       logger=self.logger)
+        write_netcdf(ds_mesh, 'culled_mesh.nc')

--- a/compass/ocean/tests/soma/initial_state.py
+++ b/compass/ocean/tests/soma/initial_state.py
@@ -1,15 +1,10 @@
-import xarray
-
-from mpas_tools.io import write_netcdf
-from mpas_tools.mesh.conversion import convert, cull
-
-from compass.step import Step
-from compass.model import run_model
+from compass.model import ModelStep
 
 
-class InitialState(Step):
+class InitialState(ModelStep):
     """
-    A step for creating a mesh and initial condition for SOMA test cases
+    A step for creating a mesh and initial condition, either with or without
+    a mask for culling land cells, for SOMA test cases
 
     Attributes
     ----------
@@ -18,7 +13,7 @@ class InitialState(Step):
     """
 
     def __init__(self, test_case, resolution, with_surface_restoring,
-                 three_layer):
+                 three_layer, mark_land):
         """
         Create the step
 
@@ -36,6 +31,8 @@ class InitialState(Step):
         three_layer : bool
             Whether to use only 3 vertical layers and no continental shelf
 
+        mark_land : bool
+            Whether to mark land cells for culling
         """
         self.resolution = resolution
 
@@ -55,22 +52,15 @@ class InitialState(Step):
 
         res_params = res_params[resolution]
 
-        super().__init__(test_case=test_case, name='initial_state',
+        if mark_land:
+            name = 'init_on_base_mesh'
+        else:
+            name = 'initial_state'
+
+        super().__init__(test_case=test_case, name=name,
                          ntasks=res_params['cores'],
-                         min_tasks=res_params['min_tasks'])
-
-        mesh_filenames = {'32km': 'SOMA_32km_grid.161202.nc',
-                          '16km': 'SOMA_16km_grid.161202.nc',
-                          '8km': 'SOMA_8km_grid.161202.nc',
-                          '4km': 'SOMA_4km_grid.161202.nc'}
-        if resolution not in mesh_filenames:
-            raise ValueError(f'Unexpected SOMA resolution: {resolution}')
-
-        self.add_input_file(filename='base_mesh.nc',
-                            target=mesh_filenames[resolution],
-                            database='mesh_database')
-
-        self.add_model_as_input()
+                         min_tasks=res_params['min_tasks'],
+                         openmp_threads=1)
 
         package = 'compass.ocean.tests.soma'
 
@@ -86,46 +76,40 @@ class InitialState(Step):
             options['config_soma_vert_levels'] = '60'
             options['config_vertical_grid'] = "'60layerPHC'"
 
-        self.add_namelist_file(package, 'namelist.init', mode='init',
-                               out_name='namelist_mark_land.ocean')
-
-        mark_land_options = dict(
-            config_write_cull_cell_mask='.true.',
-            config_block_decomp_file_prefix="'base_graph.info.part.'",
-            config_proc_decomp_file_prefix="'base_graph.info.part.'")
-
-        mark_land_options.update(options)
-
-        self.add_namelist_options(options=mark_land_options, mode='init',
-                                  out_name='namelist_mark_land.ocean')
-
-        self.add_streams_file(
-            package, 'streams.init', mode='init',
-            template_replacements={'mesh_filename': 'mesh.nc',
-                                   'init_filename': 'masked_initial_state.nc',
-                                   'forcing_filename': 'masked_forcing.nc'},
-            out_name='streams_mark_land.ocean')
+        if mark_land:
+            options['config_write_cull_cell_mask'] = '.true.'
+        else:
+            options['config_write_cull_cell_mask'] = '.false.'
 
         self.add_namelist_file(package, 'namelist.init', mode='init',
                                out_name='namelist.ocean')
-        options['config_write_cull_cell_mask'] = '.false.'
+
         self.add_namelist_options(options=options, mode='init',
                                   out_name='namelist.ocean')
 
         self.add_streams_file(
             package, 'streams.init', mode='init',
-            template_replacements={'mesh_filename': 'culled_mesh.nc',
-                                   'init_filename': 'initial_state.nc',
-                                   'forcing_filename': 'forcing.nc'},
             out_name='streams.ocean')
 
-        for file in ['initial_state.nc', 'forcing.nc', 'graph.info']:
+        if mark_land:
+            self.add_input_file(filename='mesh.nc',
+                                target='../base_mesh/mesh.nc')
+            self.add_input_file(filename='graph.info',
+                                target='../base_mesh/base_graph.info')
+        else:
+            self.add_input_file(filename='mesh.nc',
+                                target='../culled_mesh/culled_mesh.nc')
+            self.add_input_file(filename='graph.info',
+                                target='../culled_mesh/culled_graph.info')
+
+        for file in ['initial_state.nc', 'forcing.nc']:
             self.add_output_file(filename=file)
 
-    def run(self):
+    def runtime_setup(self):
         """
-        Run this step of the test case
+        Set namelist options from config options
         """
+        super().runtime_setup()
 
         config = self.config
         section = config['soma']
@@ -142,21 +126,5 @@ class InitialState(Step):
             config_soma_shelf_depth=section.get('shelf_depth'),
             config_soma_bottom_depth=section.get('bottom_depth'))
 
-        for out_name in ['namelist_mark_land.ocean', 'namelist.ocean']:
-            self.update_namelist_at_runtime(options=options, out_name=out_name)
-        ds_mesh = convert(xarray.open_dataset('base_mesh.nc'),
-                          graphInfoFileName='base_graph.info',
-                          logger=self.logger)
-        write_netcdf(ds_mesh, 'mesh.nc')
-
-        run_model(self, namelist='namelist_mark_land.ocean',
-                  streams='streams_mark_land.ocean',
-                  graph_file='base_graph.info')
-
-        ds_mesh = cull(xarray.open_dataset('masked_initial_state.nc'),
-                       graphInfoFileName='graph.info',
-                       logger=self.logger)
-        write_netcdf(ds_mesh, 'culled_mesh.nc')
-
-        run_model(self, namelist='namelist.ocean', streams='streams.ocean',
-                  graph_file='graph.info')
+        self.update_namelist_at_runtime(options=options,
+                                        out_name='namelist.ocean')

--- a/compass/ocean/tests/soma/soma_test_case.py
+++ b/compass/ocean/tests/soma/soma_test_case.py
@@ -1,4 +1,6 @@
 from compass.testcase import TestCase
+from compass.ocean.tests.soma.base_mesh import BaseMesh
+from compass.ocean.tests.soma.culled_mesh import CulledMesh
 from compass.ocean.tests.soma.initial_state import InitialState
 from compass.ocean.tests.soma.forward import Forward
 from compass.ocean.tests.soma.analysis import Analysis
@@ -89,10 +91,22 @@ class SomaTestCase(TestCase):
 
         super().__init__(test_group=test_group, name=name, subdir=subdir)
 
+        self.add_step(BaseMesh(
+            test_case=self, resolution=resolution))
+
         self.add_step(InitialState(
             test_case=self, resolution=resolution,
             with_surface_restoring=with_surface_restoring,
-            three_layer=three_layer))
+            three_layer=three_layer, mark_land=True))
+
+        self.add_step(CulledMesh(
+            test_case=self))
+
+        self.add_step(InitialState(
+            test_case=self, resolution=resolution,
+            with_surface_restoring=with_surface_restoring,
+            three_layer=three_layer, mark_land=False))
+
         options = dict()
         if with_surface_restoring:
             options['config_use_activeTracers_surface_restoring'] = '.true.'

--- a/compass/ocean/tests/soma/streams.init
+++ b/compass/ocean/tests/soma/streams.init
@@ -2,18 +2,18 @@
 
 <immutable_stream name="mesh"
                   type="input"
-                  filename_template="{{ mesh_filename }}"
+                  filename_template="mesh.nc"
                   input_interval="initial_only" />
 
 <immutable_stream name="input_init"
-        filename_template="{{ mesh_filename }}">
+        filename_template="mesh.nc">
 </immutable_stream>
 
 <stream name="output_init"
         type="output"
         output_interval="0000_00:00:01"
         clobber_mode="truncate"
-        filename_template="{{ init_filename }}">
+        filename_template="initial_state.nc">
 
     <stream name="input_init"/>
     <var_struct name="tracers"/>
@@ -38,7 +38,7 @@
         type="output"
         output_interval="0000_00:00:01"
         clobber_mode="truncate"
-        filename_template="{{ forcing_filename }}">
+        filename_template="forcing.nc">
 
     <var_array name="activeTracersPistonVelocity"/>
     <var_array name="activeTracersSurfaceRestoringValue"/>

--- a/compass/ocean/tests/sphere_transport/correlated_tracers_2d/forward.py
+++ b/compass/ocean/tests/sphere_transport/correlated_tracers_2d/forward.py
@@ -1,11 +1,8 @@
-import time
-
-from compass.model import run_model
-from compass.step import Step
+from compass.model import ModelStep
 from datetime import timedelta
 
 
-class Forward(Step):
+class Forward(ModelStep):
     """
     A step for performing forward MPAS-Ocean runs as part of the
       correlated_tracers_2d.
@@ -30,9 +27,9 @@ class Forward(Step):
         dt_minutes : int
             The time step size in minutes.  **must divide 1 day (24*60)**
         """
-        super().__init__(test_case=test_case,
-                         name='QU{}_forward'.format(resolution),
-                         subdir='QU{}/forward'.format(resolution))
+        super().__init__(test_case=test_case, openmp_threads=1,
+                         name=f'QU{resolution}_forward',
+                         subdir=f'QU{resolution}/forward')
 
         self.resolution = resolution
         self.dt_minutes = dt_minutes
@@ -46,8 +43,6 @@ class Forward(Step):
                             target='../init/initial_state.nc')
         self.add_input_file(filename='graph.info',
                             target='../mesh/graph.info')
-
-        self.add_model_as_input()
 
         self.add_output_file(filename='output.nc')
 
@@ -63,10 +58,12 @@ class Forward(Step):
                                        'correlated_tracers_2d',
                                        'time_integrator')})
 
-    def run(self):
+    def runtime_setup(self):
         """
-        Run this step of the testcase
+        Update the resources and time step in case the user has update config
+        options
         """
+        super().runtime_setup()
         config = self.config
         dt = self.get_timestep_str()
         self.update_namelist_at_runtime(
@@ -76,8 +73,6 @@ class Forward(Step):
                     'correlated_tracers_2d',
                     'time_integrator')},
             out_name='namelist.ocean')
-
-        run_model(self)
 
     def get_timestep_str(self):
         """

--- a/compass/ocean/tests/sphere_transport/correlated_tracers_2d/init.py
+++ b/compass/ocean/tests/sphere_transport/correlated_tracers_2d/init.py
@@ -1,8 +1,7 @@
-from compass.model import run_model
-from compass.step import Step
+from compass.model import ModelStep
 
 
-class Init(Step):
+class Init(ModelStep):
     """
     A step for an initial condition for for the cosine bell test case
     """
@@ -21,9 +20,9 @@ class Init(Step):
         """
 
         super().__init__(test_case=test_case,
-                         name='QU{}_init'.format(resolution),
-                         subdir='QU{}/init'.format(resolution),
-                         ntasks=36, min_tasks=1)
+                         name=f'QU{resolution}_init',
+                         subdir=f'QU{resolution}/init',
+                         ntasks=36, min_tasks=1, openmp_threads=1)
 
         package = 'compass.ocean.tests.sphere_transport.correlated_tracers_2d'
 
@@ -38,9 +37,3 @@ class Init(Step):
 
         self.add_output_file(filename='namelist.ocean')
         self.add_output_file(filename='initial_state.nc')
-
-    def run(self):
-        """
-        Run this step of the testcase
-        """
-        run_model(self)

--- a/compass/ocean/tests/sphere_transport/divergent_2d/forward.py
+++ b/compass/ocean/tests/sphere_transport/divergent_2d/forward.py
@@ -1,11 +1,8 @@
-import time
-
-from compass.model import run_model
-from compass.step import Step
+from compass.model import ModelStep
 from datetime import timedelta
 
 
-class Forward(Step):
+class Forward(ModelStep):
     """
     A step for performing forward MPAS-Ocean runs as part of the divergent_2d
 
@@ -29,9 +26,9 @@ class Forward(Step):
         dt_minutes : int
             The time step size in minutes.  **must divide 1 day (24*60)**
         """
-        super().__init__(test_case=test_case,
-                         name='QU{}_forward'.format(resolution),
-                         subdir='QU{}/forward'.format(resolution))
+        super().__init__(test_case=test_case, openmp_threads=1,
+                         name=f'QU{resolution}_forward',
+                         subdir=f'QU{resolution}/forward')
 
         self.resolution = resolution
         self.dt_minutes = dt_minutes
@@ -60,10 +57,12 @@ class Forward(Step):
                                    'config_time_integrator': config.get(
                                        'divergent_2d', 'time_integrator')})
 
-    def run(self):
+    def runtime_setup(self):
         """
-        Run this step of the testcase
+        Update the resources and time step in case the user has update config
+        options
         """
+        super().runtime_setup()
         config = self.config
         dt = self.get_timestep_str()
         self.update_namelist_at_runtime(
@@ -73,8 +72,6 @@ class Forward(Step):
                     'divergent_2d',
                     'time_integrator')},
             out_name='namelist.ocean')
-
-        run_model(self)
 
     def get_timestep_str(self):
         """

--- a/compass/ocean/tests/sphere_transport/divergent_2d/init.py
+++ b/compass/ocean/tests/sphere_transport/divergent_2d/init.py
@@ -1,8 +1,7 @@
-from compass.model import run_model
-from compass.step import Step
+from compass.model import ModelStep
 
 
-class Init(Step):
+class Init(ModelStep):
     """
     A step for an initial condition for for the cosine bell test case
     """
@@ -21,9 +20,9 @@ class Init(Step):
         """
 
         super().__init__(test_case=test_case,
-                         name='QU{}_init'.format(resolution),
-                         subdir='QU{}/init'.format(resolution),
-                         ntasks=36, min_tasks=1)
+                         name=f'QU{resolution}_init',
+                         subdir=f'QU{resolution}/init',
+                         ntasks=36, min_tasks=1, openmp_threads=1)
 
         package = 'compass.ocean.tests.sphere_transport.divergent_2d'
 
@@ -38,9 +37,3 @@ class Init(Step):
 
         self.add_output_file(filename='namelist.ocean')
         self.add_output_file(filename='initial_state.nc')
-
-    def run(self):
-        """
-        Run this step of the testcase
-        """
-        run_model(self)

--- a/compass/ocean/tests/sphere_transport/nondivergent_2d/forward.py
+++ b/compass/ocean/tests/sphere_transport/nondivergent_2d/forward.py
@@ -1,11 +1,8 @@
-import time
-
-from compass.model import run_model
-from compass.step import Step
+from compass.model import ModelStep
 from datetime import timedelta
 
 
-class Forward(Step):
+class Forward(ModelStep):
     """
     A step for performing forward MPAS-Ocean runs as part of the
       nondivergent_2d test case.
@@ -30,9 +27,9 @@ class Forward(Step):
         dt_minutes : int
             The time step size in minutes.  **must divide 1 day (24*60)**
         """
-        super().__init__(test_case=test_case,
-                         name='QU{}_forward'.format(resolution),
-                         subdir='QU{}/forward'.format(resolution))
+        super().__init__(test_case=test_case, openmp_threads=1,
+                         name=f'QU{resolution}_forward',
+                         subdir=f'QU{resolution}/forward')
 
         self.resolution = resolution
         self.dt_minutes = dt_minutes
@@ -61,10 +58,12 @@ class Forward(Step):
                                    'config_time_integrator': config.get(
                                        'nondivergent_2d', 'time_integrator')})
 
-    def run(self):
+    def runtime_setup(self):
         """
-        Run this step of the testcase
+        Update the resources and time step in case the user has update config
+        options
         """
+        super().runtime_setup()
         config = self.config
         dt = self.get_timestep_str()
         self.update_namelist_at_runtime(
@@ -74,8 +73,6 @@ class Forward(Step):
                     'nondivergent_2d',
                     'time_integrator')},
             out_name='namelist.ocean')
-
-        run_model(self)
 
     def get_timestep_str(self):
         """

--- a/compass/ocean/tests/sphere_transport/nondivergent_2d/init.py
+++ b/compass/ocean/tests/sphere_transport/nondivergent_2d/init.py
@@ -1,8 +1,7 @@
-from compass.model import run_model
-from compass.step import Step
+from compass.model import ModelStep
 
 
-class Init(Step):
+class Init(ModelStep):
     """
     A step for an initial condition for for the cosine bell test case
     """
@@ -21,9 +20,9 @@ class Init(Step):
         """
 
         super().__init__(test_case=test_case,
-                         name='QU{}_init'.format(resolution),
-                         subdir='QU{}/init'.format(resolution),
-                         ntasks=36, min_tasks=1)
+                         name=f'QU{resolution}_init',
+                         subdir=f'QU{resolution}/init',
+                         ntasks=36, min_tasks=1, openmp_threads=1)
 
         package = 'compass.ocean.tests.sphere_transport.nondivergent_2d'
 
@@ -38,9 +37,3 @@ class Init(Step):
 
         self.add_output_file(filename='namelist.ocean')
         self.add_output_file(filename='initial_state.nc')
-
-    def run(self):
-        """
-        Run this step of the testcase
-        """
-        run_model(self)

--- a/compass/ocean/tests/sphere_transport/rotation_2d/forward.py
+++ b/compass/ocean/tests/sphere_transport/rotation_2d/forward.py
@@ -1,11 +1,8 @@
-import time
-
-from compass.model import run_model
-from compass.step import Step
+from compass.model import ModelStep
 from datetime import timedelta
 
 
-class Forward(Step):
+class Forward(ModelStep):
     """
     A step for performing forward MPAS-Ocean runs as part of the rotation_2d
 
@@ -29,9 +26,9 @@ class Forward(Step):
         dt_minutes : int
             The time step size in minutes.  **must divide 1 day (24*60)**
         """
-        super().__init__(test_case=test_case,
-                         name='QU{}_forward'.format(resolution),
-                         subdir='QU{}/forward'.format(resolution))
+        super().__init__(test_case=test_case, openmp_threads=1,
+                         name=f'QU{resolution}_forward',
+                         subdir=f'QU{resolution}/forward')
 
         self.resolution = resolution
         self.dt_minutes = dt_minutes
@@ -60,9 +57,10 @@ class Forward(Step):
                                    'config_time_integrator': config.get(
                                        'rotation_2d', 'time_integrator')})
 
-    def run(self):
+    def runtime_setup(self):
         """
-        Run this step of the testcase
+        Update the resources and time step in case the user has update config
+        options
         """
         config = self.config
         dt = self.get_timestep_str()
@@ -73,8 +71,6 @@ class Forward(Step):
                     'rotation_2d',
                     'time_integrator')},
             out_name='namelist.ocean')
-
-        run_model(self)
 
     def get_timestep_str(self):
         """

--- a/compass/ocean/tests/sphere_transport/rotation_2d/init.py
+++ b/compass/ocean/tests/sphere_transport/rotation_2d/init.py
@@ -1,8 +1,7 @@
-from compass.model import run_model
-from compass.step import Step
+from compass.model import ModelStep
 
 
-class Init(Step):
+class Init(ModelStep):
     """
     A step for an initial condition for for the cosine bell test case
     """
@@ -21,9 +20,9 @@ class Init(Step):
         """
 
         super().__init__(test_case=test_case,
-                         name='QU{}_init'.format(resolution),
-                         subdir='QU{}/init'.format(resolution),
-                         ntasks=36, min_tasks=1)
+                         name=f'QU{resolution}_init',
+                         subdir=f'QU{resolution}/init',
+                         ntasks=36, min_tasks=1, openmp_threads=1)
 
         package = 'compass.ocean.tests.sphere_transport.rotation_2d'
 
@@ -38,9 +37,3 @@ class Init(Step):
 
         self.add_output_file(filename='namelist.ocean')
         self.add_output_file(filename='initial_state.nc')
-
-    def run(self):
-        """
-        Run this step of the testcase
-        """
-        run_model(self)

--- a/compass/ocean/tests/spherical_harmonic_transform/qu_convergence/init.py
+++ b/compass/ocean/tests/spherical_harmonic_transform/qu_convergence/init.py
@@ -1,11 +1,10 @@
-from compass.model import run_model
-from compass.step import Step
+from compass.model import ModelStep
 
 
-class Init(Step):
+class Init(ModelStep):
     """
     A step for running a spherical harmonic transformation
-    for the shperical_harmonic_transfrom test case
+    for the spherical_harmonic_transform test case
     """
     def __init__(self, test_case, resolution, algorithm, order):
         """
@@ -23,7 +22,7 @@ class Init(Step):
             Use either the 'parallel' or 'serial' algorithm
 
         order : int
-            - For algorithm = 'parallel', the order of the shperical
+            - For algorithm = 'parallel', the order of the spherical
               harmonic transform
             - For algorithm = 'serial', the number of latitudes in the
               Gaussian grid
@@ -31,7 +30,7 @@ class Init(Step):
         super().__init__(test_case=test_case,
                          name=f'QU{resolution}_init_{algorithm}_{order}',
                          subdir=f'QU{resolution}/init/{algorithm}/{order}',
-                         ntasks=36, min_tasks=1)
+                         ntasks=36, min_tasks=1, openmp_threads=1)
 
         package = \
             'compass.ocean.tests.spherical_harmonic_transform.qu_convergence'
@@ -44,8 +43,6 @@ class Init(Step):
 
         self.add_input_file(filename='graph.info',
                             target='../../../mesh/graph.info')
-
-        self.add_model_as_input()
 
         self.add_output_file(filename='initial_state.nc')
 
@@ -69,10 +66,3 @@ class Init(Step):
                 target=f'../../../mesh/grid_to_mpas_{order}.nc')
 
         self.add_namelist_options(options=init_options, mode='init')
-
-    def run(self):
-        """
-        Run this step of the testcase
-        """
-
-        run_model(self)

--- a/compass/step.py
+++ b/compass/step.py
@@ -134,6 +134,9 @@ class Step:
         subprocess if there is not a good way to redirect output to a log
         file (e.g. if the step calls external code that, in turn, calls
         additional subprocesses).
+
+    args : {list of str, None}
+        A list of command-line arguments to call in parallel
     """
 
     def __init__(self, test_case, name, subdir=None, cpus_per_task=1,
@@ -221,6 +224,7 @@ class Step:
         self.outputs = list()
         self.namelist_data = dict()
         self.streams_data = dict()
+        self.args = None
 
         # these will be set later during setup
         self.config = None


### PR DESCRIPTION
For task parallelism, it is necessary for steps to use a consistent number of resources.  A compass step can no longer have a python piece followed by an MPI-parallel piece.

Currently, combination python and MPI steps are common in compass.  Many such steps involve setting up a model run  in some way in python before running the model with MPI.  More complex steps may run the model multiple times, performing python operations between each model run.  Other such steps include those that generate mapping files (using `ESMF_RegridWeightGen` run with MPI).

To support task parallelism, it will be necessary to break these steps into smaller steps, each either running python code or MPI code.  This is necessary because each step will be called with `srun` and the specified resources (e.g. `ntasks`, `cpus_per_task`, or sometimes both).  The python code must be run with `ntasks = 1`, while the MPI code typically is run with `ntasks > 1`.  @altheaden and I took a good deal of time to investigate breaking steps in to "substeps" to support different numbers of resources.  Ultimately, the complexity of both the concepts and the code itself was worse than if we just break current steps into multiple steps with unique resources.

As a significant step toward this goal, this PR:
1. Adds an `args` attribute to the `Step` class.  If `args` is defined, the step's `run()` method isn't called (and shouldn't be overridden).  Instead, the contents of `args` should be a list of command-line arguments to be called with `srun` (or `mpirun` on a laptop) and an appropriate set of resources.  Running the model is an obvious example of this, as we discuss next.
2. Adds a `ModelStep` class for reducing the amount of redundancy involved in making steps that run the MPAS model.  This class descends from `Step` and takes care of work like creating graph and partition files, updating PIO namelist options, etc. that are needed before running the model.  It also automatically creates the `args` attribute used to run the model itself.
3. Migrates many (but by no means all) of the ocean test groups to using `ModelStep`

Migrated test groups:
- [x] `baroclinic_channel`
- [x] `drying_slope`
- [x] `global_convergence`
- [x] `gotm`
- [x] `hurricane`
- [x] `internal_waves`
- [x] `planar_convergence`
- [x] `soma`
- [x] `sphere_transport`
- [x] `spherical_harmonic_transform`
- [x] `ziso`

_Not_ migrated (typically because of the complexity of SSH adjustment for ice-shelf cavities):
- [ ] `global_ocean`
- [ ] `ice_shelf_2d`
- [ ] `isomip_plus`