### PR TITLE
Add support for spherical meshes in ISOMIP+

### DIFF
--- a/compass/ocean/tests/isomip_plus/__init__.py
+++ b/compass/ocean/tests/isomip_plus/__init__.py
@@ -76,3 +76,13 @@ class IsomipPlus(TestGroup):
                             vertical_coordinate=vertical_coordinate,
                             tidal_forcing=True,
                             thin_film_present=True))
+
+        for resolution in [2.]:
+            for experiment in ['Ocean0', 'Ocean1', 'Ocean2']:
+                for vertical_coordinate in ['z-star']:
+                    self.add_test_case(
+                        IsomipPlusTest(
+                            test_group=self, resolution=resolution,
+                            experiment=experiment,
+                            vertical_coordinate=vertical_coordinate,
+                            planar=False))

--- a/compass/ocean/tests/isomip_plus/__init__.py
+++ b/compass/ocean/tests/isomip_plus/__init__.py
@@ -1,6 +1,5 @@
-from compass.testgroup import TestGroup
-
 from compass.ocean.tests.isomip_plus.isomip_plus_test import IsomipPlusTest
+from compass.testgroup import TestGroup
 
 
 class IsomipPlus(TestGroup):

--- a/compass/ocean/tests/isomip_plus/cull_mesh.py
+++ b/compass/ocean/tests/isomip_plus/cull_mesh.py
@@ -1,12 +1,13 @@
 import xarray as xr
-
 from mpas_tools.io import write_netcdf
 from mpas_tools.mesh.conversion import convert, cull
 
-from compass.step import Step
-from compass.ocean.tests.isomip_plus.geom import \
-    define_thin_film_mask_step1, interpolate_ocean_mask
+from compass.ocean.tests.isomip_plus.geom import (
+    define_thin_film_mask_step1,
+    interpolate_ocean_mask,
+)
 from compass.ocean.tests.isomip_plus.spherical_mesh import add_isomip_plus_xy
+from compass.step import Step
 
 
 class CullMesh(Step):
@@ -72,7 +73,8 @@ class CullMesh(Step):
         if thin_film_present:
             ds_mask = define_thin_film_mask_step1(ds_mesh, ds_geom)
         else:
-            ds_mask = interpolate_ocean_mask(ds_mesh, ds_geom, min_ocean_fraction)
+            ds_mask = \
+                interpolate_ocean_mask(ds_mesh, ds_geom, min_ocean_fraction)
         ds_mesh = cull(ds_mesh, dsInverse=ds_mask, logger=logger)
         ds_mesh.attrs['is_periodic'] = 'NO'
 

--- a/compass/ocean/tests/isomip_plus/cull_mesh.py
+++ b/compass/ocean/tests/isomip_plus/cull_mesh.py
@@ -6,6 +6,7 @@ from mpas_tools.mesh.conversion import convert, cull
 from compass.step import Step
 from compass.ocean.tests.isomip_plus.geom import \
     define_thin_film_mask_step1, interpolate_ocean_mask
+from compass.ocean.tests.isomip_plus.spherical_mesh import add_isomip_plus_xy
 
 
 class CullMesh(Step):
@@ -77,4 +78,13 @@ class CullMesh(Step):
 
         ds_mesh = convert(ds_mesh, graphInfoFileName='culled_graph.info',
                           logger=logger)
+        if self.planar:
+            ds_mesh['xIsomipCell'] = ds_mesh.xCell
+            ds_mesh['yIsomipCell'] = ds_mesh.yCell
+            ds_mesh['xIsomipVertex'] = ds_mesh.xVertex
+            ds_mesh['yIsomipVertex'] = ds_mesh.yVertex
+        else:
+            lat0 = config.getfloat('spherical_mesh', 'lat0')
+            add_isomip_plus_xy(ds_mesh, lat0)
+
         write_netcdf(ds_mesh, 'culled_mesh.nc')

--- a/compass/ocean/tests/isomip_plus/files_for_e3sm.py
+++ b/compass/ocean/tests/isomip_plus/files_for_e3sm.py
@@ -1,10 +1,8 @@
 import os
-import xarray as xr
-import numpy as np
 from datetime import datetime
 from glob import glob
 
-from mpas_tools.io import write_netcdf
+import numpy as np
 from mpas_tools.logging import check_call
 from mpas_tools.scrip.from_mpas import scrip_from_mpas
 

