### PR TITLE
Bugfix for dam break tests

### DIFF
--- a/compass/ocean/tests/dam_break/default/__init__.py
+++ b/compass/ocean/tests/dam_break/default/__init__.py
@@ -3,6 +3,7 @@ from compass.testcase import TestCase
 from compass.ocean.tests.dam_break.initial_state import InitialState
 from compass.ocean.tests.dam_break.forward import Forward
 from compass.ocean.tests.dam_break.viz import Viz
+from compass.validate import compare_variables
 
 
 class Default(TestCase):
@@ -67,3 +68,11 @@ class Default(TestCase):
                    'mesh cells in the y direction')
         config.set('dam_break', 'dc', f'{dc}', comment='the distance '
                    'between adjacent cell centers')
+
+    def validate(self):
+        """
+        Validate variables against a baseline
+        """
+        variables = ['layerThickness', 'normalVelocity', 'ssh']
+        compare_variables(test_case=self, variables=variables,
+                          filename1=f'forward/output.nc')

--- a/compass/ocean/tests/dam_break/namelist.forward
+++ b/compass/ocean/tests/dam_break/namelist.forward
@@ -12,3 +12,4 @@ config_zero_drying_velocity=.true.
 config_drying_min_cell_height=1e-6
 config_thickness_flux_type='upwind'
 config_vert_coord_movement='impermeable_interfaces'
+config_disable_tr_all_tend = .true.

--- a/compass/ocean/tests/dam_break/streams.init
+++ b/compass/ocean/tests/dam_break/streams.init
@@ -10,6 +10,7 @@
         filename_template="ocean.nc">
 
     <stream name="input_init"/>
+    <var_struct name="tracers"/>
     <var name="bottomDepth"/>
     <var name="refZMid"/>
     <var name="refBottomDepth"/>


### PR DESCRIPTION
In order to avoid crashes of the dam break test case, tracers need to be initialized  (currently handled in init mode and fixed here https://github.com/E3SM-Ocean-Discussion/E3SM/pull/33), and those tracers also need to be stored in the initial state stream (fixed here). 

Related changes also included here are (1) adding the validation step to the test case and (2) disabling tracer tendencies, which are not needed in this test case.