### PR TITLE
Add bed topo to cell spacing

### DIFF
--- a/compass/landice/mesh.py
+++ b/compass/landice/mesh.py
@@ -215,7 +215,7 @@ def set_cell_width(self, section, thk, bed=None, vx=None, vy=None,
             # spacing_bed[dist_to_grounding_line >= high_dist_bed] = max_spac
             in_mask2 = (bed <= low_bed)
             in_mask2[np.logical_and(
-                       thk > 0, spacing_bed > min_spac)] = 0
+                       thk > 0, spacing_bed > (2. * min_spac))] = 0
             low_bed_mask2 = gridded_flood_fill(in_mask2,
                                               iStart=flood_fill_iStart,
                                               jStart=flood_fill_jStart)

--- a/compass/landice/mesh.py
+++ b/compass/landice/mesh.py
@@ -182,11 +182,11 @@ def set_cell_width(self, section, thk, bed=None, vx=None, vy=None,
                         bedTopography <= low_bed connected to the ocean.')
             tic = time.time()
             # initialize mask to low bed topography
-            in_mask = (bed<=low_bed)
+            in_mask = (bed <= low_bed)
             # Do not let flood fill reach further than high_dist_bed into
             # the ice sheet interior.
             in_mask[np.logical_and(
-                       thk>0, dist_to_grounding_line >= high_dist_bed)] = 0
+                       thk > 0, dist_to_grounding_line >= high_dist_bed)] = 0
             low_bed_mask = gridded_flood_fill(in_mask,
                                               iStart=flood_fill_iStart,
                                               jStart=flood_fill_jStart)
