### PR TITLE
Add TimeSeriesStatsRestartTest to global ocean 

### DIFF
--- a/compass/ocean/suites/pr.txt
+++ b/compass/ocean/suites/pr.txt
@@ -15,6 +15,12 @@ ocean/global_ocean/QU240/PHC/restart_test
 ocean/global_ocean/QU240/PHC/decomp_test
 ocean/global_ocean/QU240/PHC/threads_test
 ocean/global_ocean/QU240/PHC/analysis_test
+ocean/global_ocean/QU240/PHC/analysis_test
+ocean/global_ocean/QU240/PHC/analysis_test
+ocean/global_ocean/QU240/PHC/daily_analysis_restart
+ocean/global_ocean/QU240/PHC/daily_model_restart
+ocean/global_ocean/QU240/PHC/monthly_analysis_restart
+ocean/global_ocean/QU240/PHC/monthly_model_restart
 ocean/global_ocean/QU240/PHC/dynamic_adjustment
 ocean/global_ocean/QU240/PHC/files_for_e3sm
 

--- a/compass/ocean/suites/time_series_stats.txt
+++ b/compass/ocean/suites/time_series_stats.txt
@@ -1,0 +1,8 @@
+ocean/global_ocean/QU240/mesh
+ocean/global_ocean/QU240/PHC/init
+ocean/global_ocean/QU240/PHC/daily_analysis_restart
+ocean/global_ocean/QU240/PHC/daily_model_restart
+ocean/global_ocean/QU240/PHC/monthly_analysis_restart
+ocean/global_ocean/QU240/PHC/monthly_model_restart
+ocean/global_ocean/QU240/PHC/daily_output_test
+ocean/global_ocean/QU240/PHC/monthly_output_test

--- a/compass/ocean/tests/global_ocean/__init__.py
+++ b/compass/ocean/tests/global_ocean/__init__.py
@@ -76,14 +76,24 @@ class GlobalOcean(TestGroup):
                     time_integrator=time_integrator))
             self.add_test_case(
                 TimeSeriesStatsRestartTest(
-                    test_group=self, mesh=mesh, init=init, analysis='Daily'))
+                    test_group=self, mesh=mesh, init=init, analysis='Daily',
+                    with_analysis_restart=True))
+            self.add_test_case(
+                TimeSeriesStatsRestartTest(
+                    test_group=self, mesh=mesh, init=init, analysis='Daily',
+                    with_analysis_restart=False))
             self.add_test_case(
                 MonthlyOutputTest(
                     test_group=self, mesh=mesh, init=init,
                     time_integrator=time_integrator))
             self.add_test_case(
                 TimeSeriesStatsRestartTest(
-                    test_group=self, mesh=mesh, init=init, analysis='Monthly'))
+                    test_group=self, mesh=mesh, init=init, analysis='Monthly',
+                    with_analysis_restart=True))
+            self.add_test_case(
+                TimeSeriesStatsRestartTest(
+                    test_group=self, mesh=mesh, init=init, analysis='Monthly',
+                    with_analysis_restart=False))
 
             dynamic_adjustment = QU240DynamicAdjustment(
                 test_group=self, mesh=mesh, init=init,

--- a/compass/ocean/tests/global_ocean/__init__.py
+++ b/compass/ocean/tests/global_ocean/__init__.py
@@ -18,6 +18,8 @@ from compass.ocean.tests.global_ocean.decomp_test import DecompTest
 from compass.ocean.tests.global_ocean.threads_test import ThreadsTest
 from compass.ocean.tests.global_ocean.analysis_test import AnalysisTest
 from compass.ocean.tests.global_ocean.daily_output_test import DailyOutputTest
+from compass.ocean.tests.global_ocean.time_series_stats_restart_test import \
+    TimeSeriesStatsRestartTest
 from compass.ocean.tests.global_ocean.monthly_output_test import \
     MonthlyOutputTest
 from compass.ocean.tests.global_ocean.files_for_e3sm import FilesForE3SM
@@ -73,9 +75,15 @@ class GlobalOcean(TestGroup):
                     test_group=self, mesh=mesh, init=init,
                     time_integrator=time_integrator))
             self.add_test_case(
+                TimeSeriesStatsRestartTest(
+                    test_group=self, mesh=mesh, init=init, analysis='Daily'))
+            self.add_test_case(
                 MonthlyOutputTest(
                     test_group=self, mesh=mesh, init=init,
                     time_integrator=time_integrator))
