### PR TITLE
Add more projection grids to diagnostics_files

### DIFF
--- a/compass/ocean/tests/global_ocean/files_for_e3sm/diagnostics_files.py
+++ b/compass/ocean/tests/global_ocean/files_for_e3sm/diagnostics_files.py
@@ -1,8 +1,10 @@
 import os
 import xarray
 import glob
+import pyproj
+import numpy
 
-from pyremap import get_lat_lon_descriptor, get_polar_descriptor, \
+from pyremap import get_lat_lon_descriptor, ProjectionGridDescriptor, \
     MpasMeshDescriptor, Remapper
 from geometric_features import GeometricFeatures
 from geometric_features.aggregation import get_aggregator_by_name
@@ -126,11 +128,11 @@ def make_diagnostics_files(config, logger, mesh_short_name,
                              logger=logger, cores=cores)
 
     _make_analysis_lat_lon_map(config, mesh_short_name, cores, logger)
-    _make_analysis_polar_map(config, mesh_short_name,
-                             projection='antarctic', cores=cores,
-                             logger=logger)
-    _make_analysis_polar_map(config, mesh_short_name, projection='arctic',
-                             cores=cores, logger=logger)
+    for projection_name in ['antarctic', 'arctic', 'antarctic_extended',
+                            'arctic_extended', 'north_atlantic',
+                            'north_pacific', 'subpolar_north_atlantic']:
+        _make_analysis_projection_map(config, mesh_short_name, projection_name,
+                                      cores, logger)
 
     # make links in output directory
     files = glob.glob('map_*')
@@ -224,29 +226,101 @@ def _make_analysis_lat_lon_map(config, mesh_name, cores, logger):
                        cores, config, logger)
 
 
-def _make_analysis_polar_map(config, mesh_name, projection, cores, logger):
+# copied from MPAS-Analysis for now
+def _get_pyproj_projection(comparison_grid_name):
+    """
+    Get the projection from the comparison_grid_name.
+    Parameters
+    ----------
+    comparison_grid_name : str
+        The name of the projection comparison grid to use for remapping
+    Returns
+    -------
+    projection : pyproj.Proj
+        The projection
+    Raises
+    ------
+    ValueError
+        If comparison_grid_name does not describe a known comparison grid
+    """
+
+    if comparison_grid_name == 'latlon':
+        raise ValueError('latlon is not a projection grid.')
+    elif comparison_grid_name in ['antarctic', 'antarctic_extended']:
+        projection = pyproj.Proj(
+            '+proj=stere +lat_ts=-71.0 +lat_0=-90 +lon_0=0.0  +k_0=1.0 '
+            '+x_0=0.0 +y_0=0.0 +ellps=WGS84')
+    elif comparison_grid_name in ['arctic', 'arctic_extended']:
+        projection = pyproj.Proj(
+            '+proj=stere +lat_ts=75.0 +lat_0=90 +lon_0=0.0  +k_0=1.0 '
+            '+x_0=0.0 +y_0=0.0 +ellps=WGS84')
+    elif comparison_grid_name == 'north_atlantic':
+        projection = pyproj.Proj('+proj=lcc +lon_0=-45 +lat_0=45 +lat_1=39 '
+                                 '+lat_2=51 +x_0=0.0 +y_0=0.0 +ellps=WGS84')
+    elif comparison_grid_name == 'north_pacific':
+        projection = pyproj.Proj('+proj=lcc +lon_0=180 +lat_0=40 +lat_1=34 '
+                                 '+lat_2=46 +x_0=0.0 +y_0=0.0 +ellps=WGS84')
+    elif comparison_grid_name == 'subpolar_north_atlantic':
+        projection = pyproj.Proj('+proj=lcc +lon_0=-40 +lat_0=54 +lat_1=40 '
+                                 '+lat_2=68 +x_0=0.0 +y_0=0.0 +ellps=WGS84')
+    else:
+        raise ValueError(f'We missed one of the known comparison grids: '
+                         f'{comparison_grid_name}')
+
+    return projection
+
+
+# A lot of duplication from MPAS-Analysis for now.
+def _make_analysis_projection_map(config, mesh_name, projection_name, cores,
+                                  logger):
     mesh_filename = 'restart.nc'