@@ -210,6 +210,16 @@ def set_cell_width(self, section, thk, bed=None, vx=None, vy=None,
         spacing_bed[dist_to_grounding_line >= high_dist_bed] = max_spac
         if flood_fill_iStart is not None and flood_fill_jStart is not None:
             spacing_bed[low_bed_mask == 0] = max_spac
+            # Do one more flood fill to eliminate isolated pockets
+            # of high resolution that were separated when we set
+            # spacing_bed[dist_to_grounding_line >= high_dist_bed] = max_spac
+            in_mask2 = (bed <= low_bed)
+            in_mask2[np.logical_and(
+                       thk > 0, spacing_bed > min_spac)] = 0
+            low_bed_mask2 = gridded_flood_fill(in_mask2,
+                                              iStart=flood_fill_iStart,
+                                              jStart=flood_fill_jStart)
+            spacing_bed[low_bed_mask2 == 0] = max_spac
     else:
         spacing_bed = max_spac * np.ones_like(thk)
 

--- a/compass/landice/mesh.py
+++ b/compass/landice/mesh.py
@@ -177,14 +177,15 @@ def set_cell_width(self, section, thk, bed=None, vx=None, vy=None,
         # We only want bed topography to influence spacing within high_dist_bed
         # from the ice margin. In the region between high_dist_bed and low_dist_bed,
         # use a linear ramp to damp influence of bed topo.
-        spacing_bed[dist_to_edge >= low_dist_bed] = (
-                ( 1.0 - (dist_to_edge[dist_to_edge >= low_dist_bed] 
-                  - low_dist_bed) / (high_dist_bed - low_dist_bed) ) *
-                spacing_bed[dist_to_edge >= low_dist_bed] +
-                (dist_to_edge[dist_to_edge >= low_dist_bed] - low_dist_bed) /
-                (high_dist_bed - low_dist_bed) * max_spac )
-        spacing_bed[dist_to_edge >= high_dist_bed] = max_spac
-        logger.info(np.min(spacing_bed))
+        spacing_bed[dist_to_grounding_line >= low_dist_bed] = (
+            ( 1.0 - (dist_to_grounding_line[
+             dist_to_grounding_line >= low_dist_bed] 
+             - low_dist_bed) / (high_dist_bed - low_dist_bed) ) *
+            spacing_bed[dist_to_grounding_line >= low_dist_bed] +
+            (dist_to_grounding_line[dist_to_grounding_line >= 
+             low_dist_bed] - low_dist_bed) /
+            (high_dist_bed - low_dist_bed) * max_spac )
+        spacing_bed[dist_to_grounding_line >= high_dist_bed] = max_spac
     else:
         spacing_bed = max_spac * np.ones_like(thk)
                                                                                          

--- a/compass/landice/mesh.py
+++ b/compass/landice/mesh.py
@@ -1,6 +1,7 @@
-import numpy as np
-import jigsawpy
 import time
+
+import jigsawpy
+import numpy as np
 
 
 def gridded_flood_fill(field, iStart=None, jStart=None):
@@ -16,6 +17,12 @@ def gridded_flood_fill(field, iStart=None, jStart=None):
     field : numpy.ndarray
         Array from gridded dataset to use for flood-fill.
         Usually ice thickness.
+    iStart : int
+        x index from which to start flood fill for field.
+        Defaults to the center x coordinate.
+    jStart : int
+        y index from which to start flood fill.
+        Defaults to the center y coordinate.
 
     Returns
     -------
@@ -174,7 +181,7 @@ def set_cell_width(self, section, thk, bed=None, vx=None, vy=None,
     # convert km to m
     cull_distance = float(section.get('cull_distance')) * 1.e3
 
-    # Cell spacking function based on union of masks
+    # Cell spacing function based on union of masks
     if section.get('use_bed') == 'True':
         logger.info('Using bed elevation for spacing.')
         if flood_fill_iStart is not None and flood_fill_jStart is not None:
@@ -201,10 +208,10 @@ def set_cell_width(self, section, thk, bed=None, vx=None, vy=None,
         # low_dist_bed, use a linear ramp to damp influence of bed topo.
         spacing_bed[dist_to_grounding_line >= low_dist_bed] = (
             ( 1.0 - (dist_to_grounding_line[
-             dist_to_grounding_line >= low_dist_bed] 
+             dist_to_grounding_line >= low_dist_bed]
              - low_dist_bed) / (high_dist_bed - low_dist_bed) ) *
             spacing_bed[dist_to_grounding_line >= low_dist_bed] +
-            (dist_to_grounding_line[dist_to_grounding_line >= 
+            (dist_to_grounding_line[dist_to_grounding_line >=
              low_dist_bed] - low_dist_bed) /
             (high_dist_bed - low_dist_bed) * max_spac )
         spacing_bed[dist_to_grounding_line >= high_dist_bed] = max_spac
@@ -217,8 +224,8 @@ def set_cell_width(self, section, thk, bed=None, vx=None, vy=None,
             in_mask2[np.logical_and(
                        thk > 0, spacing_bed > (2. * min_spac))] = 0
             low_bed_mask2 = gridded_flood_fill(in_mask2,
-                                              iStart=flood_fill_iStart,
-                                              jStart=flood_fill_jStart)
+                                               iStart=flood_fill_iStart,
+                                               jStart=flood_fill_jStart)
             spacing_bed[low_bed_mask2 == 0] = max_spac
     else:
         spacing_bed = max_spac * np.ones_like(thk)
@@ -229,8 +236,8 @@ def set_cell_width(self, section, thk, bed=None, vx=None, vy=None,
         speed = (vx ** 2 + vy ** 2) ** 0.5
         lspd = np.log10(speed)
         spacing_speed = np.interp(lspd, [low_log_speed, high_log_speed],
-                            [max_spac, min_spac], left=max_spac,
-                            right=min_spac)
+                                  [max_spac, min_spac], left=max_spac,
+                                  right=min_spac)
 
         # Clean up where we have missing velocities. These are usually nans
         # or the default netCDF _FillValue of ~10.e36
@@ -302,6 +309,8 @@ def get_dist_to_edge_and_GL(self, thk, topg, x, y, section, window_size=None):
         x coordinates from gridded dataset
     y : numpy.ndarray
         y coordinates from gridded dataset
+    section : str
+        section of config file used to define mesh parameters
     window_size : int or float
         Size (in meters) of a search 'box' (one-directional) to use
         to calculate the distance from each cell to the ice margin.

--- a/compass/landice/tests/greenland/high_res_mesh/high_res_mesh.cfg
+++ b/compass/landice/tests/greenland/high_res_mesh/high_res_mesh.cfg
@@ -25,7 +25,7 @@ low_dist = 1.e4
 # distance at which bed topography has no effect
 high_dist_bed = 1.e5
 # distance within which bed topography has maximum effect
-low_dist_bed = 5.e4
+low_dist_bed = 7.5e4
 # Bed elev beneath which cell spacing is minimized
 low_bed = 50.0
 # Bed elev above which cell spacing is minimized

--- a/compass/landice/tests/greenland/high_res_mesh/high_res_mesh.cfg
+++ b/compass/landice/tests/greenland/high_res_mesh/high_res_mesh.cfg
@@ -28,7 +28,7 @@ high_dist_bed = 1.e5
 low_dist_bed = 7.5e4
 # Bed elev beneath which cell spacing is minimized
 low_bed = 50.0
-# Bed elev above which cell spacing is minimized
+# Bed elev above which cell spacing is maximized
 high_bed = 100.0
 
 # mesh density functions

--- a/compass/landice/tests/greenland/high_res_mesh/high_res_mesh.cfg
+++ b/compass/landice/tests/greenland/high_res_mesh/high_res_mesh.cfg
@@ -21,9 +21,18 @@ low_log_speed = 0.75
 # distance at which cell spacing = max_spac
 high_dist = 1.e5
 # distance within which cell spacing = min_spac
-low_dist = 5.e4
+low_dist = 1.e4
+# distance at which bed topography has no effect
+high_dist_bed = 1.e5
+# distance within which bed topography has maximum effect
+low_dist_bed = 5.e4
+# Bed elev beneath which cell spacing is minimized
+low_bed = 50.0
+# Bed elev above which cell spacing is minimized
+high_bed = 100.0
 
 # mesh density functions
 use_speed = True
 use_dist_to_grounding_line = False
 use_dist_to_edge = True
+use_bed = True

--- a/compass/landice/tests/greenland/mesh.py
+++ b/compass/landice/tests/greenland/mesh.py
@@ -173,8 +173,8 @@ class Mesh(Step):
 
         # Calculate distance from each grid point to ice edge
         # and grounding line, for use in cell spacing functions.
-        distToEdge, distToGL = get_dist_to_edge_and_GL(self, thk, topg, x1,
-                                                       y1, window_size=1.e5)
+        distToEdge, distToGL = get_dist_to_edge_and_GL(
+                self, thk, topg, x1, y1, section='high_res_GIS_mesh')
         # optional - plot distance calculation
         # plt.pcolor(distToEdge/1000.0); plt.colorbar(); plt.show()
 

--- a/compass/landice/tests/greenland/mesh.py
+++ b/compass/landice/tests/greenland/mesh.py
@@ -1,19 +1,19 @@
-import numpy as np
 import netCDF4
+import numpy as np
 import xarray
-from matplotlib import pyplot as plt
-
-from mpas_tools.mesh.creation import build_planar_mesh
-from mpas_tools.mesh.conversion import convert, cull
-from mpas_tools.planar_hex import make_planar_hex_mesh
 from mpas_tools.io import write_netcdf
 from mpas_tools.logging import check_call
+from mpas_tools.mesh.conversion import convert, cull
+from mpas_tools.mesh.creation import build_planar_mesh
 
-from compass.step import Step
+from compass.landice.mesh import (
+    get_dist_to_edge_and_GL,
+    gridded_flood_fill,
+    set_cell_width,
+    set_rectangular_geom_points_and_edges,
+)
 from compass.model import make_graph_file
-from compass.landice.mesh import gridded_flood_fill, \
-                                 set_rectangular_geom_points_and_edges, \
-                                 set_cell_width, get_dist_to_edge_and_GL
+from compass.step import Step
 
 
 class Mesh(Step):
@@ -42,9 +42,9 @@ class Mesh(Step):
         self.add_output_file(filename='graph.info')
         self.add_output_file(filename='GIS.nc')
         self.add_input_file(
-                filename='greenland_1km_2020_04_20.epsg3413.icesheetonly.nc',
-                target='greenland_1km_2020_04_20.epsg3413.icesheetonly.nc',
-                database='')
+            filename='greenland_1km_2020_04_20.epsg3413.icesheetonly.nc',
+            target='greenland_1km_2020_04_20.epsg3413.icesheetonly.nc',
+            database='')
         self.add_input_file(filename='greenland_2km_2020_04_20.epsg3413.nc',
                             target='greenland_2km_2020_04_20.epsg3413.nc',
                             database='')
@@ -163,7 +163,7 @@ class Mesh(Step):
         yy0 = np.min(y1)
         yy1 = np.max(y1)
         geom_points, geom_edges = set_rectangular_geom_points_and_edges(
-                                                           xx0, xx1, yy0, yy1)
+            xx0, xx1, yy0, yy1)
 
         # Remove ice not connected to the ice sheet.
         floodMask = gridded_flood_fill(thk)
@@ -174,7 +174,7 @@ class Mesh(Step):
         # Calculate distance from each grid point to ice edge
         # and grounding line, for use in cell spacing functions.
         distToEdge, distToGL = get_dist_to_edge_and_GL(
-                self, thk, topg, x1, y1, section='high_res_GIS_mesh')
+            self, thk, topg, x1, y1, section='high_res_GIS_mesh')
         # optional - plot distance calculation
         # plt.pcolor(distToEdge/1000.0); plt.colorbar(); plt.show()
 

--- a/compass/landice/tests/greenland/mesh.py
+++ b/compass/landice/tests/greenland/mesh.py
@@ -180,7 +180,8 @@ class Mesh(Step):
 
         # Set cell widths based on mesh parameters set in config file
         cell_width = set_cell_width(self, section='high_res_GIS_mesh', thk=thk,
-                                    vx=vx, vy=vy, dist_to_edge=distToEdge,
+                                    bed=topg, vx=vx, vy=vy,
+                                    dist_to_edge=distToEdge,
                                     dist_to_grounding_line=None)
         # plt.pcolor(cell_width); plt.colorbar(); plt.show()
 

--- a/compass/landice/tests/greenland/mesh.py
+++ b/compass/landice/tests/greenland/mesh.py
@@ -178,8 +178,12 @@ class Mesh(Step):
         # optional - plot distance calculation
         # plt.pcolor(distToEdge/1000.0); plt.colorbar(); plt.show()
 
-        # Set cell widths based on mesh parameters set in config file
-        # Start flood-fill for bed topography at point off central west coast
+        # Set cell widths based on mesh parameters set in config file.
+        # Start flood-fill for bed topography in the ocean at a point
+        # with bed < low_bed. This is often necessary to remove pockets
+        # of high resolution that are no longer connected to the rest of
+        # the high resolution part of the mesh. These indices are specific
+        # to the mesh and the gridded data product used to set cell spacing.
         cell_width = set_cell_width(self, section='high_res_GIS_mesh', thk=thk,
                                     bed=topg, vx=vx, vy=vy,
                                     dist_to_edge=distToEdge,

--- a/compass/landice/tests/greenland/mesh.py
+++ b/compass/landice/tests/greenland/mesh.py
@@ -45,8 +45,8 @@ class Mesh(Step):
                 filename='greenland_1km_2020_04_20.epsg3413.icesheetonly.nc',
                 target='greenland_1km_2020_04_20.epsg3413.icesheetonly.nc',
                 database='')
-        self.add_input_file(filename='greenland_8km_2020_04_20.epsg3413.nc',
-                            target='greenland_8km_2020_04_20.epsg3413.nc',
+        self.add_input_file(filename='greenland_2km_2020_04_20.epsg3413.nc',
+                            target='greenland_2km_2020_04_20.epsg3413.nc',
                             database='')
 
     # no setup() method is needed
@@ -90,7 +90,7 @@ class Mesh(Step):
         cullDistance = section.get('cull_distance')
         logger.info('calling define_cullMask.py')
         args = ['define_cullMask.py', '-f',
-                'gis_1km_preCull.nc', '-m'
+                'gis_1km_preCull.nc', '-m',
                 'distance', '-d', cullDistance]
 
         check_call(args, logger=logger)
@@ -146,7 +146,7 @@ class Mesh(Step):
         speed and distance to the ice margin.
         """
         # get needed fields from GIS dataset
-        f = netCDF4.Dataset('greenland_8km_2020_04_20.epsg3413.nc', 'r')
+        f = netCDF4.Dataset('greenland_2km_2020_04_20.epsg3413.nc', 'r')
         f.set_auto_mask(False)  # disable masked arrays
 
         x1 = f.variables['x1'][:]
@@ -179,10 +179,13 @@ class Mesh(Step):
         # plt.pcolor(distToEdge/1000.0); plt.colorbar(); plt.show()
 
         # Set cell widths based on mesh parameters set in config file
+        # Start flood-fill for bed topography at point off central west coast
         cell_width = set_cell_width(self, section='high_res_GIS_mesh', thk=thk,
                                     bed=topg, vx=vx, vy=vy,
                                     dist_to_edge=distToEdge,
-                                    dist_to_grounding_line=distToGL)
+                                    dist_to_grounding_line=distToGL,
+                                    flood_fill_iStart=100,
+                                    flood_fill_jStart=700)
         # plt.pcolor(cell_width); plt.colorbar(); plt.show()
 
         return (cell_width.astype('float64'), x1.astype('float64'),

--- a/compass/landice/tests/greenland/mesh.py
+++ b/compass/landice/tests/greenland/mesh.py
@@ -182,7 +182,7 @@ class Mesh(Step):
         cell_width = set_cell_width(self, section='high_res_GIS_mesh', thk=thk,
                                     bed=topg, vx=vx, vy=vy,
                                     dist_to_edge=distToEdge,
-                                    dist_to_grounding_line=None)
+                                    dist_to_grounding_line=distToGL)
         # plt.pcolor(cell_width); plt.colorbar(); plt.show()
 
         return (cell_width.astype('float64'), x1.astype('float64'),

--- a/compass/landice/tests/humboldt/humboldt.cfg
+++ b/compass/landice/tests/humboldt/humboldt.cfg
@@ -28,7 +28,7 @@ high_dist_bed = 1.e5
 low_dist_bed = 5.e4
 # Bed elev beneath which cell spacing is minimized
 low_bed = 50.0
-# Bed elev above which cell spacing is minimized
+# Bed elev above which cell spacing is maximized
 high_bed = 100.0
 
 # mesh density functions

--- a/compass/landice/tests/humboldt/humboldt.cfg
+++ b/compass/landice/tests/humboldt/humboldt.cfg
@@ -22,8 +22,17 @@ low_log_speed = 0.75
 high_dist = 1.e5
 # distance within which cell spacing = min_spac (meters)
 low_dist = 1.e4
+# distance at which bed topography has no effect
+high_dist_bed = 1.e5
+# distance within which bed topography has maximum effect
+low_dist_bed = 5.e4
+# Bed elev beneath which cell spacing is minimized
+low_bed = 0.0
+# Bed elev above which cell spacing is minimized
+high_bed = 1.e5
 
 # mesh density functions
 use_speed = True
 use_dist_to_grounding_line = False
 use_dist_to_edge = True
+use_bed = True

--- a/compass/landice/tests/humboldt/humboldt.cfg
+++ b/compass/landice/tests/humboldt/humboldt.cfg
@@ -27,9 +27,9 @@ high_dist_bed = 1.e5
 # distance within which bed topography has maximum effect
 low_dist_bed = 5.e4
 # Bed elev beneath which cell spacing is minimized
-low_bed = 0.0
+low_bed = 50.0
 # Bed elev above which cell spacing is minimized
-high_bed = 1.e5
+high_bed = 100.0
 
 # mesh density functions
 use_speed = True

--- a/compass/landice/tests/humboldt/mesh.py
+++ b/compass/landice/tests/humboldt/mesh.py
@@ -1,19 +1,18 @@
-import numpy as np
 import netCDF4
 import xarray
-from matplotlib import pyplot as plt
-
-from mpas_tools.mesh.creation import build_planar_mesh
-from mpas_tools.mesh.conversion import convert, cull
-from mpas_tools.planar_hex import make_planar_hex_mesh
 from mpas_tools.io import write_netcdf
 from mpas_tools.logging import check_call
+from mpas_tools.mesh.conversion import convert, cull
+from mpas_tools.mesh.creation import build_planar_mesh
 
-from compass.step import Step
+from compass.landice.mesh import (
+    get_dist_to_edge_and_GL,
+    gridded_flood_fill,
+    set_cell_width,
+    set_rectangular_geom_points_and_edges,
+)
 from compass.model import make_graph_file
-from compass.landice.mesh import gridded_flood_fill, \
-                                 set_rectangular_geom_points_and_edges, \
-                                 set_cell_width, get_dist_to_edge_and_GL
+from compass.step import Step
 
 
 class Mesh(Step):
@@ -42,9 +41,9 @@ class Mesh(Step):
         self.add_output_file(filename='graph.info')
         self.add_output_file(filename='Humboldt_1to10km.nc')
         self.add_input_file(
-                filename='humboldt_1km_2020_04_20.epsg3413.icesheetonly.nc',
-                target='humboldt_1km_2020_04_20.epsg3413.icesheetonly.nc',
-                database='')
+            filename='humboldt_1km_2020_04_20.epsg3413.icesheetonly.nc',
+            target='humboldt_1km_2020_04_20.epsg3413.icesheetonly.nc',
+            database='')
         self.add_input_file(filename='Humboldt.geojson',
                             package='compass.landice.tests.humboldt',
                             target='Humboldt.geojson',
@@ -196,7 +195,7 @@ class Mesh(Step):
         yy0 = -1560000
         yy1 = -860000
         geom_points, geom_edges = set_rectangular_geom_points_and_edges(
-                                                           xx0, xx1, yy0, yy1)
+            xx0, xx1, yy0, yy1)
 
         # Remove ice not connected to the ice sheet.
         floodMask = gridded_flood_fill(thk)
@@ -207,8 +206,8 @@ class Mesh(Step):
         # Calculate distance from each grid point to ice edge
         # and grounding line, for use in cell spacing functions.
         distToEdge, distToGL = get_dist_to_edge_and_GL(
-                                            self, thk, topg, x1,
-                                            y1, section='humboldt_mesh')
+            self, thk, topg, x1,
+            y1, section='humboldt_mesh')
         # optional - plot distance calculation
         # plt.pcolor(distToEdge/1000.0); plt.colorbar(); plt.show()
 

--- a/compass/landice/tests/humboldt/mesh.py
+++ b/compass/landice/tests/humboldt/mesh.py
@@ -206,8 +206,9 @@ class Mesh(Step):
 
         # Calculate distance from each grid point to ice edge
         # and grounding line, for use in cell spacing functions.
-        distToEdge, distToGL = get_dist_to_edge_and_GL(self, thk, topg, x1,
-                                                       y1, window_size=1.e5)
+        distToEdge, distToGL = get_dist_to_edge_and_GL(
+                                            self, thk, topg, x1,
+                                            y1, section='humboldt_mesh')
         # optional - plot distance calculation
         # plt.pcolor(distToEdge/1000.0); plt.colorbar(); plt.show()
 

--- a/compass/landice/tests/humboldt/mesh.py
+++ b/compass/landice/tests/humboldt/mesh.py
@@ -49,8 +49,8 @@ class Mesh(Step):
                             package='compass.landice.tests.humboldt',
                             target='Humboldt.geojson',
                             database=None)
-        self.add_input_file(filename='greenland_8km_2020_04_20.epsg3413.nc',
-                            target='greenland_8km_2020_04_20.epsg3413.nc',
+        self.add_input_file(filename='greenland_2km_2020_04_20.epsg3413.nc',
+                            target='greenland_2km_2020_04_20.epsg3413.nc',
                             database='')
 
     # no setup() method is needed
@@ -179,7 +179,7 @@ class Mesh(Step):
         functions to be reusable by multiple test groups.
         """
         # get needed fields from GIS dataset
-        f = netCDF4.Dataset('greenland_8km_2020_04_20.epsg3413.nc', 'r')
+        f = netCDF4.Dataset('greenland_2km_2020_04_20.epsg3413.nc', 'r')
         f.set_auto_mask(False)  # disable masked arrays
 
         x1 = f.variables['x1'][:]

--- a/compass/landice/tests/humboldt/mesh.py
+++ b/compass/landice/tests/humboldt/mesh.py
@@ -151,7 +151,7 @@ class Mesh(Step):
         logger.info('calling interpolate_to_mpasli_grid.py')
         args = ['interpolate_to_mpasli_grid.py', '-s',
                 'humboldt_1km_2020_04_20.epsg3413.icesheetonly.nc',
-                '-d', 'Humboldt_1to10km.nc', '-m', 'b', '-t']
+                '-d', 'Humboldt_1to10km.nc', '-m', 'b']
         check_call(args, logger=logger)
 
         logger.info('Marking domain boundaries dirichlet')

--- a/compass/landice/tests/humboldt/mesh.py
+++ b/compass/landice/tests/humboldt/mesh.py
@@ -215,7 +215,7 @@ class Mesh(Step):
         cell_width = set_cell_width(self, section='humboldt_mesh',
                                     thk=thk, bed=topg, vx=vx, vy=vy,
                                     dist_to_edge=distToEdge,
-                                    dist_to_grounding_line=None)
+                                    dist_to_grounding_line=distToGL)
         # plt.pcolor(cell_width); plt.colorbar(); plt.show()
         return (cell_width.astype('float64'), x1.astype('float64'),
                 y1.astype('float64'), geom_points, geom_edges)

--- a/compass/landice/tests/humboldt/mesh.py
+++ b/compass/landice/tests/humboldt/mesh.py
@@ -212,7 +212,7 @@ class Mesh(Step):
         # plt.pcolor(distToEdge/1000.0); plt.colorbar(); plt.show()
 
         # Set cell widths based on mesh parameters set in config file
-        cell_width = set_cell_width(self, section='humboldt_mesh', x=x1, y=y1,
+        cell_width = set_cell_width(self, section='humboldt_mesh',
                                     thk=thk, bed=topg, vx=vx, vy=vy,
                                     dist_to_edge=distToEdge,
                                     dist_to_grounding_line=None)

--- a/compass/landice/tests/humboldt/mesh.py
+++ b/compass/landice/tests/humboldt/mesh.py
@@ -212,10 +212,10 @@ class Mesh(Step):
         # plt.pcolor(distToEdge/1000.0); plt.colorbar(); plt.show()
 
         # Set cell widths based on mesh parameters set in config file
-        cell_width = set_cell_width(self, section='humboldt_mesh', thk=thk,
-                                    vx=vx, vy=vy, dist_to_edge=distToEdge,
+        cell_width = set_cell_width(self, section='humboldt_mesh', x=x1, y=y1,
+                                    thk=thk, bed=topg, vx=vx, vy=vy,
+                                    dist_to_edge=distToEdge,
                                     dist_to_grounding_line=None)
         # plt.pcolor(cell_width); plt.colorbar(); plt.show()
-
         return (cell_width.astype('float64'), x1.astype('float64'),
                 y1.astype('float64'), geom_points, geom_edges)

--- a/compass/landice/tests/kangerlussuaq/mesh.py
+++ b/compass/landice/tests/kangerlussuaq/mesh.py
@@ -210,7 +210,7 @@ class Mesh(Step):
                                     section='high_res_Kangerlussuaq_mesh',
                                     thk=thk, bed=topg, vx=vx, vy=vy,
                                     dist_to_edge=distToEdge,
-                                    dist_to_grounding_line=None)
+                                    dist_to_grounding_line=distToGL)
         # plt.pcolor(cell_width); plt.colorbar(); plt.show()
 
         return (cell_width.astype('float64'), x1.astype('float64'),

--- a/compass/landice/tests/kangerlussuaq/mesh.py
+++ b/compass/landice/tests/kangerlussuaq/mesh.py
@@ -147,7 +147,7 @@ class Mesh(Step):
         logger.info('calling interpolate_to_mpasli_grid.py')
         args = ['interpolate_to_mpasli_grid.py', '-s',
                 'greenland_1km_2020_04_20.epsg3413.icesheetonly.nc',
-                '-d', 'Kangerlussuaq.nc', '-m', 'b', '-t']
+                '-d', 'Kangerlussuaq.nc', '-m', 'b']
         check_call(args, logger=logger)
 
         logger.info('Marking domain boundaries dirichlet')
@@ -208,7 +208,7 @@ class Mesh(Step):
         # Set cell widths based on mesh parameters set in config file
         cell_width = set_cell_width(self,
                                     section='high_res_Kangerlussuaq_mesh',
-                                    thk=thk, vx=vx, vy=vy,
+                                    thk=thk, bed=topg, vx=vx, vy=vy,
                                     dist_to_edge=distToEdge,
                                     dist_to_grounding_line=None)
         # plt.pcolor(cell_width); plt.colorbar(); plt.show()

--- a/compass/landice/tests/kangerlussuaq/mesh.py
+++ b/compass/landice/tests/kangerlussuaq/mesh.py
@@ -1,19 +1,18 @@
-import numpy as np
 import netCDF4
 import xarray
-from matplotlib import pyplot as plt
-
-from mpas_tools.mesh.creation import build_planar_mesh
-from mpas_tools.mesh.conversion import convert, cull
-from mpas_tools.planar_hex import make_planar_hex_mesh
 from mpas_tools.io import write_netcdf
 from mpas_tools.logging import check_call
+from mpas_tools.mesh.conversion import convert, cull
+from mpas_tools.mesh.creation import build_planar_mesh
 
-from compass.step import Step
+from compass.landice.mesh import (
+    get_dist_to_edge_and_GL,
+    gridded_flood_fill,
+    set_cell_width,
+    set_rectangular_geom_points_and_edges,
+)
 from compass.model import make_graph_file
-from compass.landice.mesh import gridded_flood_fill, \
-                                 set_rectangular_geom_points_and_edges, \
-                                 set_cell_width, get_dist_to_edge_and_GL
+from compass.step import Step
 
 
 class Mesh(Step):
@@ -43,9 +42,9 @@ class Mesh(Step):
         self.add_output_file(filename='graph.info')
         self.add_output_file(filename='Kangerlussuaq.nc')
         self.add_input_file(
-                filename='greenland_1km_2020_04_20.epsg3413.icesheetonly.nc',
-                target='greenland_1km_2020_04_20.epsg3413.icesheetonly.nc',
-                database='')
+            filename='greenland_1km_2020_04_20.epsg3413.icesheetonly.nc',
+            target='greenland_1km_2020_04_20.epsg3413.icesheetonly.nc',
+            database='')
         self.add_input_file(filename='Kangerlussuaq.geojson',
                             package='compass.landice.tests.kangerlussuaq',
                             target='Kangerlussuaq.geojson',
@@ -190,7 +189,7 @@ class Mesh(Step):
         yy0 = -2370000
         yy1 = -2070000
         geom_points, geom_edges = set_rectangular_geom_points_and_edges(
-                                                           xx0, xx1, yy0, yy1)
+            xx0, xx1, yy0, yy1)
 
         # Remove ice not connected to the ice sheet.
         floodMask = gridded_flood_fill(thk)
