### PR TITLE
Clean up ISOMIP+

### DIFF
--- a/compass/ocean/tests/isomip_plus/__init__.py
+++ b/compass/ocean/tests/isomip_plus/__init__.py
@@ -1,6 +1,6 @@
 from compass.testgroup import TestGroup
 
-from compass.ocean.tests.isomip_plus.ocean_test import OceanTest
+from compass.ocean.tests.isomip_plus.isomip_plus_test import IsomipPlusTest
 
 
 class IsomipPlus(TestGroup):
@@ -18,53 +18,61 @@ class IsomipPlus(TestGroup):
             for experiment in ['Ocean0', 'Ocean1', 'Ocean2']:
                 for vertical_coordinate in ['z-star']:
                     self.add_test_case(
-                        OceanTest(test_group=self, resolution=resolution,
-                                  experiment=experiment,
-                                  vertical_coordinate=vertical_coordinate))
+                        IsomipPlusTest(
+                            test_group=self, resolution=resolution,
+                            experiment=experiment,
+                            vertical_coordinate=vertical_coordinate))
 
             self.add_test_case(
-                OceanTest(test_group=self, resolution=resolution,
-                          experiment='Ocean0',
-                          vertical_coordinate='sigma'))
+                IsomipPlusTest(
+                    test_group=self, resolution=resolution,
+                    experiment='Ocean0',
+                    vertical_coordinate='sigma'))
 
             for experiment in ['Ocean0']:
                 for vertical_coordinate in ['z-star']:
                     self.add_test_case(
-                        OceanTest(test_group=self, resolution=resolution,
-                                  experiment=experiment,
-                                  vertical_coordinate=vertical_coordinate,
-                                  time_varying_forcing=True))
+                        IsomipPlusTest(
+                            test_group=self, resolution=resolution,
+                            experiment=experiment,
+                            vertical_coordinate=vertical_coordinate,
+                            time_varying_forcing=True))
                 for vertical_coordinate in ['z-star', 'sigma', 'single_layer']:
                     self.add_test_case(
-                        OceanTest(test_group=self, resolution=resolution,
-                                  experiment=experiment,
-                                  vertical_coordinate=vertical_coordinate,
-                                  thin_film_present=True))
+                        IsomipPlusTest(
+                            test_group=self, resolution=resolution,
+                            experiment=experiment,
+                            vertical_coordinate=vertical_coordinate,
+                            thin_film_present=True))
                     self.add_test_case(
-                        OceanTest(test_group=self, resolution=resolution,
-                                  experiment=experiment,
-                                  vertical_coordinate=vertical_coordinate,
-                                  time_varying_forcing=True,
-                                  thin_film_present=True))
+                        IsomipPlusTest(
+                            test_group=self, resolution=resolution,
+                            experiment=experiment,
+                            vertical_coordinate=vertical_coordinate,
+                            time_varying_forcing=True,
+                            thin_film_present=True))
                 for vertical_coordinate in ['sigma', 'single_layer']:
                     self.add_test_case(
-                        OceanTest(test_group=self, resolution=resolution,
-                                  experiment=experiment,
-                                  vertical_coordinate=vertical_coordinate,
-                                  time_varying_forcing=True,
-                                  time_varying_load='increasing',
-                                  thin_film_present=True))
+                        IsomipPlusTest(
+                            test_group=self, resolution=resolution,
+                            experiment=experiment,
+                            vertical_coordinate=vertical_coordinate,
+                            time_varying_forcing=True,
+                            time_varying_load='increasing',
+                            thin_film_present=True))
                     self.add_test_case(
-                        OceanTest(test_group=self, resolution=resolution,
-                                  experiment=experiment,
-                                  vertical_coordinate=vertical_coordinate,
-                                  time_varying_forcing=True,
-                                  time_varying_load='decreasing',
-                                  thin_film_present=True))
+                        IsomipPlusTest(
+                            test_group=self, resolution=resolution,
+                            experiment=experiment,
+                            vertical_coordinate=vertical_coordinate,
+                            time_varying_forcing=True,
+                            time_varying_load='decreasing',
+                            thin_film_present=True))
                 for vertical_coordinate in ['single_layer']:
                     self.add_test_case(
-                        OceanTest(test_group=self, resolution=resolution,
-                                  experiment=experiment,
-                                  vertical_coordinate=vertical_coordinate,
-                                  tidal_forcing=True,
-                                  thin_film_present=True))
+                        IsomipPlusTest(
+                            test_group=self, resolution=resolution,
+                            experiment=experiment,
+                            vertical_coordinate=vertical_coordinate,
+                            tidal_forcing=True,
+                            thin_film_present=True))