+    section = 'files_for_e3sm'
 
-    upperProj = projection[0].upper() + projection[1:]
+    option_suffixes = {'antarctic': 'AntarcticStereo',
+                       'arctic': 'ArcticStereo',
+                       'antarctic_extended': 'AntarcticExtended',
+                       'arctic_extended': 'ArcticExtended',
+                       'north_atlantic': 'NorthAtlantic',
+                       'north_pacific': 'NorthPacific',
+                       'subpolar_north_atlantic': 'SubpolarNorthAtlantic'}
 
-    inDescriptor = MpasMeshDescriptor(mesh_filename, mesh_name)
+    grid_suffixes = {'antarctic': 'Antarctic_stereo',
+                     'arctic': 'Arctic_stereo',
+                     'antarctic_extended': 'Antarctic_stereo',
+                     'arctic_extended': 'Arctic_stereo',
+                     'north_atlantic': 'North_Atlantic',
+                     'north_pacific': 'North_Pacific',
+                     'subpolar_north_atlantic': 'Subpolar_North_Atlantic'}
 
-    comparisonStereoWidth = config.getfloat(
-        'files_for_e3sm', 'comparison{}StereoWidth'.format(upperProj))
-    comparisonStereoResolution = config.getfloat(
-        'files_for_e3sm', 'comparison{}StereoResolution'.format(upperProj))
+    projection = _get_pyproj_projection(projection_name)
+    option_suffix = option_suffixes[projection_name]
+    grid_suffix = grid_suffixes[projection_name]
 
-    outDescriptor = get_polar_descriptor(Lx=comparisonStereoWidth,
-                                         Ly=comparisonStereoWidth,
-                                         dx=comparisonStereoResolution,
-                                         dy=comparisonStereoResolution,
-                                         projection=projection)
+    in_descriptor = MpasMeshDescriptor(mesh_filename, mesh_name)
 
-    outGridName = '{}x{}km_{}km_{}_stereo'.format(
-        comparisonStereoWidth,  comparisonStereoWidth,
-        comparisonStereoResolution, upperProj)
+    width = config.getfloat(
+        section, f'comparison{option_suffix}Width')
+    option = f'comparison{option_suffix}Height'
+    if config.has_option(section, option):
+        height = config.getfloat(section, option)
+    else:
+        height = width
+    res = config.getfloat(
+        section, f'comparison{option_suffix}Resolution')
 
-    _make_mapping_file(mesh_name, outGridName, inDescriptor, outDescriptor,
+    xmax = 0.5 * width * 1e3
+    nx = int(width / res) + 1
+    x = numpy.linspace(-xmax, xmax, nx)
+
+    ymax = 0.5 * height * 1e3
+    ny = int(height / res) + 1
+    y = numpy.linspace(-ymax, ymax, ny)
+
+    out_grid_name = f'{width}x{height}km_{res}km_{grid_suffix}'
+    out_descriptor = ProjectionGridDescriptor.create(projection, x, y,
+                                                     mesh_name)
+
+    _make_mapping_file(mesh_name, out_grid_name, in_descriptor, out_descriptor,
                        cores, config, logger)
 
 

--- a/compass/ocean/tests/global_ocean/files_for_e3sm/diagnostics_files.py
+++ b/compass/ocean/tests/global_ocean/files_for_e3sm/diagnostics_files.py
@@ -50,7 +50,7 @@ class DiagnosticsFiles(Step):
 
         self.add_input_file(filename='README', target='../README')
         self.add_input_file(filename='restart.nc',
-                            target='../{}'.format(restart_filename))
+                            target=f'../{restart_filename}')
 
         self.with_ice_shelf_cavities = with_ice_shelf_cavities
 
