### PR TITLE
Add error message for namelist replacements

### DIFF
--- a/compass/namelist.py
+++ b/compass/namelist.py
@@ -51,10 +51,16 @@ def ingest(defaults_filename):
 def replace(namelist, replacements):
     """ Replace entries in the namelist using the replacements dict """
     new = dict(namelist)
+    is_not_replaced = [True for key in replacements.keys()]
     for record in new:
-        for key in replacements:
+        for idx, key in enumerate(replacements):
             if key in new[record]:
                 new[record][key] = replacements[key]
+                is_not_replaced[idx] = False
+    for idx, key in enumerate(replacements):
+        if is_not_replaced[idx]:
+            print(f'Warning: {key} is not in the namelist and replacements '
+                  'will not be used')
 
     return new
 


### PR DESCRIPTION
Prior to this commit, if namelist options specified in test cases are out of date with the registry, the user is not warned. This PR adds a warning which is printed at the setup stage.