--- a/compass/ocean/tests/isomip_plus/files_for_e3sm.py
+++ b/compass/ocean/tests/isomip_plus/files_for_e3sm.py
@@ -1,0 +1,188 @@
+import os
+import xarray as xr
+import numpy as np
+from datetime import datetime
+from glob import glob
+
+from mpas_tools.io import write_netcdf
+from mpas_tools.logging import check_call
+from mpas_tools.scrip.from_mpas import scrip_from_mpas
+
+from compass.io import symlink
+from compass.step import Step
+
+
+class FilesForE3sm(Step):
+    """
+    A step for creating an E3SM ocean initial condition from the results of
+    the ssh-adjustment process
+
+    Attributes
+    ----------
+    resolution : float
+        The horizontal resolution (km) of the test case
+
+    experiment : {'Ocean0', 'Ocean1', 'Ocean2'}
+        The ISOMIP+ experiment
+
+    out_dir : str
+        The subdirectory where files will be "assembled" within the same
+        directory structure as the inputdata for E3SM
+
+    creation_date : str
+        The date today, to append to file names
+
+    init_filename : str
+        The filename for the E3SM initial condition
+
+    forcing_filename : str
+        The filename for the E3SM forcing
+
+    graph_filename : str
+        The filename for the E3SM graph file
+
+    no_mask_scrip_filename : str
+        The filename for the E3SM scrip file with land-ice included
+
+    mask_scrip_filename : str
+        The filename for the E3SM scrip file without land-ice (just open ocean)
+
+    """
+    def __init__(self, test_case, resolution, experiment):
+        """
+        Create a new step
+
+        Parameters
+        ----------
+        test_case : compass.TestCase
+            The test case this step belongs to
+
+        resolution : float
+            The horizontal resolution (km) of the test case
+
+        experiment : {'Ocean0', 'Ocean1', 'Ocean2'}
+            The ISOMIP+ experiment
+        """
+
+        super().__init__(test_case, name='files_for_e3sm', ntasks=1,
+                         min_tasks=1, openmp_threads=1)
+
+        self.resolution = resolution
+        self.experiment = experiment
+        self.out_dir = None
+        self.creation_date = None
+        self.init_filename = None
+        self.forcing_filename = None
+        self.graph_filename = None
+        self.no_mask_scrip_filename = None
+        self.mask_scrip_filename = None
+
+    def setup(self):
+        resolution = self.resolution
+        experiment = self.experiment
+        if resolution == int(resolution):
+            res_string = f'{int(resolution)}km'
+        else:
+            res_string = f'{resolution}km'
+
+        mesh_short_name = f'IsomipPlus{res_string}{experiment}'
+        now = datetime.now()
+        creation_date = now.strftime("%Y%m%d")
+
+        out_dir = f'assembled_files/inputdata/ocn/mpas-o/{mesh_short_name}'
+        out_filename = f'mpaso.{mesh_short_name}.{creation_date}.nc'
+        self.add_input_file(filename=out_filename,
+                            target='../ssh_adjustment/adjusted_init.nc')
+        self.init_filename = out_filename
+        self.add_output_file(f'{out_dir}/{out_filename}')
+
+        out_filename = f'mpaso.forcing.{mesh_short_name}.{creation_date}.nc'
+        self.add_input_file(
+            filename=out_filename,
+            target='../initial_state/init_mode_forcing_data.nc')
+        self.forcing_filename = out_filename
+        self.add_output_file(f'{out_dir}/{out_filename}')
+
+        graph_filename = f'mpas-o.graph.info.{creation_date}'
+        self.add_input_file(filename=graph_filename,
+                            target='../cull_mesh/culled_graph.info')
+        self.add_output_file(f'{out_dir}/{graph_filename}')
+        self.graph_filename = graph_filename
+
+        self.out_dir = out_dir
+        self.creation_date = creation_date
+
+        out_filename = \
+            f'{mesh_short_name}.nomask.scrip.{creation_date}.nc'
+        self.add_output_file(out_filename)
+        self.add_output_file(f'{out_dir}/{out_filename}')
+        self.no_mask_scrip_filename = out_filename
+
+        out_filename = f'{mesh_short_name}.scrip.{creation_date}.nc'
+        self.add_output_file(out_filename)
+        self.add_output_file(f'{out_dir}/{out_filename}')
+        self.mask_scrip_filename = out_filename
+
+    def run(self):
+        """
+        Run this step of the testcase
+        """
+        try:
+            os.makedirs(self.out_dir)
+        except OSError:
+            pass
+
+        self._symlink_initial_condition()
+        self._make_partition_files()
+        self._make_scrip_files()
+
+    def _symlink_initial_condition(self):
+        dest_filename = self.init_filename
+        symlink(
+            f'../../../../../{dest_filename}',
+            f'{self.out_dir}/{dest_filename}')
+
+        dest_filename = self.forcing_filename
+        symlink(
+            f'../../../../../{dest_filename}',
+            f'{self.out_dir}/{dest_filename}')
+
+    def _make_partition_files(self):
+        logger = self.logger
+        graph_filename = self.graph_filename
+        print(graph_filename)
+
+        ncells = sum(1 for _ in open(graph_filename))
+        min_graph_size = int(ncells / 6000)
+        max_graph_size = int(ncells / 100)
+        logger.info('Creating graph files between {} and {}'.format(
+            min_graph_size, max_graph_size))
+        n_power2 = 2**np.arange(1, 21)
+        n_multiples12 = 12 * np.arange(1, 9)
+
+        ncores = n_power2
+        for power10 in range(3):
+            ncores = np.concatenate([ncores, 10**power10 * n_multiples12])
+
+        for n in ncores:
+            if min_graph_size <= n <= max_graph_size:
+                args = ['gpmetis', graph_filename, f'{n}']
+                check_call(args, logger)
+
+        # create link in assembled files directory
+        files = glob('mpas-o.graph.info.*')
+        for file in files:
+            symlink(f'../../../../../{file}',
+                    f'{self.out_dir}/{file}')
+
+    def _make_scrip_files(self):
+        init_filename = self.init_filename
+        scrip_filename = self.no_mask_scrip_filename
+        scrip_from_mpas(init_filename, scrip_filename)
+        symlink(f'../../../../../{scrip_filename}',
+                f'{self.out_dir}/{scrip_filename}')
+
+        scrip_filename = self.mask_scrip_filename
+        scrip_from_mpas(init_filename, scrip_filename, useLandIceMask=True)
+        symlink(f'../../../../../{scrip_filename}',
+                f'{self.out_dir}/{scrip_filename}')