+            self.add_test_case(
+                TimeSeriesStatsRestartTest(
+                    test_group=self, mesh=mesh, init=init, analysis='Monthly'))
 
             dynamic_adjustment = QU240DynamicAdjustment(
                 test_group=self, mesh=mesh, init=init,

--- a/compass/ocean/tests/global_ocean/time_series_stats_restart_test/__init__.py
+++ b/compass/ocean/tests/global_ocean/time_series_stats_restart_test/__init__.py
@@ -1,0 +1,92 @@
+from compass.validate import compare_variables
+from compass.ocean.tests.global_ocean.forward import ForwardTestCase, \
+    ForwardStep
+
+
+class TimeSeriesStatsRestartTest(ForwardTestCase):
+    """
+    A test case to test bit-for-bit restart capabilities from the
+    TimeSeriesStats analysis members in E3SM.
+
+    Attributes
+    ----------
+    analysis : {'Daily', 'Monthly'}
+        The suffix for the ``timeSeriesStats`` analysis member to check.
+
+    """
+
+    def __init__(self, test_group, mesh, init, analysis):
+        """
+        Create test case
+
+        Parameters
+        ----------
+        test_group : compass.ocean.tests.global_ocean.GlobalOcean
+            The global ocean test group that this test case belongs to
+
+        mesh : compass.ocean.tests.global_ocean.mesh.Mesh
+            The test case that produces the mesh for this run
+
+        init : compass.ocean.tests.global_ocean.init.Init
+            The test case that produces the initial condition for this run
+
+        analysis : {'Daily', 'Monthly'}
+            The suffix for the ``timeSeriesStats`` analysis member to check.
+        """
+        name = f'{analysis.lower()}_restart_test'
+        time_integrator = 'split_explicit'
+        super().__init__(test_group=test_group, mesh=mesh, init=init,
+                         time_integrator=time_integrator, name=name)
+        module = self.__module__
+        self.analysis = analysis
+
+        output_interval = '0000-00-00_04:00:00'
+
+        replacements = dict(analysis=analysis,
+                            output_interval=output_interval)
+
+        restart_filename = '../restarts/rst.0001-01-01_04.00.00.nc'
+        analysis_restart_filename = \
+            f'../restarts/rst.timeSeriesStats{analysis}.0001-01-01_04.00.00.nc'
+        analysis_filename = \
+            f'analysis_members/mpaso.hist.am.timeSeriesStats{analysis}.0001-01-01_08.00.00.nc'
+
+        for part in ['full', 'restart']:
+            name = f'{part}_run'
+            step = ForwardStep(test_case=self, mesh=mesh, init=init,
+                               time_integrator=time_integrator, name=name,
+                               subdir=name, ntasks=4, openmp_threads=1)
+
+            step.add_namelist_file(module, f'namelist.{part}')
+            step.add_streams_file(module, 'streams.forward',
+                                  template_replacements=replacements)
+            if part == 'full':
+                step.add_output_file(restart_filename)
+                step.add_output_file(analysis_restart_filename)
+            else:
+                step.add_input_file(restart_filename)
+                step.add_input_file(analysis_restart_filename)
+            step.add_output_file(analysis_filename)
+            self.add_step(step)
+
+    def validate(self):
+        """
+        Test cases can override this method to perform validation of variables
+        and timers
+        """
+        analysis = self.analysis
+        variables = [
+            'Time', 'Time_bnds',
+            f'time{analysis}_avg_activeTracers_temperature',
+            f'time{analysis}_avg_activeTracers_salinity',
+            f'time{analysis}_avg_layerThickness',
+            f'time{analysis}_avg_normalVelocity',
+            f'time{analysis}_avg_ssh']
+
+        analysis_filename = \
+            f'analysis_members/mpaso.hist.am.timeSeriesStats{analysis}.0001-02-01.nc'
+
+        compare_variables(
+            test_case=self, variables=variables,
+            filename1=f'full_run/{analysis_filename}',
+            filename2=f'restart_run/{analysis_filename}')

--- a/compass/ocean/tests/global_ocean/time_series_stats_restart_test/namelist.full
+++ b/compass/ocean/tests/global_ocean/time_series_stats_restart_test/namelist.full
@@ -1,0 +1,9 @@
+config_start_time = '0001-01-01_00:00:00'
+config_run_duration = '08:00:00'
+config_do_restart = .false.
+config_AM_timeSeriesStatsDaily_enable = .true.
+config_AM_timeSeriesStatsDaily_compute_on_startup = .false.
+config_AM_timeSeriesStatsDaily_write_on_startup = .false.
+config_AM_timeSeriesStatsDaily_compute_interval = '00-00-00_04:00:00'
+config_AM_timeSeriesStatsDaily_reset_intervals = '00-00-00_04:00:00'
+config_AM_timeSeriesStatsDaily_backward_output_offset = '00-00-00_04:00:00'

--- a/compass/ocean/tests/global_ocean/time_series_stats_restart_test/namelist.full
+++ b/compass/ocean/tests/global_ocean/time_series_stats_restart_test/namelist.full
@@ -1,9 +1,4 @@
 config_start_time = '0001-01-01_00:00:00'
 config_run_duration = '08:00:00'
+config_dt = '00:30:00'
 config_do_restart = .false.
-config_AM_timeSeriesStatsDaily_enable = .true.
-config_AM_timeSeriesStatsDaily_compute_on_startup = .false.
-config_AM_timeSeriesStatsDaily_write_on_startup = .false.
-config_AM_timeSeriesStatsDaily_compute_interval = '00-00-00_04:00:00'
-config_AM_timeSeriesStatsDaily_reset_intervals = '00-00-00_04:00:00'
-config_AM_timeSeriesStatsDaily_backward_output_offset = '00-00-00_04:00:00'

--- a/compass/ocean/tests/global_ocean/time_series_stats_restart_test/namelist.restart
+++ b/compass/ocean/tests/global_ocean/time_series_stats_restart_test/namelist.restart
@@ -1,9 +1,4 @@
 config_start_time = '0001-01-01_04:00:00'
 config_run_duration = '04:00:00'
+config_dt = '00:30:00'
 config_do_restart = .true.
-config_AM_timeSeriesStatsDaily_enable = .true.
-config_AM_timeSeriesStatsDaily_compute_on_startup = .false.
-config_AM_timeSeriesStatsDaily_write_on_startup = .false.
-config_AM_timeSeriesStatsDaily_compute_interval = '00-00-00_04:00:00'
-config_AM_timeSeriesStatsDaily_reset_intervals = '00-00-00_04:00:00'
-config_AM_timeSeriesStatsDaily_backward_output_offset = '00-00-00_04:00:00'

--- a/compass/ocean/tests/global_ocean/time_series_stats_restart_test/namelist.restart
+++ b/compass/ocean/tests/global_ocean/time_series_stats_restart_test/namelist.restart
@@ -1,0 +1,9 @@
+config_start_time = '0001-01-01_04:00:00'
+config_run_duration = '04:00:00'
+config_do_restart = .true.
+config_AM_timeSeriesStatsDaily_enable = .true.
+config_AM_timeSeriesStatsDaily_compute_on_startup = .false.
+config_AM_timeSeriesStatsDaily_write_on_startup = .false.
+config_AM_timeSeriesStatsDaily_compute_interval = '00-00-00_04:00:00'
+config_AM_timeSeriesStatsDaily_reset_intervals = '00-00-00_04:00:00'
+config_AM_timeSeriesStatsDaily_backward_output_offset = '00-00-00_04:00:00'

--- a/compass/ocean/tests/global_ocean/time_series_stats_restart_test/streams.forward
+++ b/compass/ocean/tests/global_ocean/time_series_stats_restart_test/streams.forward
@@ -9,8 +9,10 @@
         output_interval="{{ output_interval }}">
 </stream>
 
-<immutable_stream name="timeSeriesStats{{ analysis }}Restart"
-                  filename_template="../restarts/rst.timeSeriesStats{{ analysis }}.$Y-$M-$D_$h.$m.$s.nc"/>
+<stream name="timeSeriesStats{{ analysis }}Restart"
+        filename_template="../restarts/rst.timeSeriesStats{{ analysis }}.$Y-$M-$D_$h.$m.$s.nc"
+        input_interval="{{ analysis_restart_input_interval }}"
+        output_interval="{{ analysis_restart_output_interval }}"/>
 
 <stream name="timeSeriesStats{{ analysis }}Output"
         type="output"

--- a/compass/ocean/tests/global_ocean/time_series_stats_restart_test/streams.forward
+++ b/compass/ocean/tests/global_ocean/time_series_stats_restart_test/streams.forward
@@ -1,0 +1,24 @@
+<streams>
+
+<immutable_stream name="restart"
+                  filename_template="../restarts/rst.$Y-$M-$D_$h.$m.$s.nc"
+                  filename_interval="output_interval"
+                  output_interval="{{ output_interval }}"/>
+
+<stream name="output"
+        output_interval="{{ output_interval }}">
+</stream>
+
+<immutable_stream name="timeSeriesStats{{ analysis }}Restart"
+                  filename_template="../restarts/rst.timeSeriesStats{{ analysis }}.$Y-$M-$D_$h.$m.$s.nc"/>
+
+<stream name="timeSeriesStats{{ analysis }}Output"
+        type="output"
+        precision="double"
+        filename_template="analysis_members/mpaso.hist.am.timeSeriesStats{{ analysis }}.$Y-$M-$D_$h.$m.$s.nc"
+        filename_interval="output_interval"
+        output_interval="{{ output_interval }}"
+        clobber_mode="truncate">
+</stream>
+
+</streams>


### PR DESCRIPTION
This merge adds a new TimeSeriesStatsRestartTest test case that makes sure the timeSeriesStats* analysis member
produces the same results with a full 8-hour run and with two 4-hour runs with a restart in between.  Tests are available with or without analysis restart files (the former is the MPAS-Ocean standalone default, the latter is the behavior in E3SM).

These tests exist with the variables used in both daily and monthly averages, though they are not computed over so long a time interval for efficiency.

QU240 versions of these test cases have been added to the `pr` test suite for both daily and monthly output and both with and without analysis restarts.

The tests will fail with the current E3SM master.  They pass with the bug fixes in https://github.com/E3SM-Project/E3SM/pull/5218.