### PR TITLE
Add SO12to60E2r5 (without ice-shelf cavities)

### DIFF
--- a/compass/mesh/mesh.cfg
+++ b/compass/mesh/mesh.cfg
@@ -17,7 +17,7 @@ mpas_mesh_filename = base_mesh.nc
 plot_cell_width = True
 cell_width_filename = cellWidthVsLatLon.nc
 cell_width_image_filename = cellWidthGlobal.png
-cell_width_colormap = '3Wbgy5'
+cell_width_colormap = 3Wbgy5
 
 # whether to add the mesh density to the file
 add_mesh_density = False

--- a/compass/mesh/spherical.py
+++ b/compass/mesh/spherical.py
@@ -72,7 +72,7 @@ class SphericalBaseStep(Step):
         cell_width_filename = section.get('cell_width_filename')
         da.to_netcdf(cell_width_filename)
 
-        if section.getboolean('plot_cell_widths'):
+        if section.getboolean('plot_cell_width'):
             self._plot_cell_width(cell_width)
 
     def setup(self):

--- a/compass/ocean/tests/global_ocean/__init__.py
+++ b/compass/ocean/tests/global_ocean/__init__.py
@@ -180,8 +180,8 @@ class GlobalOcean(TestGroup):
                     test_group=self, mesh=mesh, init=init,
                     dynamic_adjustment=dynamic_adjustment))
 
-        # SOwISC12to60: just the version with cavities for now
-        for mesh_name in ['SOwISC12to60']:
+        # SO12to60: with and without cavities
+        for mesh_name in ['SO12to60', 'SOwISC12to60']:
             mesh = Mesh(test_group=self, mesh_name=mesh_name)
             self.add_test_case(mesh)
 

--- a/compass/ocean/tests/global_ocean/mesh/__init__.py
+++ b/compass/ocean/tests/global_ocean/mesh/__init__.py
@@ -66,7 +66,7 @@ class Mesh(TestCase):
             base_mesh_step = EC30to60BaseMesh(self, name=name, subdir=subdir)
         elif mesh_name in ['ARRM10to60']:
             base_mesh_step = ARRM10to60BaseMesh(self, name=name, subdir=subdir)
-        elif mesh_name in ['SOwISC12to60']:
+        elif mesh_name in ['SO12to60', 'SOwISC12to60']:
             base_mesh_step = SO12to60BaseMesh(self, name=name, subdir=subdir)
         elif mesh_name in ['WC14']:
             base_mesh_step = WC14BaseMesh(self, name=name, subdir=subdir)

--- a/compass/ocean/tests/global_ocean/mesh/so12to60/__init__.py
+++ b/compass/ocean/tests/global_ocean/mesh/so12to60/__init__.py
@@ -11,7 +11,7 @@ from compass.mesh import QuasiUniformSphericalMeshStep
 
 class SO12to60BaseMesh(QuasiUniformSphericalMeshStep):
     """
-    A step for creating SOwISC12to60 meshes
+    A step for creating SO12to60 meshes
     """
     def setup(self):
         """

--- a/compass/ocean/tests/global_ocean/mesh/so12to60/high_res_region.geojson
+++ b/compass/ocean/tests/global_ocean/mesh/so12to60/high_res_region.geojson
@@ -4,7 +4,7 @@
     {
       "type": "Feature",
       "properties": {
-        "name": "SOwISC12to60 high res region",
+        "name": "SO12to60 high res region",
         "component": "ocean",
         "object": "region",
         "author": "Xylar Asay-Davis"

--- a/compass/ocean/tests/global_ocean/mesh/so12to60/so12to60.cfg
+++ b/compass/ocean/tests/global_ocean/mesh/so12to60/so12to60.cfg
@@ -40,13 +40,13 @@ mesh_description = MPAS Southern Ocean regionally refined mesh for E3SM version
 e3sm_version = 2
 # The revision number of the mesh, which should be incremented each time the
 # mesh is revised
-mesh_revision = 4
+mesh_revision = 5
 # the minimum (finest) resolution in the mesh
 min_res = 12
 # the maximum (coarsest) resolution in the mesh, can be the same as min_res
 max_res = 60
 # The URL of the pull request documenting the creation of the mesh
-pull_request = https://github.com/MPAS-Dev/compass/pull/37
+pull_request = https://github.com/MPAS-Dev/compass/pull/460
 
 
 # config options related to initial condition and diagnostics support files
@@ -54,4 +54,4 @@ pull_request = https://github.com/MPAS-Dev/compass/pull/37
 [files_for_e3sm]
 
 # CMIP6 grid resolution
-cmip6_grid_res = 720x1440
+cmip6_grid_res = 180x360

--- a/compass/ocean/tests/global_ocean/mesh/wc14/__init__.py
+++ b/compass/ocean/tests/global_ocean/mesh/wc14/__init__.py
@@ -15,7 +15,7 @@ from compass.mesh import QuasiUniformSphericalMeshStep
 
 class WC14BaseMesh(QuasiUniformSphericalMeshStep):
     """
-    A step for creating SOwISC12to60 meshes
+    A step for creating WC14 mesh
     """
     def setup(self):
         """

--- a/compass/ocean/tests/global_ocean/mesh/wc14/wc14.cfg
+++ b/compass/ocean/tests/global_ocean/mesh/wc14/wc14.cfg
@@ -50,4 +50,4 @@ pull_request = https://github.com/MPAS-Dev/MPAS-Model/pull/628
 [files_for_e3sm]
 
 # CMIP6 grid resolution
-cmip6_grid_res = 720x1440
+cmip6_grid_res = 180x360


### PR DESCRIPTION
This merge also cleans up a doc string and switches the CMIP mesh for both SO12to60 and WC14 to the 1 degree, consistent with conversations with colleagues.