@@ -201,8 +200,8 @@ class Mesh(Step):
         # Calculate distance from each grid point to ice edge
         # and grounding line, for use in cell spacing functions.
         distToEdge, distToGL = get_dist_to_edge_and_GL(
-                                self, thk, topg, x1,
-                                y1, section='high_res_Kangerlussuaq_mesh')
+            self, thk, topg, x1,
+            y1, section='high_res_Kangerlussuaq_mesh')
         # optional - plot distance calculation
         # plt.pcolor(distToEdge/1000.0); plt.colorbar(); plt.show()
 

--- a/compass/landice/tests/kangerlussuaq/mesh.py
+++ b/compass/landice/tests/kangerlussuaq/mesh.py
@@ -200,8 +200,9 @@ class Mesh(Step):
 
         # Calculate distance from each grid point to ice edge
         # and grounding line, for use in cell spacing functions.
-        distToEdge, distToGL = get_dist_to_edge_and_GL(self, thk, topg, x1,
-                                                       y1, window_size=1.e5)
+        distToEdge, distToGL = get_dist_to_edge_and_GL(
+                                self, thk, topg, x1,
+                                y1, section='high_res_Kangerlussuaq_mesh')
         # optional - plot distance calculation
         # plt.pcolor(distToEdge/1000.0); plt.colorbar(); plt.show()
 