@@ -94,8 +94,7 @@ def make_diagnostics_files(config, logger, mesh_short_name,
     """
 
     for directory in [
-            '../assembled_files/inputdata/ocn/mpas-o/{}'.format(
-                mesh_short_name),
+            f'../assembled_files/inputdata/ocn/mpas-o/{mesh_short_name}',
             '../assembled_files/diagnostics/mpas_analysis/region_masks',
             '../assembled_files/diagnostics/mpas_analysis/maps']:
         try:
@@ -114,7 +113,7 @@ def make_diagnostics_files(config, logger, mesh_short_name,
 
     for region_group in region_groups:
         function, prefix, date = get_aggregator_by_name(region_group)
-        suffix = '{}{}'.format(prefix, date)
+        suffix = f'{prefix}{date}'
         fc_mask = function(gf)
         _make_region_masks(mesh_short_name, suffix=suffix, fc_mask=fc_mask,
                            logger=logger, cores=cores)
@@ -122,7 +121,7 @@ def make_diagnostics_files(config, logger, mesh_short_name,
     transect_groups = ['Transport Transects']
     for transect_group in transect_groups:
         function, prefix, date = get_aggregator_by_name(transect_group)
-        suffix = '{}{}'.format(prefix, date)
+        suffix = f'{prefix}{date}'
         fc_mask = function(gf)
         _make_transect_masks(mesh_short_name, suffix=suffix, fc_mask=fc_mask,
                              logger=logger, cores=cores)
@@ -140,15 +139,15 @@ def make_diagnostics_files(config, logger, mesh_short_name,
     # make links in output directory
     output_dir = '../assembled_files/diagnostics/mpas_analysis/maps'
     for filename in files:
-        symlink('../../../../diagnostics_files/{}'.format(filename),
-                '{}/{}'.format(output_dir, filename))
+        symlink(f'../../../../diagnostics_files/{filename}',
+                f'{output_dir}/{filename}')
 
 
 def _make_region_masks(mesh_name, suffix, fc_mask, logger, cores):
     mesh_filename = 'restart.nc'
 
-    geojson_filename = '{}.geojson'.format(suffix)
-    mask_filename = '{}_{}.nc'.format(mesh_name, suffix)
+    geojson_filename = f'{suffix}.geojson'
+    mask_filename = f'{mesh_name}_{suffix}.nc'
 
     fc_mask.to_geojson(geojson_filename)
 
@@ -162,7 +161,7 @@ def _make_region_masks(mesh_name, suffix, fc_mask, logger, cores):
             '-g', geojson_filename,
             '-o', mask_filename,
             '-t', 'cell',
-            '--process_count', '{}'.format(cores),
+            '--process_count', f'{cores}',
             '--format', netcdf_format,
             '--engine', netcdf_engine]
     check_call(args, logger=logger)
@@ -170,16 +169,16 @@ def _make_region_masks(mesh_name, suffix, fc_mask, logger, cores):
     # make links in output directory
     output_dir = '../assembled_files/diagnostics/mpas_analysis/' \
                  'region_masks'
-    symlink('../../../../diagnostics_files/{}'.format(mask_filename),
-            '{}/{}'.format(output_dir, mask_filename))
+    symlink(f'../../../../diagnostics_files/{mask_filename}',
+            f'{output_dir}/{mask_filename}')
 
 
 def _make_transect_masks(mesh_name, suffix, fc_mask, logger, cores,
                          subdivision_threshold=10e3):
     mesh_filename = 'restart.nc'
 
-    geojson_filename = '{}.geojson'.format(suffix)
-    mask_filename = '{}_{}.nc'.format(mesh_name, suffix)
+    geojson_filename = f'{suffix}.geojson'
+    mask_filename = f'{mesh_name}_{suffix}.nc'
 
     fc_mask.to_geojson(geojson_filename)
 
@@ -193,8 +192,8 @@ def _make_transect_masks(mesh_name, suffix, fc_mask, logger, cores,
             '-g', geojson_filename,
             '-o', mask_filename,
             '-t', 'edge',
-            '-s', '{}'.format(subdivision_threshold),
-            '--process_count', '{}'.format(cores),
+            '-s', f'{subdivision_threshold}',
+            '--process_count', f'{cores}',
             '--add_edge_sign',
             '--format', netcdf_format,
             '--engine', netcdf_engine]
@@ -203,8 +202,8 @@ def _make_transect_masks(mesh_name, suffix, fc_mask, logger, cores,
     # make links in output directory
     output_dir = '../assembled_files/diagnostics/mpas_analysis/' \
                  'region_masks'
-    symlink('../../../../diagnostics_files/{}'.format(mask_filename),
-            '{}/{}'.format(output_dir, mask_filename))
+    symlink(f'../../../../diagnostics_files/{mask_filename}',
+            f'{output_dir}/{mask_filename}')
 
 
 def _make_analysis_lat_lon_map(config, mesh_name, cores, logger):
@@ -327,8 +326,7 @@ def _make_mapping_file(mesh_name, out_grid_name, in_descriptor, out_descriptor,
 
     parallel_executable = config.get('parallel', 'parallel_executable')
 
-    mapping_file_name = 'map_{}_to_{}_bilinear.nc'.format(mesh_name,
-                                                          out_grid_name)
+    mapping_file_name = f'map_{mesh_name}_to_{out_grid_name}_bilinear.nc'
 
     remapper = Remapper(in_descriptor, out_descriptor, mapping_file_name)
 
@@ -345,10 +343,10 @@ def _make_moc_masks(mesh_short_name, logger, cores):
     function, prefix, date = get_aggregator_by_name('MOC Basins')
     fc_mask = function(gf)
 
-    suffix = '{}{}'.format(prefix, date)
+    suffix = f'{prefix}{date}'
 
-    geojson_filename = '{}.geojson'.format(suffix)
-    mask_filename = '{}_{}.nc'.format(mesh_short_name, suffix)
+    geojson_filename = f'{suffix}.geojson'
+    mask_filename = f'{mesh_short_name}_{suffix}.nc'
 
     fc_mask.to_geojson(geojson_filename)
 
@@ -362,13 +360,13 @@ def _make_moc_masks(mesh_short_name, logger, cores):
             '-g', geojson_filename,
             '-o', mask_filename,
             '-t', 'cell',
-            '--process_count', '{}'.format(cores),
+            '--process_count', f'{cores}',
             '--format', netcdf_format,
             '--engine', netcdf_engine]
     check_call(args, logger=logger)
 
-    mask_and_transect_filename = '{}_mocBasinsAndTransects{}.nc'.format(
-        mesh_short_name, date)
+    mask_and_transect_filename = \
+        f'{mesh_short_name}_mocBasinsAndTransects{date}.nc'
 
     ds_mesh = xarray.open_dataset(mesh_filename)
     ds_mask = xarray.open_dataset(mask_filename)
@@ -380,16 +378,13 @@ def _make_moc_masks(mesh_short_name, logger, cores):
                  char_dim_name='StrLen')
 
     # make links in output directories (both inputdata and diagnostics)
-    output_dir = '../assembled_files/inputdata/ocn/mpas-o/{}'.format(
-        mesh_short_name)
+    output_dir = f'../assembled_files/inputdata/ocn/mpas-o/{mesh_short_name}'
     symlink(
-        '../../../../../diagnostics_files/{}'.format(
-            mask_and_transect_filename),
-        '{}/{}'.format(output_dir, mask_and_transect_filename))
+        f'../../../../../diagnostics_files/{mask_and_transect_filename}',
+        f'{output_dir}/{mask_and_transect_filename}')
 
     output_dir = '../assembled_files/diagnostics/mpas_analysis/' \
                  'region_masks'
     symlink(
-        '../../../../diagnostics_files/{}'.format(
-            mask_and_transect_filename),
-        '{}/{}'.format(output_dir, mask_and_transect_filename))
+        f'../../../../diagnostics_files/{mask_and_transect_filename}',
+        f'{output_dir}/{mask_and_transect_filename}')

--- a/compass/ocean/tests/global_ocean/global_ocean.cfg
+++ b/compass/ocean/tests/global_ocean/global_ocean.cfg
@@ -113,5 +113,30 @@ comparisonAntarcticStereoResolution = 10.
 comparisonArcticStereoWidth = 6000.
 comparisonArcticStereoResolution = 10.
 
+# The extended Antarctic polar stereographic comparison grid size and
+# resolution in km
+comparisonAntarcticExtendedWidth = 9000.
+comparisonAntarcticExtendedResolution = 15.
+
+# The extended Arctic polar stereographic comparison grid size and
+# resolution in km
+comparisonArcticExtendedWidth = 9000.
+comparisonArcticExtendedResolution = 15.
+
+# The comparison North Atlantic grid size and resolution in km
+comparisonNorthAtlanticWidth = 8500.
+comparisonNorthAtlanticHeight = 5500.
+comparisonNorthAtlanticResolution = 20.
+
+# The comparison North Pacific c grid size and resolution in km
+comparisonNorthPacificWidth = 15000.
+comparisonNorthPacificHeight = 5000.
+comparisonNorthPacificResolution = 20.
+
+# The comparison North Atlantic grid size and resolution in km
+comparisonSubpolarNorthAtlanticWidth = 7000.
+comparisonSubpolarNorthAtlanticHeight = 4000.
+comparisonSubpolarNorthAtlanticResolution = 20.
+
 # CMIP6 grid resolution
 cmip6_grid_res = 180x360

--- a/compass/ocean/tests/global_ocean/make_diagnostics_files/__init__.py
+++ b/compass/ocean/tests/global_ocean/make_diagnostics_files/__init__.py
@@ -44,7 +44,7 @@ class MakeDiagnosticsFiles(TestCase):
         """
         Run each step of the testcase
         """
-        cores = self.config.getint( 'make_diagnostics_files', 'cores')
+        cores = self.config.getint('make_diagnostics_files', 'cores')
         self.steps['diagnostics_files'].cpus_per_task = cores
         self.steps['e3sm_to_cmip_maps'].ntasks = cores
 

--- a/compass/ocean/tests/global_ocean/make_diagnostics_files/__init__.py
+++ b/compass/ocean/tests/global_ocean/make_diagnostics_files/__init__.py
@@ -29,7 +29,7 @@ class MakeDiagnosticsFiles(TestCase):
         """
         super().__init__(test_group=test_group, name='make_diagnostics_files')
 
-        self.add_step(E3smToCmpiMaps(test_case=self))
+        self.add_step(E3smToCmipMaps(test_case=self))
         self.add_step(DiagnosticsFiles(test_case=self))
 
     def configure(self):
@@ -52,7 +52,7 @@ class MakeDiagnosticsFiles(TestCase):
         super().run()
 
 
-class E3smToCmpiMaps(Step):
+class E3smToCmipMaps(Step):
     """
     A step for making e3sm_to_cmip mapping files
     """

--- a/conda/compass_env/spec-file.template
+++ b/conda/compass_env/spec-file.template
@@ -24,6 +24,7 @@ netcdf4=*=nompi_*
 numpy
 progressbar2
 pyamg >=4.2.2
+pyproj
 pyremap>=0.0.13,<0.1.0
 requests
 scipy

--- a/conda/recipe/meta.yaml
+++ b/conda/recipe/meta.yaml
@@ -61,6 +61,7 @@ requirements:
     - numpy
     - progressbar2
     - pyamg >=4.2.2
+    - pyproj
     - pyremap >=0.0.13,<0.1.0
     - requests
     - scipy

--- a/setup.py
+++ b/setup.py
@@ -30,6 +30,7 @@ install_requires = \
      'numpy',
      'progressbar2',
      'pyamg',
+     'pyproj',
      'requests',
      'scipy',
      'shapely',


### PR DESCRIPTION
MPAS-Analysis now supports 5 more projection comparison grids, and we want to generate the associated mapping files for each new MPAS-Ocean and -Seaice mesh.

For now, 2 functions have largely been copied from MPAS-Analysis. In the near future, it would be best to handle these in a better way.