### PR TITLE
Update E3SM-Project submodule

### DIFF
--- a/utils/e3sm_update/test_e3sm_changes.py
+++ b/utils/e3sm_update/test_e3sm_changes.py
@@ -191,8 +191,10 @@ def setup_and_submit(load_script, setup_command, worktree, mpas_subdir,
         full_setup = f'{full_setup} -b {baseline}'
 
     commands = f'source {load_script}; ' \
-               f'{full_setup}; ' \
-               f'cd {workdir}; ' \
+               f'{full_setup}'
+    print_and_run(commands)
+
+    commands = f'cd {workdir}; ' \
                f'sbatch job_script.{suite}.sh'
     print_and_run(commands)
 


### PR DESCRIPTION
This merge updates the E3SM-Project submodule from [569ed6b730](https://github.com/E3SM-Project/E3SM/tree/569ed6b730) to [0273cfad9d](https://github.com/E3SM-Project/E3SM/tree/0273cfad9d).

This update includes the following MPAS-Ocean and MPAS-Frameworks PRs (check mark indicates bit-for-bit with previous PR in the list using the `pr` test suite on Chrysalis with Intel and OpenMPI, optimized):
- [x]  (ocn) https://github.com/E3SM-Project/E3SM/pull/5306
- [x]  (fwk) https://github.com/E3SM-Project/E3SM/pull/5303
- [x]  (ocn) https://github.com/E3SM-Project/E3SM/pull/5325
- [x]  (fwk) https://github.com/E3SM-Project/E3SM/pull/5337
- [x]  (fwk) https://github.com/E3SM-Project/E3SM/pull/5123
- [x]  (fwk) https://github.com/E3SM-Project/E3SM/pull/5281
- [ ]  (ocn) https://github.com/E3SM-Project/E3SM/pull/5356
  -  As documented in the PR, 18 test cases fail baseline comparison but changes are small and expected. Before this, 2 decomposition test cases consistently fail.  After this PR, they pass again.

<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->

<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [x] The `E3SM-Project` submodule has been updated with relevant E3SM changes
* [x] Document (in a comment titled `Testing` in this PR) any testing that was used to verify the changes

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->