--- a/compass/ocean/tests/isomip_plus/geom.py
+++ b/compass/ocean/tests/isomip_plus/geom.py
@@ -1,12 +1,12 @@
 import numpy
-from mpas_tools.mesh.interpolation import interp_bilin
 import xarray
+from mpas_tools.mesh.interpolation import interp_bilin
 
 
 def define_thin_film_mask_step1(ds_mesh, ds_geom):
     """
-    Define an MPAS mesh mask for the ocean domain including cells over the 
-    full x- and y-range in order to include all land cells in the ocean's 
+    Define an MPAS mesh mask for the ocean domain including cells over the
+    full x- and y-range in order to include all land cells in the ocean's
     thin-film region.
 
     Parameters
@@ -163,14 +163,15 @@ def interpolate_geom(ds_mesh, ds_geom, min_ocean_fraction, thin_film_present):
         ds_out[outfield] = (('nCells',), field)
 
     ocean_frac_observed = ds_out['oceanFracObserved']
-    if not numpy.all(ocean_frac_observed > min_ocean_fraction) and not thin_film_present:
+    if not numpy.all(ocean_frac_observed > min_ocean_fraction) and \
+            not thin_film_present:
         raise ValueError('Something went wrong with culling.  There are still '
                          'non-ocean cells in the culled mesh.')
 
     if not thin_film_present:
         for field in ['bottomDepthObserved', 'ssh', 'landIceFraction',
                       'smoothedDraftMask']:
-            ds_out[field] = ds_out[field]/ocean_frac_observed
+            ds_out[field] = ds_out[field] / ocean_frac_observed
 
     return ds_out
 

--- a/compass/ocean/tests/isomip_plus/geom.py
+++ b/compass/ocean/tests/isomip_plus/geom.py
@@ -178,8 +178,8 @@ def interpolate_geom(ds_mesh, ds_geom, min_ocean_fraction, thin_film_present):
 def _get_geom_fields(ds_geom, ds_mesh):
     x = ds_geom.x.values
     y = ds_geom.y.values
-    x_cell = ds_mesh.xCell.values
-    y_cell = ds_mesh.yCell.values
+    x_cell = ds_mesh.xIsomipCell.values
+    y_cell = ds_mesh.yIsomipCell.values
 
     ocean_fraction = - ds_geom['landFraction'] + 1.0
 

--- a/compass/ocean/tests/isomip_plus/initial_state.py
+++ b/compass/ocean/tests/isomip_plus/initial_state.py
@@ -260,7 +260,7 @@ class InitialState(Step):
         restore_xmin = section.getfloat('restore_xmin')
         restore_xmax = section.getfloat('restore_xmax')
         frac = np.maximum(
-            (ds.xCell - restore_xmin)/(restore_xmax-restore_xmin), 0.)
+            (ds.xIsomipCell - restore_xmin)/(restore_xmax-restore_xmin), 0.)
         frac = frac.broadcast_like(
             ds_forcing.temperatureInteriorRestoringValue)
 
@@ -273,8 +273,8 @@ class InitialState(Step):
         # compute "evaporation"
         restore_evap_rate = section.getfloat('restore_evap_rate')
 
-        mask = np.logical_and(ds.xCell >= restore_xmin,
-                              ds.xCell <= restore_xmax)
+        mask = np.logical_and(ds.xIsomipCell >= restore_xmin,
+                              ds.xIsomipCell <= restore_xmax)
         mask = mask.expand_dims(dim='Time', axis=0)
         # convert to m/s, negative for evaporation rather than precipitation
         evap_rate = -restore_evap_rate/(constants['SHR_CONST_CDAY']*365)
@@ -289,9 +289,9 @@ class InitialState(Step):
             mask*evap_rate*restore_top_temp/hflux_factor
 
         if self.vertical_coordinate == 'single_layer':
-            x_max = np.max(ds.xCell.values)
+            x_max = np.max(ds.xIsomipCell.values)
             ds_forcing['tidalInputMask'] = xr.where(
-                ds.xCell > (x_max - 0.6*self.resolution*1e3), 1.0, 0.0)
+                ds.xIsomipCell > (x_max - 0.6*self.resolution*1e3), 1.0, 0.0)
         else:
             ds_forcing['tidalInputMask'] = xr.zeros_like(frac)
 

--- a/compass/ocean/tests/isomip_plus/isomip_plus.cfg
+++ b/compass/ocean/tests/isomip_plus/isomip_plus.cfg
@@ -19,6 +19,13 @@ partial_cell_type = None
 # The minimum fraction of a layer for partial cells
 min_pc_fraction = 0.1
 
+# config options related to spherical meshes
+[spherical_mesh]
+
+# latitude in degrees for origin of the mesh on the sphere
+lat0 = -75.
+
+
 # Options relate to adjusting the sea-surface height or land-ice pressure
 # below ice shelves to they are dynamically consistent with one another
 [ssh_adjustment]

--- a/compass/ocean/tests/isomip_plus/isomip_plus_test.py
+++ b/compass/ocean/tests/isomip_plus/isomip_plus_test.py
@@ -1,15 +1,15 @@
-from compass.testcase import TestCase
-from compass.ocean.tests.isomip_plus.process_geom import ProcessGeom
-from compass.ocean.tests.isomip_plus.planar_mesh import PlanarMesh
-from compass.ocean.tests.isomip_plus.spherical_mesh import SphericalMesh
 from compass.ocean.tests.isomip_plus.cull_mesh import CullMesh
-from compass.ocean.tests.isomip_plus.initial_state import InitialState
-from compass.ocean.tests.isomip_plus.ssh_adjustment import SshAdjustment
+from compass.ocean.tests.isomip_plus.files_for_e3sm import FilesForE3sm
 from compass.ocean.tests.isomip_plus.forward import Forward
+from compass.ocean.tests.isomip_plus.initial_state import InitialState
+from compass.ocean.tests.isomip_plus.misomip import Misomip
+from compass.ocean.tests.isomip_plus.planar_mesh import PlanarMesh
+from compass.ocean.tests.isomip_plus.process_geom import ProcessGeom
+from compass.ocean.tests.isomip_plus.spherical_mesh import SphericalMesh
+from compass.ocean.tests.isomip_plus.ssh_adjustment import SshAdjustment
 from compass.ocean.tests.isomip_plus.streamfunction import Streamfunction
 from compass.ocean.tests.isomip_plus.viz import Viz
-from compass.ocean.tests.isomip_plus.files_for_e3sm import FilesForE3sm
-from compass.ocean.tests.isomip_plus.misomip import Misomip
+from compass.testcase import TestCase
 from compass.validate import compare_variables
 
 

--- a/compass/ocean/tests/isomip_plus/isomip_plus_test.py
+++ b/compass/ocean/tests/isomip_plus/isomip_plus_test.py
@@ -8,6 +8,7 @@ from compass.ocean.tests.isomip_plus.ssh_adjustment import SshAdjustment
 from compass.ocean.tests.isomip_plus.forward import Forward
 from compass.ocean.tests.isomip_plus.streamfunction import Streamfunction
 from compass.ocean.tests.isomip_plus.viz import Viz
+from compass.ocean.tests.isomip_plus.files_for_e3sm import FilesForE3sm
 from compass.ocean.tests.isomip_plus.misomip import Misomip
 from compass.validate import compare_variables
 
@@ -172,6 +173,12 @@ class IsomipPlusTest(TestCase):
             Viz(test_case=self, resolution=resolution, experiment=experiment,
                 tidal_forcing=tidal_forcing),
             run_by_default=False)
+
+        if not planar:
+            self.add_step(
+                FilesForE3sm(test_case=self, resolution=resolution,
+                             experiment=experiment),
+                run_by_default=False)
 
         if resolution in [2., 5.]:
             self.add_step(

--- a/compass/ocean/tests/isomip_plus/misomip.py
+++ b/compass/ocean/tests/isomip_plus/misomip.py
@@ -220,8 +220,8 @@ def _compute_misomip_interp_coeffs(in_dir, show_progress):
     inVars = inFile.variables
     nEdgesOnCell = inVars['nEdgesOnCell'][:]
     verticesOnCell = inVars['verticesOnCell'][:, :] - 1
-    xVertex = inVars['xVertex'][:]
-    yVertex = inVars['yVertex'][:]
+    xVertex = inVars['xIsomipVertex'][:]
+    yVertex = inVars['yIsomipVertex'][:]
 
     inFile.close()
     if(not os.path.exists(interpWeightsFileName)):

--- a/compass/ocean/tests/isomip_plus/misomip.py
+++ b/compass/ocean/tests/isomip_plus/misomip.py
@@ -1,11 +1,10 @@
+import glob
+import os
+
 import numpy
 from netCDF4 import Dataset
-from shapely.geometry import Polygon, LineString
-
-from progressbar import ProgressBar, Percentage, Bar, ETA
-
-import os
-import glob
+from progressbar import ETA, Bar, Percentage, ProgressBar
+from shapely.geometry import LineString, Polygon
 
 from compass.step import Step
 
@@ -75,7 +74,7 @@ class Misomip(Step):
                         show_progress=show_progress)
 
 
-def _compute_misomip_interp_coeffs(in_dir, show_progress):
+def _compute_misomip_interp_coeffs(in_dir, show_progress):  # noqa: C901
     def getTransectWeights(outFileName, axis):
 
         if show_progress:
@@ -118,7 +117,7 @@ def _compute_misomip_interp_coeffs(in_dir, show_progress):
                 sliceAxisVerts = yVert
                 otherAxisVerts = xVert
 
-            if(numpy.amax(sliceAxisVerts) < slicePos) or \
+            if (numpy.amax(sliceAxisVerts) < slicePos) or \
                     (numpy.amin(sliceAxisVerts) > slicePos):
                 # this polygon doesn't intersect the slice
                 continue
@@ -224,7 +223,7 @@ def _compute_misomip_interp_coeffs(in_dir, show_progress):
     yVertex = inVars['yIsomipVertex'][:]
 
     inFile.close()
-    if(not os.path.exists(interpWeightsFileName)):
+    if not os.path.exists(interpWeightsFileName):
 
         cellIndices = []
         xIndices = []
@@ -341,14 +340,15 @@ def _compute_misomip_interp_coeffs(in_dir, show_progress):
 
         outFile.close()
 
-    if(not os.path.exists(xTransectFileName)):
+    if not os.path.exists(xTransectFileName):
         getTransectWeights(xTransectFileName, axis='x')
 
-    if(not os.path.exists(yTransectFileName)):
+    if not os.path.exists(yTransectFileName):
         getTransectWeights(yTransectFileName, axis='y')
 
 
-def _interp_misomip(in_dir, sf_dir, out_file_name, show_progress):
+def _interp_misomip(in_dir, sf_dir, out_file_name,  # noqa: C901
+                    show_progress):
 
     def interpHoriz(field, inMask=None, outFraction=None):
         if inMask is not None:
@@ -640,7 +640,7 @@ def _interp_misomip(in_dir, sf_dir, out_file_name, show_progress):
     nTimeIn = min(nTimeIn, len(bsfFile.dimensions['Time']))
     nTimeIn = min(nTimeIn, len(osfFile.dimensions['Time']))
 
-    if(continueOutput):
+    if continueOutput:
         nTimeOut = max(0, len(outFile.dimensions['nTime']) - 2)
     else:
         nTimeOut = 0
@@ -692,8 +692,9 @@ def _interp_misomip(in_dir, sf_dir, out_file_name, show_progress):
         meltRate = freshwaterFlux / rho_fw
 
         if not numpy.all(inCavityFraction == 0.):
-            writeMetric('meanMeltRate', numpy.sum(meltRate * areaCell)
-                        / numpy.sum(inCavityFraction * areaCell))
+            writeMetric('meanMeltRate',
+                        numpy.sum(meltRate * areaCell) /
+                        numpy.sum(inCavityFraction * areaCell))
 
         writeMetric('totalMeltFlux', numpy.sum(freshwaterFlux * areaCell))
 
@@ -703,13 +704,13 @@ def _interp_misomip(in_dir, sf_dir, out_file_name, show_progress):
         writeMetric('totalOceanVolume', numpy.sum(columnThickness * areaCell))
 
         thermalDriving = (inVars['timeMonthly_avg_landIceBoundaryLayerTracers'
-                                 '_landIceBoundaryLayerTemperature'][0, :]
-                          - inVars['timeMonthly_avg_landIceInterfaceTracers'
-                                   '_landIceInterfaceTemperature'][0, :])
+                                 '_landIceBoundaryLayerTemperature'][0, :] -
+                          inVars['timeMonthly_avg_landIceInterfaceTracers'
+                                 '_landIceInterfaceTemperature'][0, :])
         halineDriving = (inVars['timeMonthly_avg_landIceBoundaryLayerTracers'
-                                '_landIceBoundaryLayerSalinity'][0, :]
-                         - inVars['timeMonthly_avg_landIceInterfaceTracers'
-                                  '_landIceInterfaceSalinity'][0, :])
+                                '_landIceBoundaryLayerSalinity'][0, :] -
+                         inVars['timeMonthly_avg_landIceInterfaceTracers'
+                                '_landIceInterfaceSalinity'][0, :])
         frictionVelocity = \
             inVars['timeMonthly_avg_landIceFrictionVelocity'][0, :]
 
@@ -777,9 +778,9 @@ def _interp_misomip(in_dir, sf_dir, out_file_name, show_progress):
         osf = 1e6 * osfFile.variables['osf'][tIndex, :, :]
         osfX = osfFile.variables['x'][:]
         osfZ = osfFile.variables['z'][:]
-        assert(numpy.all(osfX == x))
+        assert numpy.all(osfX == x)
         # the first and last OSF z values have been tweaked...
-        assert(numpy.all(osfZ[1:-1] == z[1:-1]))
+        assert numpy.all(osfZ[1:-1] == z[1:-1])
 
         writeVar('overturningStreamfunction', osf)
 
@@ -824,8 +825,8 @@ def _get_out_grid(corners):
         y = outY0 + outDx * (numpy.arange(outNy + 1))
         z = -outDz * (numpy.arange(outNz + 1))
     else:
-        x = outX0 + outDx*(numpy.arange(outNx)+0.5)
-        y = outY0 + outDx*(numpy.arange(outNy)+0.5)
-        z = -outDz*(numpy.arange(outNz)+0.5)
+        x = outX0 + outDx * (numpy.arange(outNx) + 0.5)
+        y = outY0 + outDx * (numpy.arange(outNy) + 0.5)
+        z = -outDz * (numpy.arange(outNz) + 0.5)
 
     return outNx, outNy, outNz, x, y, z, xTransect, yTransect, outDx, outDz

--- a/compass/ocean/tests/isomip_plus/planar_mesh.py
+++ b/compass/ocean/tests/isomip_plus/planar_mesh.py
@@ -58,4 +58,9 @@ class PlanarMesh(Step):
 
         translate(mesh=ds_mesh, xOffset=-1*nx_offset*dc, yOffset=-2*dc)
 
+        ds_mesh['xIsomipCell'] = ds_mesh.xCell
+        ds_mesh['yIsomipCell'] = ds_mesh.yCell
+        ds_mesh['xIsomipVertex'] = ds_mesh.xVertex
+        ds_mesh['yIsomipVertex'] = ds_mesh.yVertex
+
         write_netcdf(ds_mesh, 'base_mesh.nc')

--- a/compass/ocean/tests/isomip_plus/planar_mesh.py
+++ b/compass/ocean/tests/isomip_plus/planar_mesh.py
@@ -1,6 +1,6 @@
+from mpas_tools.io import write_netcdf
 from mpas_tools.planar_hex import make_planar_hex_mesh
 from mpas_tools.translate import translate
-from mpas_tools.io import write_netcdf
 
 from compass.step import Step
 
@@ -47,16 +47,16 @@ class PlanarMesh(Step):
         if thin_film_present:
             nx_offset = nx_thin_film
             # consider increasing nx
-            ds_mesh = make_planar_hex_mesh(nx=nx+nx_offset, ny=ny, dc=dc,
+            ds_mesh = make_planar_hex_mesh(nx=nx + nx_offset, ny=ny, dc=dc,
                                            nonperiodic_x=True,
                                            nonperiodic_y=True)
         else:
             nx_offset = 0
-            ds_mesh = make_planar_hex_mesh(nx=nx+2, ny=ny+2, dc=dc,
+            ds_mesh = make_planar_hex_mesh(nx=nx + 2, ny=ny + 2, dc=dc,
                                            nonperiodic_x=False,
                                            nonperiodic_y=False)
 
-        translate(mesh=ds_mesh, xOffset=-1*nx_offset*dc, yOffset=-2*dc)
+        translate(mesh=ds_mesh, xOffset=-1 * nx_offset * dc, yOffset=-2 * dc)
 
         ds_mesh['xIsomipCell'] = ds_mesh.xCell
         ds_mesh['yIsomipCell'] = ds_mesh.yCell

--- a/compass/ocean/tests/isomip_plus/spherical_mesh.py
+++ b/compass/ocean/tests/isomip_plus/spherical_mesh.py
@@ -1,11 +1,11 @@
 import numpy as np
-import xarray as xr
 import pyproj
-
-from mpas_tools.mesh.creation.signed_distance import \
-    signed_distance_from_geojson
+import xarray as xr
 from geometric_features import FeatureCollection
 from mpas_tools.cime.constants import constants
+from mpas_tools.mesh.creation.signed_distance import (
+    signed_distance_from_geojson,
+)
 
 from compass.mesh import QuasiUniformSphericalMeshStep
 
@@ -46,8 +46,8 @@ class SphericalMesh(QuasiUniformSphericalMeshStep):
         dlon = 0.1
         dlat = dlon
         earth_radius = constants['SHR_CONST_REARTH']
-        nlon = int(360./dlon) + 1
-        nlat = int(180./dlat) + 1
+        nlon = int(360. / dlon) + 1
+        nlat = int(180. / dlat) + 1
         lon = np.linspace(-180., 180., nlon)
         lat = np.linspace(-90., 90., nlat)
 
@@ -65,10 +65,10 @@ class SphericalMesh(QuasiUniformSphericalMeshStep):
         # this is a distance (in m) over which the resolution coarsens outside
         # the domain of interest plus buffer
         trans_width = 1000e3
-        weights = np.maximum(0., np.minimum(1., signed_distance/trans_width))
+        weights = np.maximum(0., np.minimum(1., signed_distance / trans_width))
 
-        cell_width = (self.cell_width * (1 - weights)
-                      + background_width * weights)
+        cell_width = (self.cell_width * (1 - weights) +
+                      background_width * weights)
 
         return cell_width, lon, lat
 
@@ -128,7 +128,7 @@ def _get_projections(lat0):
 def _make_feature(lat0):
     # a box with a buffer of 80 km surrounding the are of interest
     # (0 <= x <= 800) and (0 <= y <= 80)
-    bounds = 1e3*np.array((-80., 880., -80., 160.))
+    bounds = 1e3 * np.array((-80., 880., -80., 160.))
     projection, lat_lon_projection = _get_projections(lat0)
     transformer = pyproj.Transformer.from_proj(projection,
                                                lat_lon_projection)

--- a/compass/ocean/tests/isomip_plus/spherical_mesh.py
+++ b/compass/ocean/tests/isomip_plus/spherical_mesh.py
@@ -1,0 +1,160 @@
+import numpy as np
+import xarray as xr
+import pyproj
+
+from mpas_tools.mesh.creation.signed_distance import \
+    signed_distance_from_geojson
+from geometric_features import FeatureCollection
+from mpas_tools.cime.constants import constants
+
+from compass.mesh import QuasiUniformSphericalMeshStep
+
+
+class SphericalMesh(QuasiUniformSphericalMeshStep):
+    """
+    A step for creating an ISOMIP+ mesh that is a small region on a sphere
+    """
+    def setup(self):
+        """
+        Add some input files
+        """
+        self.add_input_file(
+            filename='input_geometry_processed.nc',
+            target='../process_geom/input_geometry_processed.nc')
+
+        self.add_output_file('base_mesh_with_xy.nc')
+
+        super().setup()
+
+    def build_cell_width_lat_lon(self):
+        """
+        Create cell width array for this mesh on a regular latitude-longitude
+        grid
+
+        Returns
+        -------
+        cellWidth : numpy.array
+            m x n array of cell width in km
+
+        lon : numpy.array
+            longitude in degrees (length n and between -180 and 180)
+
+        lat : numpy.array
+            longitude in degrees (length m and between -90 and 90)
+        """
+
+        dlon = 0.1
+        dlat = dlon
+        earth_radius = constants['SHR_CONST_REARTH']
+        nlon = int(360./dlon) + 1
+        nlat = int(180./dlat) + 1
+        lon = np.linspace(-180., 180., nlon)
+        lat = np.linspace(-90., 90., nlat)
+
+        # this is the width of cells (in km) on the globe outside the domain of
+        # interest, set to a coarse value to speed things up
+        background_width = 100.
+
+        lat0 = self.config.getfloat('spherical_mesh', 'lat0')
+        fc = _make_feature(lat0)
+        fc.to_geojson('isomip_plus_high_res.geojson')
+
+        signed_distance = signed_distance_from_geojson(
+            fc, lon, lat, earth_radius, max_length=0.25)
+
+        # this is a distance (in m) over which the resolution coarsens outside
+        # the domain of interest plus buffer
+        trans_width = 1000e3
+        weights = np.maximum(0., np.minimum(1., signed_distance/trans_width))
+
+        cell_width = (self.cell_width * (1 - weights)
+                      + background_width * weights)
+
+        return cell_width, lon, lat
+
+    def run(self):
+        """
+        Run this step of the test case
+        """
+        super().run()
+
+        ds = xr.open_dataset('base_mesh.nc')
+        lat0 = self.config.getfloat('spherical_mesh', 'lat0')
+        add_isomip_plus_xy(ds, lat0)
+        ds.to_netcdf('base_mesh_with_xy.nc')
+
+
+def add_isomip_plus_xy(ds, lat0):
+    """
+    Add x and y coordinates from a stereographic projection to a mesh on a
+    sphere
+
+    Parameters
+    ----------
+    ds : xarray.Dataset
+        The MPAS mesh on a sphere
+
+    lat0 : float
+        The latitude of the origin of the local stereographic project
+    """
+    projection, lat_lon_projection = _get_projections(lat0)
+    transformer = pyproj.Transformer.from_proj(lat_lon_projection,
+                                               projection)
+    lon = np.rad2deg(ds.lonCell.values)
+    lat = np.rad2deg(ds.latCell.values)
+
+    x, y = transformer.transform(lon, lat)
+
+    ds['xIsomipCell'] = ('nCells', x)
+    ds['yIsomipCell'] = ('nCells', y)
+
+    lon = np.rad2deg(ds.lonVertex.values)
+    lat = np.rad2deg(ds.latVertex.values)
+
+    x, y = transformer.transform(lon, lat)
+
+    ds['xIsomipVertex'] = ('nVertices', x)
+    ds['yIsomipVertex'] = ('nVertices', y)
+
+
+def _get_projections(lat0):
+    projection = pyproj.Proj(f'+proj=stere +lon_0=0 +lat_0={lat0} '
+                             f'+lat_ts={lat0} +x_0=0.0 +y_0=0.0 +ellps=WGS84')
+    lat_lon_projection = pyproj.Proj(proj='latlong', datum='WGS84')
+
+    return projection, lat_lon_projection
+
+
+def _make_feature(lat0):
+    # a box with a buffer of 80 km surrounding the are of interest
+    # (0 <= x <= 800) and (0 <= y <= 80)
+    bounds = 1e3*np.array((-80., 880., -80., 160.))
+    projection, lat_lon_projection = _get_projections(lat0)
+    transformer = pyproj.Transformer.from_proj(projection,
+                                               lat_lon_projection)
+
+    x = [bounds[0], bounds[1], bounds[1], bounds[0], bounds[0]]
+    y = [bounds[2], bounds[2], bounds[3], bounds[3], bounds[2]]
+    lon, lat = transformer.transform(x, y)
+
+    coordinates = [[[lon[index], lat[index]] for index in range(len(lon))]]
+
+    features = [
+        {
+            "type": "Feature",
+            "properties": {
+                "name": "ISOMIP+ high res region",
+                "component": "ocean",
+                "object": "region",
+                "author": "Xylar Asay-Davis"
+            },
+            "geometry": {
+                "type": "Polygon",
+                "coordinates": coordinates
+            }
+        }
+    ]
+
+    fc = FeatureCollection(features=features)
+
+    return fc

--- a/compass/ocean/tests/isomip_plus/streamfunction.py
+++ b/compass/ocean/tests/isomip_plus/streamfunction.py
@@ -599,7 +599,7 @@ def _horizontally_bin_overturning_streamfunction(ds, dsMesh, x, osfFileName,
         if file_complete(ds, fileName):
             continue
 
-        cellMask = dsMesh.xCell >= x[xIndex]
+        cellMask = dsMesh.xIsomipCell >= x[xIndex]
         edgeIndices, edgeSigns = _compute_region_boundary_edges(dsMesh,
                                                                 cellMask)
 

--- a/compass/ocean/tests/isomip_plus/viz/plot.py
+++ b/compass/ocean/tests/isomip_plus/viz/plot.py
@@ -839,7 +839,8 @@ class MoviePlotter(object):
         plt.close()
 
     def _compute_section_x_z(self):
-        x = _interp_extrap_corner(self.dsMesh.xCell[self.sectionCellIndices])
+        x = _interp_extrap_corner(
+            self.dsMesh.xIsomipCell[self.sectionCellIndices])
         nx = len(x)
         nVertLevels = self.dsMesh.sizes['nVertLevels']
         nTime = self.ds.sizes['Time']
@@ -881,8 +882,8 @@ def _compute_cell_patches(dsMesh, mask):
     patches = []
     nVerticesOnCell = dsMesh.nEdgesOnCell.values
     verticesOnCell = dsMesh.verticesOnCell.values - 1
-    xVertex = dsMesh.xVertex.values
-    yVertex = dsMesh.yVertex.values
+    xVertex = dsMesh.xIsomipVertex.values
+    yVertex = dsMesh.yIsomipVertex.values
     for iCell in range(dsMesh.sizes['nCells']):
         if not mask[iCell]:
             continue
@@ -901,8 +902,8 @@ def _compute_cell_patches(dsMesh, mask):
 
 
 def _compute_section_cell_indices(y, dsMesh):
-    xCell = dsMesh.xCell.values
-    yCell = dsMesh.yCell.values
+    xCell = dsMesh.xIsomipCell.values
+    yCell = dsMesh.yIsomipCell.values
     xMin = numpy.amin(xCell)
     xMax = numpy.amax(xCell)
     xs = numpy.linspace(xMin, xMax, 10000)


### PR DESCRIPTION
This merge builds on #469 and #470 to add support for meshes that are a patch of a sphere in ISOMIP+ test cases.

The idea is that these regional meshes on the sphere could be use to do idealized testing within E3SM.