### PR TITLE
Add a step for making mapping files for `e3sm_to_cmip`

### DIFF
--- a/compass/ocean/tests/global_ocean/files_for_e3sm/__init__.py
+++ b/compass/ocean/tests/global_ocean/files_for_e3sm/__init__.py
@@ -10,6 +10,8 @@ from compass.ocean.tests.global_ocean.files_for_e3sm.seaice_initial_condition \
 from compass.ocean.tests.global_ocean.files_for_e3sm.ocean_graph_partition \
     import OceanGraphPartition
 from compass.ocean.tests.global_ocean.files_for_e3sm.scrip import Scrip
+from compass.ocean.tests.global_ocean.files_for_e3sm.e3sm_to_cmip_maps import \
+    E3smToCmipMaps
 from compass.ocean.tests.global_ocean.files_for_e3sm.diagnostics_files \
     import DiagnosticsFiles
 from compass.ocean.tests.global_ocean.forward import get_forward_subdir
@@ -88,6 +90,10 @@ class FilesForE3SM(TestCase):
             Scrip(
                 test_case=self, restart_filename=restart_filename,
                 with_ice_shelf_cavities=mesh.with_ice_shelf_cavities))
+
+        self.add_step(
+            E3smToCmipMaps(
+                test_case=self, restart_filename=restart_filename))
 
         self.add_step(
             DiagnosticsFiles(

--- a/compass/ocean/tests/global_ocean/files_for_e3sm/e3sm_to_cmip_maps.py
+++ b/compass/ocean/tests/global_ocean/files_for_e3sm/e3sm_to_cmip_maps.py
@@ -88,7 +88,7 @@ def make_e3sm_to_cmip_maps(config, logger, mesh_short_name, creation_date,
         ``assembled_files``
     """
 
-    link_dir = f'../assembled_files/diagnostics/e3sm_to_cmip/maps'
+    link_dir = f'../assembled_files/diagnostics/maps'
 
     try:
         os.makedirs(link_dir)

--- a/compass/ocean/tests/global_ocean/files_for_e3sm/e3sm_to_cmip_maps.py
+++ b/compass/ocean/tests/global_ocean/files_for_e3sm/e3sm_to_cmip_maps.py
@@ -1,0 +1,80 @@
+import os
+import xarray
+
+from mpas_tools.scrip.from_mpas import scrip_from_mpas
+
+from compass.io import symlink
+from compass.step import Step
+
+
+class E3smToCmipMaps(Step):
+    """
+    A step for creating mapping files from the MPAS-Ocean mesh to a standard
+    CMIP6 mesh
+    """
+    def __init__(self, test_case, restart_filename):
+        """
+        Create a new step
+
+        Parameters
+        ----------
+        test_case : compass.ocean.tests.global_ocean.files_for_e3sm.FilesForE3SM
+            The test case this step belongs to
+
+        restart_filename : str
+            A restart file from the end of the dynamic adjustment test case to
+            use as the basis for an E3SM initial condition
+        """
+
+        super().__init__(test_case, name='e3sm_to_cmip_map', ntasks=1,
+                         min_tasks=1, openmp_threads=1)
+
+        self.add_input_file(filename='README', target='../README')
+        self.add_input_file(filename='restart.nc',
+                            target=f'../{restart_filename}')
+
+        self.add_input_file(filename='../scrip/ocean.scrip.nc')
+
+        self.add_input_file(
+            filename='cmip6_180x360_scrip.20181001.nc',
+            target='cmip6_180x360_scrip.20181001.nc',
+            database='map_database')
+
+        self.add_output_file(filename='map_mpas_to_cmip6_180x360_aave.nc')
+        self.add_output_file(filename='map_mpas_to_cmip6_180x360_mono.nc')
+        self.add_output_file(filename='map_mpas_to_cmip6_180x360_nco.nc')
+
+    def run(self):
+        """
+        Run this step of the testcase
+        """
+        with xarray.open_dataset('restart.nc') as ds:
+            mesh_short_name = ds.attrs['MPAS_Mesh_Short_Name']
+            mesh_prefix = ds.attrs['MPAS_Mesh_Prefix']
+            prefix = f'MPAS_Mesh_{mesh_prefix}'
+            creation_date = ds.attrs[f'{prefix}_Version_Creation_Date']
+
+        link_dir = f'../assembled_files/diagnostics/e3sm_to_cmip/maps'
+
+        try:
+            os.makedirs(link_dir)
+        except OSError:
+            pass
+
+        src_scrip_filename = 'ocean.scrip.nc'
+        # Todo: the resolution should be a config option
+        dst_scrip_filename = 'cmip6_180x360_scrip.20181001.nc'
+        map_methods = dict(aave='conserve', mono='fv2fv_flx', nco='nco')
+        for suffix, map_method in map_methods.items():
+            local_map_filename = f'map_mpas_to_cmip6_180x360_{suffix}.nc'
+            args = ['ncremap', f'--alg_typ={map_method}',
+                    f'--grd_src={src_scrip_filename}',
+                    f'--grd_dst={dst_scrip_filename}',
+                    f'--map={local_map_filename}']
+            check_call(args, logger=logger)
+
+            map_filename = \
+                f'map_{mesh_short_name}_to_cmip6_180x360_{suffix}.{creation_date}.nc'
+
+            symlink(f'../../../../e3sm_to_cmip_map/{local_map_filename}',
+                    f'{link_dir}/{map_filename}')

--- a/compass/ocean/tests/global_ocean/files_for_e3sm/scrip.py
+++ b/compass/ocean/tests/global_ocean/files_for_e3sm/scrip.py
@@ -40,9 +40,10 @@ class Scrip(Step):
 
         self.with_ice_shelf_cavities = with_ice_shelf_cavities
 
-        # for now, we won't define any outputs because they include the mesh
-        # short name, which is not known at setup time.  Currently, this is
-        # safe because no other steps depend on the outputs of this one.
+        self.add_output_file(filename='ocean.scrip.nc')
+
+        if with_ice_shelf_cavities:
+            self.add_output_file(filename='ocean.mask.scrip.nc')
 
     def run(self):
         """
@@ -67,23 +68,25 @@ class Scrip(Step):
         else:
             nomask_str = ''
 
+        local_filename = 'ocean.scrip.nc'
         scrip_filename = 'ocean.{}{}.scrip.{}.nc'.format(
             mesh_short_name,  nomask_str, creation_date)
 
-        scrip_from_mpas('restart.nc', scrip_filename)
+        scrip_from_mpas('restart.nc', local_filename)
 
-        symlink('../../../../../scrip/{}'.format(scrip_filename),
+        symlink('../../../../../scrip/{}'.format(local_filename),
                 '../assembled_files/inputdata/ocn/mpas-o/{}/{}'.format(
                     mesh_short_name, scrip_filename))
 
         if with_ice_shelf_cavities:
+            local_filename = 'ocean.mask.scrip.nc'
             scrip_mask_filename = 'ocean.{}.mask.scrip.{}.nc'.format(
                 mesh_short_name, creation_date)
-            scrip_from_mpas('restart.nc', scrip_mask_filename,
+            scrip_from_mpas('restart.nc', local_filename,
                             useLandIceMask=True)
 
             symlink(
                 '../../../../../scrip/{}'.format(
-                    scrip_mask_filename),
+                    local_filename),
                 '../assembled_files/inputdata/ocn/mpas-o/{}/{}'.format(
                     mesh_short_name, scrip_mask_filename))

--- a/compass/ocean/tests/global_ocean/files_for_e3sm/scrip.py
+++ b/compass/ocean/tests/global_ocean/files_for_e3sm/scrip.py
@@ -36,7 +36,7 @@ class Scrip(Step):
 
         self.add_input_file(filename='README', target='../README')
         self.add_input_file(filename='restart.nc',
-                            target='../{}'.format(restart_filename))
+                            target=f'../{restart_filename}')
 
         self.with_ice_shelf_cavities = with_ice_shelf_cavities
 
@@ -48,18 +48,19 @@ class Scrip(Step):
     def run(self):
         """
         Run this step of the testcase
-            """
+        """
         with_ice_shelf_cavities = self.with_ice_shelf_cavities
 
         with xarray.open_dataset('restart.nc') as ds:
             mesh_short_name = ds.attrs['MPAS_Mesh_Short_Name']
             mesh_prefix = ds.attrs['MPAS_Mesh_Prefix']
-            prefix = 'MPAS_Mesh_{}'.format(mesh_prefix)
-            creation_date = ds.attrs['{}_Version_Creation_Date'.format(prefix)]
+            prefix = f'MPAS_Mesh_{mesh_prefix}'
+            creation_date = ds.attrs[f'{prefix}_Version_Creation_Date']
+
+        link_dir = f'../assembled_files/inputdata/ocn/mpas-o/{mesh_short_name}'
 
         try:
-            os.makedirs('../assembled_files/inputdata/ocn/mpas-o/{}'.format(
-                mesh_short_name))
+            os.makedirs(link_dir)
         except OSError:
             pass
 
@@ -69,24 +70,20 @@ class Scrip(Step):
             nomask_str = ''
 
         local_filename = 'ocean.scrip.nc'
-        scrip_filename = 'ocean.{}{}.scrip.{}.nc'.format(
-            mesh_short_name,  nomask_str, creation_date)
+        scrip_filename = \
+            f'ocean.{mesh_short_name}{nomask_str}.scrip.{creation_date}.nc'
 
         scrip_from_mpas('restart.nc', local_filename)
 
-        symlink('../../../../../scrip/{}'.format(local_filename),
-                '../assembled_files/inputdata/ocn/mpas-o/{}/{}'.format(
-                    mesh_short_name, scrip_filename))
+        symlink(f'../../../../../scrip/{local_filename}',
+                f'{link_dir}/{scrip_filename}')
 
         if with_ice_shelf_cavities:
             local_filename = 'ocean.mask.scrip.nc'
-            scrip_mask_filename = 'ocean.{}.mask.scrip.{}.nc'.format(
-                mesh_short_name, creation_date)
+            scrip_mask_filename = \
+                f'ocean.{mesh_short_name}.mask.scrip.{creation_date}.nc'
             scrip_from_mpas('restart.nc', local_filename,
                             useLandIceMask=True)
 
-            symlink(
-                '../../../../../scrip/{}'.format(
-                    local_filename),
-                '../assembled_files/inputdata/ocn/mpas-o/{}/{}'.format(
-                    mesh_short_name, scrip_mask_filename))
+            symlink(f'../../../../../scrip/{local_filename}',
+                    f'{link_dir}/{scrip_mask_filename}')

--- a/compass/ocean/tests/global_ocean/global_ocean.cfg
+++ b/compass/ocean/tests/global_ocean/global_ocean.cfg
@@ -112,3 +112,6 @@ comparisonAntarcticStereoResolution = 10.
 # The comparison Arctic polar stereographic grid size and resolution in km
 comparisonArcticStereoWidth = 6000.
 comparisonArcticStereoResolution = 10.
+
+# CMIP6 grid resolution
+cmip6_grid_res = 180x360

--- a/compass/ocean/tests/global_ocean/make_diagnostics_files/__init__.py
+++ b/compass/ocean/tests/global_ocean/make_diagnostics_files/__init__.py
@@ -2,6 +2,8 @@ import os
 import xarray
 from datetime import datetime
 
+from mpas_tools.scrip.from_mpas import scrip_from_mpas
+
 from compass.io import symlink
 from compass.testcase import TestCase
 from compass.step import Step
@@ -64,7 +66,8 @@ class DiagnosticsFiles(Step):
         test_case : compass.ocean.tests.global_ocean.make_diagnostics_files.MakeDiagnosticsFiles
             The test case this step belongs to
         """
-        super().__init__(test_case=test_case, name='diagnostics_files')
+        super().__init__(test_case=test_case, name='diagnostics_files',
+                         ntasks=36, min_tasks=1, openmp_threads=1)
 
     def run(self):
         """
@@ -95,8 +98,10 @@ class DiagnosticsFiles(Step):
                     now = datetime.now()
                     creation_date = now.strftime("%y%m%d")
 
+        scrip_from_mpas('restart.nc', 'ocean.scrip.nc')
+
         make_e3sm_to_cmip_maps(self.config, self.logger, mesh_short_name,
-                               creation_date, self.subdir)
+                               creation_date, self.subdir, self.ntasks)
 
         make_diagnostics_files(self.config, self.logger, mesh_short_name,
                                with_ice_shelf_cavities, cores)

--- a/compass/ocean/tests/global_ocean/make_diagnostics_files/make_diagnostics_files.cfg
+++ b/compass/ocean/tests/global_ocean/make_diagnostics_files/make_diagnostics_files.cfg
@@ -1,8 +1,9 @@
 # config options related to diagnostics support files for an existing mesh
 [make_diagnostics_files]
 
-# the E3SM short name of the mesh
-mesh_name = EC30to60E2r3
+# the E3SM short name of the mesh if not in the MPAS_Mesh_Short_Name attribute
+# of the mesh file
+# mesh_name = EC30to60E2r3
 
 # the absolute path or relative path with respect to the test case's work
 # directory of a mesh file with the given short name

--- a/compass/ocean/tests/global_ocean/mesh/so12to60/so12to60.cfg
+++ b/compass/ocean/tests/global_ocean/mesh/so12to60/so12to60.cfg
@@ -47,3 +47,11 @@ min_res = 12
 max_res = 60
 # The URL of the pull request documenting the creation of the mesh
 pull_request = https://github.com/MPAS-Dev/compass/pull/37
+
+
+# config options related to initial condition and diagnostics support files
+# for E3SM
+[files_for_e3sm]
+
+# CMIP6 grid resolution
+cmip6_grid_res = 720x1440

--- a/compass/ocean/tests/global_ocean/mesh/wc14/wc14.cfg
+++ b/compass/ocean/tests/global_ocean/mesh/wc14/wc14.cfg
@@ -43,3 +43,11 @@ min_res = 14
 max_res = 60
 # The URL of the pull request documenting the creation of the mesh
 pull_request = https://github.com/MPAS-Dev/MPAS-Model/pull/628
+
+
+# config options related to initial condition and diagnostics support files
+# for E3SM
+[files_for_e3sm]
+
+# CMIP6 grid resolution
+cmip6_grid_res = 720x1440

--- a/compass/parallel.py
+++ b/compass/parallel.py
@@ -140,8 +140,7 @@ def run_command(args, cpus_per_task, ntasks, openmp_threads, config, logger):
     command_line_args = parallel_executable.split(' ')
     parallel_system = config.get('parallel', 'system')
     if parallel_system == 'slurm':
-        command_line_args.extend(['-c', f'{cpus_per_task}', '-n', f'{ntasks}',
-                                  '--exclusive'])
+        command_line_args.extend(['-c', f'{cpus_per_task}', '-n', f'{ntasks}'])
     elif parallel_system == 'single_node':
         if ntasks > 1:
             command_line_args.extend(['-n', f'{ntasks}'])


### PR DESCRIPTION
To make things easier for the team publishing CMIP6 data from E3SM simulations, we want a set of mapping files from each MPAS-Ocean (and -Seaice) mesh to a standard CMIP6 grid.  This merge adds a step to the `files_for_e3sm` test case for making these mapping files.

It also adds this capability to the `make_diagnostic_files` to test case so these mapping files can be created (along with other diagnostics files) for existing meshes.