--- a/compass/ocean/tests/isomip_plus/geom.py
+++ b/compass/ocean/tests/isomip_plus/geom.py
@@ -90,7 +90,7 @@ def process_input_geometry(inFileName, outFileName, filterSigma,
     surf[mask] = 0.
     draft[mask] = 0.
     floatingMask[mask] = 0.
-    thinFilmMask = bed>=0
+    thinFilmMask = bed >= 0
     if thin_film_present:
         smoothMask = numpy.logical_and(groundedMask, thinFilmMask)
     else:
@@ -104,11 +104,11 @@ def process_input_geometry(inFileName, outFileName, filterSigma,
     outFile.createDimension('x', nx)
     outFile.createDimension('y', ny)
 
-    outVar = outFile.createVariable('x', 'f8', ('x'))
+    outVar = outFile.createVariable('x', 'f8', ('x',))
     inVar = inFile.variables['x']
     outVar[:] = outX
     outVar.setncatts({k: inVar.getncattr(k) for k in inVar.ncattrs()})
-    outVar = outFile.createVariable('y', 'f8', ('y'))
+    outVar = outFile.createVariable('y', 'f8', ('y',))
     inVar = inFile.variables['y']
     outVar[:] = outY
     outVar.setncatts({k: inVar.getncattr(k) for k in inVar.ncattrs()})

--- a/compass/ocean/tests/isomip_plus/initial_state.py
+++ b/compass/ocean/tests/isomip_plus/initial_state.py
@@ -168,7 +168,8 @@ class InitialState(Step):
 
         section = config['isomip_plus']
 
-        # Deepen the bottom depth to maintain the minimum water-column thickness
+        # Deepen the bottom depth to maintain the minimum water-column
+        # thickness
         min_column_thickness = section.getfloat('min_column_thickness')
         min_layer_thickness = section.getfloat('min_layer_thickness')
         min_levels = section.getint('minimum_levels')
@@ -232,10 +233,12 @@ class InitialState(Step):
                                sectionY=section_y, dsMesh=ds, ds=ds,
                                showProgress=show_progress)
 
-        ds['landIcePressure'] = ds['landIcePressure'].expand_dims(dim='Time', axis=0)
+        ds['landIcePressure'] = \
+            ds['landIcePressure'].expand_dims(dim='Time', axis=0)
         ds['bottomDepth'] = ds['bottomDepth'].expand_dims(dim='Time', axis=0)
         ds['totalColThickness'] = ds['ssh']
-        ds['totalColThickness'].values = numpy.sum(ds['layerThickness'].values, axis=2)
+        ds['totalColThickness'].values = \
+            ds['layerThickness'].sum(dim='nVertLevels')
         plotter.plot_horiz_series(ds.landIcePressure,
                                   'landIcePressure', 'landIcePressure',
                                   True)
@@ -247,9 +250,9 @@ class InitialState(Step):
                                   vmin=min_column_thickness+1e-10, vmax=700,
                                   cmap_set_under='r', cmap_scale='log')
         plotter.plot_horiz_series(ds.totalColThickness,
-                                  'totalColThickness', 'totalColThickness', True,
-                                  vmin=min_column_thickness+1e-10, vmax=700,
-                                  cmap_set_under='r')
+                                  'totalColThickness', 'totalColThickness',
+                                  True, vmin=min_column_thickness+1e-10,
+                                  vmax=700, cmap_set_under='r')
         plotter.plot_layer_interfaces()
 
         plotter.plot_3d_field_top_bot_section(
@@ -287,7 +290,8 @@ class InitialState(Step):
         restore_xmax = section.getfloat('restore_xmax')
         frac = numpy.maximum(
             (ds.xCell - restore_xmin)/(restore_xmax-restore_xmin), 0.)
-        frac = frac.broadcast_like(ds_forcing.temperatureInteriorRestoringValue)
+        frac = frac.broadcast_like(
+            ds_forcing.temperatureInteriorRestoringValue)
 
         # convert from 1/days to 1/s
         ds_forcing['temperatureInteriorRestoringRate'] = \

--- a/compass/ocean/tests/isomip_plus/isomip_plus_test.py
+++ b/compass/ocean/tests/isomip_plus/isomip_plus_test.py
@@ -8,7 +8,7 @@ from compass.ocean.tests.isomip_plus.misomip import Misomip
 from compass.validate import compare_variables
 
 
-class OceanTest(TestCase):
+class IsomipPlusTest(TestCase):
     """
     An ISOMIP+ test case
 

--- a/compass/ocean/tests/isomip_plus/namelist.thin_film.forward_and_ssh_adjust
+++ b/compass/ocean/tests/isomip_plus/namelist.thin_film.forward_and_ssh_adjust
@@ -4,5 +4,4 @@ config_use_wetting_drying=.true.
 config_prevent_drying=.true.
 config_drying_min_cell_height=1.0e-3
 config_zero_drying_velocity = .true.
-config_zero_drying_velocity_ramp = .true.
 config_thickness_flux_type='upwind'

--- a/compass/ocean/tests/isomip_plus/ssh_adjustment.py
+++ b/compass/ocean/tests/isomip_plus/ssh_adjustment.py
@@ -45,7 +45,7 @@ class SshAdjustment(Step):
         # start with the same namelist settings as the forward run
         self.add_namelist_file('compass.ocean.tests.isomip_plus',
                                'namelist.forward_and_ssh_adjust')
-        if vertical_coordinate=='single_layer':
+        if vertical_coordinate == 'single_layer':
             self.add_namelist_file('compass.ocean.tests.isomip_plus',
                                    'namelist.single_layer.forward_and_ssh_adjust')
         if thin_film_present:

--- a/compass/ocean/tests/isomip_plus/streamfunction.py
+++ b/compass/ocean/tests/isomip_plus/streamfunction.py
@@ -546,7 +546,7 @@ def _compute_region_boundary_edges(dsMesh, cellMask):
     # convert from boolean mask to indices
     edgeIndices = numpy.nonzero(edgeMask)[0]
 
-    if(len(edgeIndices) == 0):
+    if len(edgeIndices) == 0:
         return numpy.array([]), numpy.array([])
     else:
         # according to the mesh spec, normals point from cell 0 to cell 1 on a

--- a/compass/ocean/tests/isomip_plus/viz/__init__.py
+++ b/compass/ocean/tests/isomip_plus/viz/__init__.py
@@ -1,6 +1,5 @@
 import xarray
 import os
-import numpy
 
 from mpas_tools.io import write_netcdf
 
@@ -72,8 +71,7 @@ class Viz(Step):
         out_dir = '.'
 
         dsMesh = xarray.open_dataset(f'{sim_dir}/init.nc')
-        dsOut = xarray.open_dataset(f'{sim_dir}/output.nc'.format(sim_dir))
-        dsForcing = xarray.open_dataset(f'{sim_dir}/forcing_data_init.nc')
+        dsOut = xarray.open_dataset(f'{sim_dir}/output.nc')
 
         plotter = MoviePlotter(inFolder=sim_dir,
                                streamfunctionFolder=streamfunction_dir,

--- a/compass/ocean/tests/isomip_plus/viz/plot.py
+++ b/compass/ocean/tests/isomip_plus/viz/plot.py
@@ -120,7 +120,7 @@ class TimeSeriesPlotter(object):
                          figsize=(12, 6), color=None, overwrite=True):
 
         fileName = '{}/{}.png'.format(self.outFolder, prefix)
-        if(not overwrite and os.path.exists(fileName)):
+        if not overwrite and os.path.exists(fileName):
             return
 
         nTime = da.sizes['Time']
@@ -479,8 +479,14 @@ class MoviePlotter(object):
         vmin, vmax : float, optional
             The minimum and maximum values for the colorbar
 
-        cmap : Colormap or str
+        cmap : Colormap or str, optional
             A color map to plot
+
+        cmap_set_under : str or None, optional
+            A color for low out-of-range values
+
+        cmap_scale : {'log', 'linear'}, optional
+            Whether the colormap is logarithmic or linear
         """
 
         nTime = self.ds.sizes['Time']
@@ -539,6 +545,9 @@ class MoviePlotter(object):
 
         cmap : Colormap or str, optional
             A color map to plot
+
+        cmap_set_under : str or None, optional
+            A color for low out-of-range values
         """
 
         if vmin is None:
@@ -799,14 +808,11 @@ class MoviePlotter(object):
         if os.path.exists(outFileName):
             return
 
-        nTime = self.Z.shape[0]
-
         z_mask = numpy.ones(self.X.shape)
         z_mask[0:-1, 0:-1] *= numpy.where(self.sectionMask, 1., numpy.nan)
 
         tIndex = 0
         Z = numpy.array(self.Z[tIndex, :, :])
-        ylim = [numpy.amin(Z), 20]
         Z *= z_mask
         X = self.X
 
@@ -875,7 +881,7 @@ def _compute_cell_patches(dsMesh, mask):
     xVertex = dsMesh.xVertex.values
     yVertex = dsMesh.yVertex.values
     for iCell in range(dsMesh.sizes['nCells']):
-        if(not mask[iCell]):
+        if not mask[iCell]:
             continue
         nVert = nVerticesOnCell[iCell]
         vertexIndices = verticesOnCell[iCell, :nVert]

--- a/compass/ocean/tests/isomip_plus/viz/plot.py
+++ b/compass/ocean/tests/isomip_plus/viz/plot.py
@@ -686,13 +686,15 @@ class MoviePlotter(object):
             plt.plot(1e-3 * X[0, :], self.zBotSection, 'g')
 
             ax.autoscale(tight=True)
+            x1, x2, y1, y2 = 420, 470, -650, -520
+            xlim = [min(x1, 1e-3*numpy.amin(X)), 1e-3*numpy.amax(X)]
+            plt.xlim(xlim)
             plt.ylim(ylim)
             axins = ax.inset_axes([0.01, 0.6, 0.3, 0.39])
             for z_index in range(1, X.shape[0]):
                 axins.plot(1e-3 * X[z_index, :], Z[z_index, :], 'k')
             axins.plot(1e-3 * X[0, :], Z[0, :], 'b')
             axins.plot(1e-3 * X[0, :], self.zBotSection, 'g')
-            x1, x2, y1, y2 = 420, 470, -650, -520
             axins.set_xlim(x1, x2)
             axins.set_ylim(y1, y2)
             axins.set_xticklabels([])

--- a/docs/developers_guide/ocean/api.rst
+++ b/docs/developers_guide/ocean/api.rst
@@ -403,9 +403,9 @@ isomip_plus
 
    IsomipPlus
 
-   ocean_test.OceanTest
-   ocean_test.OceanTest.configure
-   ocean_test.OceanTest.run
+   isomip_plus_test.IsomipPlusTest
+   isomip_plus_test.IsomipPlusTest.configure
+   isomip_plus_test.IsomipPlusTest.run
 
    viz.Viz
    viz.Viz.run

--- a/docs/developers_guide/ocean/test_groups/isomip_plus.rst
+++ b/docs/developers_guide/ocean/test_groups/isomip_plus.rst
@@ -42,7 +42,7 @@ ice-shelf topography.
 The function :py:func:`compass.ocean.tests.isomip_plus.geom.interpolate_ocean_mask()`
 interpolates the ocean mask from the BISICLES grid of the input geometry to
 the MPAS-Ocean mesh.  The mask can later be used to cull land cells from the
-MPAS mesh before interpolating other variables to the resulting culled mesh. 
+MPAS mesh before interpolating other variables to the resulting culled mesh.
 Optionally, a thin film under the ice sheet can be used and grounded ice is
 not culled.
 
@@ -169,14 +169,14 @@ out the results in the format expected by MISOMIP.
     There is currently an issue with fill values not being handled correctly
     that needs to be resolved before this step is fully useful.
 
-.. _dev_ocean_isomip_plus_ocean_test:
+.. _dev_ocean_isomip_plus_test:
 
-ocean_test
-----------
+isomip_plus_test
+----------------
 
 The same class,
-:py:class:`compass.ocean.tests.isomip_plus.ocean_test.OceanTest`, defines
-the Ocean0, Ocean1 and Ocean2 test cases at various resolutions and with
+:py:class:`compass.ocean.tests.isomip_plus.isomip_plus_test.IsomipPlusTest`,
+defines the Ocean0, Ocean1 and Ocean2 test cases at various resolutions and with
 various vertical coordinates.  By default, these test cases only run 3 of the
 7 available steps: ``initial_state`` to create and mesh and initial condition,
 ``ssh_adjustment`` to perform 10 1-hour simulations used to balance the


### PR DESCRIPTION
This is just a clean-up PR to take care of a few things that have been missed over time in the ISOMIP+ test group.
* Rename `OceanTest` to `IsomipPlusTest` and move it from its own package directory to a module
* Some PEP8 issues
* Some parameters and attributes missing from docstrings
* Some plots that look weird for "normal" (z-star, no thin film) test cases.