### PR TITLE
Fix `landIceFraction` in ISOMIP+

### DIFF
--- a/compass/ocean/tests/isomip_plus/viz/plot.py
+++ b/compass/ocean/tests/isomip_plus/viz/plot.py
@@ -237,7 +237,7 @@ class MoviePlotter(object):
         self.dsMesh = dsMesh
         self.ds = ds
 
-        landIceMask = self.dsMesh.landIceFraction.isel(Time=0) > 0.01
+        landIceMask = self.dsMesh.landIceMask.isel(Time=0) > 0
         self.oceanMask = self.dsMesh.maxLevelCell-1 >= 0
         self.cavityMask = numpy.logical_and(self.oceanMask, landIceMask)
 


### PR DESCRIPTION
We need `landIceFraciton` to be zero when `landIceMask` is zero.

Following up on #469, but this is a bug and is non-BFB.