### PR TITLE
Fix typo in hurrincane init plotting

### DIFF
--- a/compass/ocean/tests/hurricane/init/interpolate_atm_forcing.py
+++ b/compass/ocean/tests/hurricane/init/interpolate_atm_forcing.py
@@ -185,7 +185,7 @@ class InterpolateAtmForcing(Step):
         # Save figure
         fig.tight_layout()
         fig.savefig(var_abrev+'_'+str(i).zfill(4)+'.png',
-                    box_inches='tight')
+                    bbox_inches='tight')
         plt.close()
 
     def write_to_file(self, filename, data, var, xtime):


### PR DESCRIPTION
This PR fixes a typo in plotting the atmospheric forcing in the init step of the hurricane case.