### PR TITLE
Switch from 2- to 4-digit year in global ocean

### DIFF
--- a/compass/ocean/tests/global_ocean/make_diagnostics_files/__init__.py
+++ b/compass/ocean/tests/global_ocean/make_diagnostics_files/__init__.py
@@ -94,15 +94,16 @@ class E3smToCmpiMaps(Step):
                 mesh_short_name = ds.attrs['MPAS_Mesh_Short_Name']
             else:
                 mesh_short_name = section.get('mesh_name')
-            if 'MPAS_Mesh_Prefix' in ds.attrs:
-                mesh_prefix = ds.attrs['MPAS_Mesh_Prefix']
-                prefix = f'MPAS_Mesh_{mesh_prefix}'
-                creation_date = ds.attrs[f'{prefix}_Version_Creation_Date']
-            else:
-                creation_date = config.get('global_ocean', 'creation_date')
-                if creation_date == 'autodetect':
+
+            creation_date = config.get('global_ocean', 'creation_date')
+            if creation_date == 'autodetect':
+                if 'MPAS_Mesh_Prefix' in ds.attrs:
+                    mesh_prefix = ds.attrs['MPAS_Mesh_Prefix']
+                    prefix = f'MPAS_Mesh_{mesh_prefix}'
+                    creation_date = ds.attrs[f'{prefix}_Version_Creation_Date']
+                else:
                     now = datetime.now()
-                    creation_date = now.strftime("%y%m%d")
+                    creation_date = now.strftime("%Y%m%d")
 
         scrip_from_mpas('restart.nc', 'ocean.scrip.nc')
 

--- a/compass/ocean/tests/global_ocean/metadata.py
+++ b/compass/ocean/tests/global_ocean/metadata.py
@@ -126,7 +126,7 @@ def _get_metadata(dsInit, config):
     creation_date = config.get('global_ocean', 'creation_date')
     if creation_date == 'autodetect':
         now = datetime.now()
-        creation_date = now.strftime("%y%m%d")
+        creation_date = now.strftime("%Y%m%d")
         config.set('global_ocean', 'creation_date', creation_date)
 
     max_depth = dsInit.bottomDepth.max().values


### PR DESCRIPTION
In the date stamp in output files and metadata, it is significantly less ambiguous to have a 4-digit year.