### PR TITLE
Add a sigma vertical coordinate to ocean framework

### DIFF
--- a/compass/ocean/tests/isomip_plus/__init__.py
+++ b/compass/ocean/tests/isomip_plus/__init__.py
@@ -21,10 +21,13 @@ class IsomipPlus(TestGroup):
                         OceanTest(test_group=self, resolution=resolution,
                                   experiment=experiment,
                                   vertical_coordinate=vertical_coordinate))
-            for experiment in ['Ocean0']:
-                for vertical_coordinate in ['z-star']:
-                    self.add_test_case(
-                        OceanTest(test_group=self, resolution=resolution,
-                                  experiment=experiment,
-                                  vertical_coordinate=vertical_coordinate,
-                                  time_varying_forcing=True))
+
+            self.add_test_case(
+                OceanTest(test_group=self, resolution=resolution,
+                          experiment='Ocean0',
+                          vertical_coordinate='z-star',
+                          time_varying_forcing=True))
+            self.add_test_case(
+                OceanTest(test_group=self, resolution=resolution,
+                          experiment='Ocean0',
+                          vertical_coordinate='sigma'))

--- a/compass/ocean/tests/isomip_plus/initial_state.py
+++ b/compass/ocean/tests/isomip_plus/initial_state.py
@@ -86,6 +86,7 @@ class InitialState(Step):
         """
         config = self.config
         logger = self.logger
+        vertical_coordinate = self.vertical_coordinate
 
         section = config['isomip_plus']
         nx = section.getint('nx')
@@ -143,14 +144,15 @@ class InitialState(Step):
         section = config['isomip_plus']
 
         min_column_thickness = section.getfloat('min_column_thickness')
-        min_levels = section.getint('minimum_levels')
 
         interfaces = generate_1d_grid(config)
 
         # Deepen the bottom depth to maintain the minimum water-column
         # thickness
-        min_depth = numpy.maximum(-ds.ssh + min_column_thickness,
-                                  interfaces[min_levels+1])
+        min_depth = -ds.ssh + min_column_thickness
+        if vertical_coordinate == 'z-star':
+            min_levels = section.getint('minimum_levels')
+            min_depth = numpy.maximum(min_depth, interfaces[min_levels+1])
         ds['bottomDepth'] = numpy.maximum(ds.bottomDepth, min_depth)
 
         init_vertical_coord(config, ds)

--- a/compass/ocean/tests/isomip_plus/ocean_test/__init__.py
+++ b/compass/ocean/tests/isomip_plus/ocean_test/__init__.py
@@ -156,6 +156,10 @@ class OceanTest(TestCase):
 
         config.set('vertical_grid', 'coord_type', vertical_coordinate)
 
+        if vertical_coordinate == 'sigma':
+            # default to 10 vertical levels instead of 36
+            config.set('vertical_grid', 'vert_levels', '10')
+
         for step_name in self.steps:
             if step_name in ['ssh_adjustment', 'performance', 'simulation']:
                 step = self.steps[step_name]

--- a/compass/ocean/tests/isomip_plus/viz/plot.py
+++ b/compass/ocean/tests/isomip_plus/viz/plot.py
@@ -746,9 +746,9 @@ class MoviePlotter(object):
             localPatches.set_array(field[self.cavityMask])
 
         localPatches.set_edgecolor('face')
-        localPatches.set_clim(vmin=vmin, vmax=vmax)
         if cmap is not None:
             localPatches.set_cmap(cmap)
+        localPatches.set_clim(vmin=vmin, vmax=vmax)
 
         plt.figure(figsize=figsize)
         ax = plt.subplot(111)

--- a/compass/ocean/vertical/__init__.py
+++ b/compass/ocean/vertical/__init__.py
@@ -1,6 +1,7 @@
 import numpy
 import xarray
 
+from compass.ocean.vertical.sigma import init_sigma_vertical_coord
 from compass.ocean.vertical.zlevel import init_z_level_vertical_coord
 from compass.ocean.vertical.zstar import init_z_star_vertical_coord
 
@@ -72,6 +73,8 @@ def init_vertical_coord(config, ds):
         init_z_level_vertical_coord(config, ds)
     elif coord_type == 'z-star':
         init_z_star_vertical_coord(config, ds)
+    elif coord_type == 'sigma':
+        init_sigma_vertical_coord(config, ds)
     elif coord_type == 'haney-number':
         raise ValueError('Haney Number coordinate not yet supported.')
     else:

--- a/compass/ocean/vertical/sigma.py
+++ b/compass/ocean/vertical/sigma.py
@@ -1,0 +1,124 @@
+import xarray
+
+from compass.ocean.vertical.grid_1d import add_1d_grid
+
+
+def init_sigma_vertical_coord(config, ds):
+    """
+    Create a sigma (terrain-following) vertical coordinate based on the config
+    options in the `vertical_grid`` section and the ``bottomDepth`` and
+    ``ssh`` variables of the mesh data set.
+
+    The following new variables will be added to the data set:
+
+      * ``minLevelCell`` - the index of the top valid layer
+
+      * ``maxLevelCell`` - the index of the bottom valid layer
+
+      * ``cellMask`` - a mask of where cells are valid
+
+      * ``layerThickness`` - the thickness of each layer
+
+      * ``restingThickness`` - the thickness of each layer stretched as if
+        ``ssh = 0``
+
+      * ``zMid`` - the elevation of the midpoint of each layer
+
+    The sigma coordinate makes use of a 1D reference vertical grid. The
+    following variables associated with that field are also added to the mesh:
+
+      * ``refTopDepth`` - the positive-down depth of the top of each ref. level
+
+      * ``refZMid`` - the positive-down depth of the middle of each ref. level
+
+      * ``refBottomDepth`` - the positive-down depth of the bottom of each ref.
+        level
+
+      * ``refInterfaces`` - the positive-down depth of the interfaces between
+        ref. levels (with ``nVertLevels`` + 1 elements).
+
+      * ``vertCoordMovementWeights`` - the weights (all ones) for coordinate
+        movement
+
+    There is considerable redundancy between these variables but each is
+    sometimes convenient.
+
+    Parameters
+    ----------
+    config : compass.config.CompassConfigParser
+        Configuration options with parameters used to construct the vertical
+        grid
+
+    ds : xarray.Dataset
+        A data set containing ``bottomDepth`` and ``ssh`` variables used to
+        construct the vertical coordinate
+    """
+    add_1d_grid(config, ds)
+
+    ds['vertCoordMovementWeights'] = xarray.ones_like(ds.refBottomDepth)
+
+    valid = ds.bottomDepth > -ds.ssh
+    cell_mask, _ = xarray.broadcast(valid, ds.refBottomDepth)
+    ds['cellMask'] = cell_mask.transpose('nCells', 'nVertLevels')
+
+    ds['minLevelCell'] = xarray.zeros_like(ds.bottomDepth, dtype=int)
+    ds['maxLevelCell'] = (ds.sizes['nVertLevels']-1 *
+                          xarray.ones_like(ds.bottomDepth, dtype=int))
+
+    resting_ssh = xarray.zeros_like(ds.bottomDepth)
+
+    ds['restingThickness'] = compute_sigma_layer_thickness(
+        ds.refInterfaces, resting_ssh, ds.bottomDepth)
+
+    ds['layerThickness'] = compute_sigma_layer_thickness(
+        ds.refInterfaces, ds.ssh, ds.bottomDepth)
+
+
+def compute_sigma_layer_thickness(ref_interfaces, ssh, bottom_depth,
+                                  max_level=None):
+    """
+    Compute sigma layer thickness by stretching restingThickness based on ssh
+    and bottom_depth
+
+    Parameters
+    ----------
+    ref_interfaces : xarray.DataArray
+        the interfaces of the reference coordinate used to define sigma layer
+        spacing.  The interfaces are renormalized to be between 0 and 1
+
+    ssh : xarray.DataArray
+        The sea surface height
+
+    bottom_depth : xarray.DataArray
+        The positive-down depth of the seafloor
+
+    max_level : int, optional
+        The maximum number of levels used for the sigma coordinate.  The
+        default is ``nVertLevels``.
+
+    Returns
+    -------
+    layer_thickness : xarray.DataArray
+        The thickness of each layer
+    """
+    n_vert_levels = ref_interfaces.sizes['nVertLevelsP1']-1
+    if max_level is None:
+        max_level = n_vert_levels
+
+    # renormalize ref_interfaces to a coordinate between 0 and 1
+    stretch = (ref_interfaces - ref_interfaces.min()).values
+    stretch = stretch / stretch[max_level]
+
+    column_thickness = ssh + bottom_depth
+    valid = bottom_depth > -ssh
+    layer_thickness = []
+
+    for z_index in range(max_level):
+        thickness = (stretch[z_index+1] - stretch[z_index])*column_thickness
+        thickness = thickness.where(valid, 0.)
+        layer_thickness.append(thickness)
+    for z_index in range(max_level, n_vert_levels):
+        layer_thickness.append(xarray.zeros_like(bottom_depth))
+    layer_thickness = xarray.concat(layer_thickness, dim='nVertLevels')
+    layer_thickness = layer_thickness.transpose('nCells', 'nVertLevels')
+    return layer_thickness


### PR DESCRIPTION
This merge also adds ISOMIP+ test cases that demonstrate the usage of the coordinate.

In the process, a small bug was found in the ISOMIP+ visualization in which the colormap bounds were incorrectly including zero even for fields (like salinity) where this is not appropriate.  This has also been fixed here for convenience.