### PR TITLE
Fix provenance when E3SM submodule not needed

### DIFF
--- a/compass/provenance.py
+++ b/compass/provenance.py
@@ -105,6 +105,9 @@ def _get_mpas_git_version(config):
 
     mpas_model_path = config.get('paths', 'mpas_model')
 
+    if not os.path.exists(mpas_model_path):
+        return None
+
     cwd = os.getcwd()
     os.chdir(mpas_model_path)
 


### PR DESCRIPTION
Some test cases don't need an MPAS component to be built in order to run.  This merge makes it so provenance does not attempt to get a git has for the MPAS component if the path to the component doesn't exist (presumably because the submodule has not been initialized).

<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->

<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
- [x] Document (in a comment titled `Testing` in this PR) any testing that was used to verify the changes

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->