--- a/compass/landice/tests/kangerlussuaq/mesh_gen/mesh_gen.cfg
+++ b/compass/landice/tests/kangerlussuaq/mesh_gen/mesh_gen.cfg
@@ -28,7 +28,7 @@ high_dist_bed = 1.e5
 low_dist_bed = 5.e4
 # Bed elev beneath which cell spacing is minimized
 low_bed = 50.0
-# Bed elev above which cell spacing is minimized
+# Bed elev above which cell spacing is maximized
 high_bed = 100.0
 
 # mesh density functions

--- a/compass/landice/tests/kangerlussuaq/mesh_gen/mesh_gen.cfg
+++ b/compass/landice/tests/kangerlussuaq/mesh_gen/mesh_gen.cfg
@@ -22,8 +22,17 @@ low_log_speed = 0.75
 high_dist = 1.e5
 # distance within which cell spacing = min_spac (meters)
 low_dist = 1.e4
+# distance at which bed topography has no effect
+high_dist_bed = 1.e5
+# distance within which bed topography has maximum effect
+low_dist_bed = 5.e4
+# Bed elev beneath which cell spacing is minimized
+low_bed = 50.0
+# Bed elev above which cell spacing is minimized
+high_bed = 100.0
 
 # mesh density functions
 use_speed = True
 use_dist_to_grounding_line = False
 use_dist_to_edge = True
+use_bed = True


### PR DESCRIPTION
Add the option to include bed topography in the cell spacing function. This allows for high resolution for areas into which the grounding line may retreat, even if they are not fast-flowing or close to the margin. The user sets config options for what should be considered low and high bed topography, as well as the distance from the grounding line within which the bed topography should have an influence on cell spacing. Included in this PR are updates to the `greenland`, `humboldt`, and `kangerlussuaq` mesh generation test cases, which now use bed topography to determine cell spacing.

The cell spacing function for bed topography uses a logistics function to smoothly transition between high and low resolution over areas of low and high bed topography. That cell spacing is then modified with a linear function of distance to the grounding line between the user-defined distances `low_dist_bed` and `high_dist_bed`. There is also a flood-fill to ensure that areas with dense cell spacing due to low bed topography are indeed connected to the ocean and thus viable regions for a future grounding-line position.