### PR TITLE
Switch Chrysalis Intel to use OpenMPI by default

### DIFF
--- a/compass/machines/chrysalis.cfg
+++ b/compass/machines/chrysalis.cfg
@@ -24,7 +24,7 @@ compass_envs = /lcrc/soft/climate/compass/chrysalis/base
 compiler = intel
 
 # the system MPI library to use for intel compiler
-mpi_intel = impi
+mpi_intel = openmpi
 
 # the system MPI library to use for gnu compiler
 mpi_gnu = openmpi


### PR DESCRIPTION
This is what E3SM uses and we have had a lot of bit-for-bit failures with Intel-MPI (see #461) that might be better with OpenMPI.