### PR TITLE
Add a recipe for OSU tidal prediction software

### DIFF
--- a/conda/bootstrap.py
+++ b/conda/bootstrap.py
@@ -248,11 +248,7 @@ def build_conda_env(env_type, recreate, machine, mpi, conda_mpi, version,
     if env_type == 'test_release':
         # for a test release, we will be the compass package from the dev label
         channels = channels + ['-c e3sm/label/compass_dev']
-    if (machine is not None and machine.startswith('conda')) \
-            or env_type == 'release':
-        # we need libpnetcdf and scorpio (and maybe compass itself) from the
-        # e3sm channel, compass label
-        channels = channels + ['-c e3sm/label/compass']
+    channels = channels + ['-c e3sm/label/compass']
 
     channels = f'--override-channels {" ".join(channels)}'
     packages = f'python={python}'

--- a/conda/compass_env/spec-file.template
+++ b/conda/compass_env/spec-file.template
@@ -22,6 +22,7 @@ mpas_tools=0.15.0
 nco
 netcdf4=*=nompi_*
 numpy
+otps=2021.10
 progressbar2
 pyamg >=4.2.2
 pyproj

--- a/conda/otps/ci/linux.yaml
+++ b/conda/otps/ci/linux.yaml
@@ -1,0 +1,14 @@
+cdt_name:
+- cos6
+channel_sources:
+- conda-forge
+channel_targets:
+- e3sm compass
+docker_image:
+- quay.io/condaforge/linux-anvil-cos7-x86_64
+fortran_compiler:
+- gfortran
+fortran_compiler_version:
+- '10'
+target_platform:
+- linux-64

--- a/conda/otps/ci/osx.yaml
+++ b/conda/otps/ci/osx.yaml
@@ -1,0 +1,14 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '10.9'
+channel_sources:
+- conda-forge
+channel_targets:
+- e3sm compass
+fortran_compiler:
+- gfortran
+fortran_compiler_version:
+- '11'
+macos_machine:
+- x86_64-apple-darwin13.4.0
+target_platform:
+- osx-64

--- a/conda/otps/recipe/build.sh
+++ b/conda/otps/recipe/build.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+set -e
+
+gdown 1FBlS_Xmf6_dnCg1T0t5GSTRTwMjLuA8N
+tar xvf OTPS.tar.Z
+
+cd OTPS
+
+for exec in extract_HC extract_local_model predict_tide
+do
+  ${FC} ${FCFLAGS} -o ${exec} -fconvert=swap -frecord-marker=4 ${exec}.f90 subs.f90
+  cp ${exec} ${PREFIX}/bin/
+done

--- a/conda/otps/recipe/meta.yaml
+++ b/conda/otps/recipe/meta.yaml
@@ -1,0 +1,35 @@
+{% set version = "2021.10" %}
+{% set build = 0 %}
+
+package:
+  name: otps
+  version: {{ version }}
+
+build:
+  number: 0
+  skip: True  # [win]
+
+requirements:
+  build:
+    - make
+    - {{ compiler('fortran') }}
+  host:
+    - gdown
+    - tar
+
+test:
+  commands:
+    - test -f ${PREFIX}/bin/extract_HC
+    - test -f ${PREFIX}/bin/extract_local_model
+    - test -f ${PREFIX}/bin/predict_tide
+
+about:
+  home: https://www.tpxo.net/otps
+  license: custom
+  license_file: OTPS/COPYRIGHT
+  summary: OSU TIDAL PREDICTION Software (OTPS)
+
+extra:
+  recipe-maintainers:
+    - xylar
+    - sbrus89

--- a/conda/recipe/meta.yaml
+++ b/conda/recipe/meta.yaml
@@ -59,6 +59,7 @@ requirements:
     - nco
     - netcdf4 * nompi_*
     - numpy
+    - otps 2021.10  # [linux]
     - progressbar2
     - pyamg >=4.2.2
     - pyproj


### PR DESCRIPTION
This merge also adds the resulting `otps` conda package as a dependency.

`otps` is needed for #456 