### PR TITLE
Override `constrain_resources()` in individual steps

### DIFF
--- a/compass/ocean/tests/global_convergence/cosine_bell/__init__.py
+++ b/compass/ocean/tests/global_convergence/cosine_bell/__init__.py
@@ -72,25 +72,6 @@ class CosineBell(TestCase):
 
         self.update_cores()
 
-    def run(self):
-        """
-        Run each step of the testcase
-        """
-        config = self.config
-        for resolution in self.resolutions:
-            if self.icosahedral:
-                mesh_name = f'Icos{resolution}'
-            else:
-                mesh_name = f'QU{resolution}'
-            ntasks = config.getint('cosine_bell', f'{mesh_name}_ntasks')
-            min_tasks = config.getint('cosine_bell', f'{mesh_name}_min_tasks')
-            step = self.steps[f'{mesh_name}_forward']
-            step.ntasks = ntasks
-            step.min_tasks = min_tasks
-
-        # run the step
-        super().run()
-
     def update_cores(self):
         """ Update the number of cores and min_tasks for each forward step """
 

--- a/compass/ocean/tests/global_convergence/cosine_bell/forward.py
+++ b/compass/ocean/tests/global_convergence/cosine_bell/forward.py
@@ -13,6 +13,9 @@ class Forward(Step):
     ----------
     resolution : int
         The resolution of the (uniform) mesh in km
+
+    mesh_name : str
+        The name of the mesh
     """
 
     def __init__(self, test_case, resolution, mesh_name):
@@ -35,6 +38,7 @@ class Forward(Step):
                          subdir=f'{mesh_name}/forward')
 
         self.resolution = resolution
+        self.mesh_name = mesh_name
 
         # make sure output is double precision
         self.add_streams_file('compass.ocean.streams', 'streams.output')
@@ -61,6 +65,14 @@ class Forward(Step):
         """
         dt = self.get_dt()
         self.add_namelist_options({'config_dt': dt})
+        self._get_resources()
+
+    def constrain_resources(self, available_cores):
+        """
+        Update resources at runtime from config options
+        """
+        self._get_resources()
+        super().constrain_resources(available_cores)
 
     def run(self):
         """
@@ -92,3 +104,9 @@ class Forward(Step):
         dt = time.strftime('%H:%M:%S', time.gmtime(dt))
 
         return dt
+
+    def _get_resources(self):
+        mesh_name = self.mesh_name
+        config = self.config
+        self.ntasks = config.getint('cosine_bell', f'{mesh_name}_ntasks')
+        self.min_tasks = config.getint('cosine_bell', f'{mesh_name}_min_tasks')

--- a/compass/ocean/tests/global_ocean/init/__init__.py
+++ b/compass/ocean/tests/global_ocean/init/__init__.py
@@ -65,36 +65,13 @@ class Init(TestCase):
 
         if mesh.with_ice_shelf_cavities:
             self.add_step(
-                SshAdjustment(test_case=self, ntasks=4))
+                SshAdjustment(test_case=self))
 
     def configure(self):
         """
         Modify the configuration options for this test case
         """
         configure_global_ocean(test_case=self, mesh=self.mesh, init=self)
-
-    def run(self):
-        """
-        Run each step of the testcase
-        """
-        config = self.config
-        steps = self.steps_to_run
-        if 'initial_state' in steps:
-            step = self.steps['initial_state']
-            # get the these properties from the config options
-            step.ntasks = config.getint('global_ocean', 'init_ntasks')
-            step.min_tasks = config.getint('global_ocean', 'init_min_tasks')
-            step.threads = config.getint('global_ocean', 'init_threads')
-
-        if 'ssh_adjustment' in steps:
-            step = self.steps['ssh_adjustment']
-            # get the these properties from the config options
-            step.ntasks = config.getint('global_ocean', 'forward_ntasks')
-            step.min_tasks = config.getint('global_ocean', 'forward_min_tasks')
-            step.threads = config.getint('global_ocean', 'forward_threads')
-
-        # run the steps
-        super().run()
 
     def validate(self):
         """

--- a/compass/ocean/tests/global_ocean/init/initial_state.py
+++ b/compass/ocean/tests/global_ocean/init/initial_state.py
@@ -148,14 +148,17 @@ class InitialState(Step):
 
     def setup(self):
         """
-        Set up the test case in the work directory, including downloading any
-        dependencies.
+        Get resources at setup from config options
         """
-        # get the these properties from the config options
-        config = self.config
-        self.ntasks = config.getint('global_ocean', 'init_ntasks')
-        self.min_tasks = config.getint('global_ocean', 'init_min_tasks')
-        self.openmp_threads = config.getint('global_ocean', 'init_threads')
+        self._get_resources()
+
+
+    def constrain_resources(self, available_cores):
+        """
+        Update resources at runtime from config options
+        """
+        self._get_resources()
+        super().constrain_resources(available_cores)
 
     def run(self):
         """
@@ -175,3 +178,10 @@ class InitialState(Step):
 
         plot_initial_state(input_file_name='initial_state.nc',
                            output_file_name='initial_state.png')
+
+    def _get_resources(self):
+        # get the these properties from the config options
+        config = self.config
+        self.ntasks = config.getint('global_ocean', 'init_ntasks')
+        self.min_tasks = config.getint('global_ocean', 'init_min_tasks')
+        self.openmp_threads = config.getint('global_ocean', 'init_threads')

--- a/compass/ocean/tests/global_ocean/init/ssh_adjustment.py
+++ b/compass/ocean/tests/global_ocean/init/ssh_adjustment.py
@@ -7,8 +7,7 @@ class SshAdjustment(Step):
     A step for iteratively adjusting the pressure from the weight of the ice
     shelf to match the sea-surface height as part of ice-shelf 2D test cases
     """
-    def __init__(self, test_case, ntasks=None, min_tasks=None,
-                 openmp_threads=None):
+    def __init__(self, test_case):
         """
         Create the step
 
@@ -16,25 +15,8 @@ class SshAdjustment(Step):
         ----------
         test_case : compass.ocean.tests.global_ocean.init.Init
             The test case this step belongs to
-
-        ntasks : int, optional
-            the number of tasks the step would ideally use.  If fewer tasks
-            are available on the system, the step will run on all available
-            tasks as long as this is not below ``min_tasks``
-
-        min_tasks : int, optional
-            the number of tasks the step requires.  If the system has fewer
-            than this number of tasks, the step will fail
-
-        openmp_threads : int, optional
-            the number of OpenMP threads the step will use
-
         """
-        if min_tasks is None:
-            min_tasks = ntasks
-        super().__init__(test_case=test_case, name='ssh_adjustment',
-                         ntasks=ntasks, min_tasks=min_tasks,
-                         openmp_threads=openmp_threads)
+        super().__init__(test_case=test_case, name='ssh_adjustment')
 
         # make sure output is double precision
         self.add_streams_file('compass.ocean.streams', 'streams.output')
@@ -71,15 +53,14 @@ class SshAdjustment(Step):
         Set up the test case in the work directory, including downloading any
         dependencies
         """
-        if self.ntasks is None:
-            self.ntasks = self.config.getint(
-                'global_ocean', 'forward_ntasks')
-        if self.min_tasks is None:
-            self.min_tasks = self.config.getint(
-                'global_ocean', 'forward_min_tasks')
-        if self.openmp_threads is None:
-            self.openmp_threads = self.config.getint(
-                'global_ocean', 'forward_threads')
+        self._get_resources()
+
+    def constrain_resources(self, available_cores):
+        """
+        Update resources at runtime from config options
+        """
+        self._get_resources()
+        super().constrain_resources(available_cores)
 
     def run(self):
         """
@@ -89,3 +70,10 @@ class SshAdjustment(Step):
         iteration_count = config.getint('ssh_adjustment', 'iterations')
         adjust_ssh(variable='landIcePressure', iteration_count=iteration_count,
                    step=self)
+
+    def _get_resources(self):
+        # get the these properties from the config options
+        config = self.config
+        self.ntasks = config.getint('global_ocean', 'forward_ntasks')
+        self.min_tasks = config.getint('global_ocean', 'forward_min_tasks')
+        self.openmp_threads = config.getint('global_ocean', 'forward_threads')

--- a/compass/ocean/tests/hurricane/forward/__init__.py
+++ b/compass/ocean/tests/hurricane/forward/__init__.py
@@ -56,10 +56,3 @@ class Forward(TestCase):
         Modify the configuration options for this test case
         """
         configure_hurricane(test_case=self, mesh=self.mesh)
-
-    def run(self):
-        """
-        Run each step of the testcase
-        """
-        # run the steps
-        super().run()

--- a/compass/ocean/tests/hurricane/forward/forward.py
+++ b/compass/ocean/tests/hurricane/forward/forward.py
@@ -69,13 +69,24 @@ class ForwardStep(Step):
         Set up the test case in the work directory, including downloading any
         dependencies
         """
-        self.ntasks = self.config.getint('hurricane', 'forward_ntasks')
-        self.min_tasks = self.config.getint('hurricane', 'forward_min_tasks')
-        self.openmp_threads = self.config.getint('hurricane',
-                                                 'forward_threads')
+        self._get_resources()
+
+    def constrain_resources(self, available_cores):
+        """
+        Update resources at runtime from config options
+        """
+        self._get_resources()
+        super().constrain_resources(available_cores)
 
     def run(self):
         """
         Run this step of the testcase
         """
         run_model(self)
+
+    def _get_resources(self):
+        # get the these properties from the config options
+        config = self.config
+        self.ntasks = config.getint('hurricane', 'forward_ntasks')
+        self.min_tasks = config.getint('hurricane', 'forward_min_tasks')
+        self.openmp_threads = config.getint('hurricane', 'forward_threads')

--- a/compass/ocean/tests/hurricane/init/__init__.py
+++ b/compass/ocean/tests/hurricane/init/__init__.py
@@ -51,11 +51,3 @@ class Init(TestCase):
         Modify the configuration options for this test case
         """
         configure_hurricane(test_case=self, mesh=self.mesh)
-
-    def run(self):
-        """
-        Run each step of the testcase
-        """
-
-        # run the steps
-        super().run()

--- a/compass/ocean/tests/hurricane/init/initial_state.py
+++ b/compass/ocean/tests/hurricane/init/initial_state.py
@@ -56,16 +56,26 @@ class InitialState(Step):
     def setup(self):
         """
         Set up the test case in the work directory, including downloading any
-        dependencies.
+        dependencies
         """
-        # get the these properties from the config options
-        config = self.config
-        self.ntasks = config.getint('hurricane', 'init_ntasks')
-        self.min_tasks = config.getint('hurricane', 'init_min_tasks')
-        self.openmp_threads = config.getint('hurricane', 'init_threads')
+        self._get_resources()
+
+    def constrain_resources(self, available_cores):
+        """
+        Update resources at runtime from config options
+        """
+        self._get_resources()
+        super().constrain_resources(available_cores)
 
     def run(self):
         """
         Run this step of the testcase
         """
         run_model(self)
+
+    def _get_resources(self):
+        # get the these properties from the config options
+        config = self.config
+        self.ntasks = config.getint('hurricane', 'init_ntasks')
+        self.min_tasks = config.getint('hurricane', 'init_min_tasks')
+        self.openmp_threads = config.getint('hurricane', 'init_threads')

--- a/compass/ocean/tests/isomip_plus/isomip_plus_test.py
+++ b/compass/ocean/tests/isomip_plus/isomip_plus_test.py
@@ -220,32 +220,6 @@ class IsomipPlusTest(TestCase):
                 # default to 10 vertical levels instead of 36
                 config.set('vertical_grid', 'vert_levels', '10')
 
-        for step_name in self.steps:
-            if step_name in ['ssh_adjustment', 'performance', 'simulation']:
-                step = self.steps[step_name]
-                step.ntasks = ntasks
-                step.min_tasks = min_tasks
-                step.openmp_threads = 1
-
-    def run(self):
-        """
-        Run each step of the test case
-        """
-        config = self.config
-        # get the these properties from the config options
-        for step_name in self.steps_to_run:
-            if step_name in ['ssh_adjustment', 'performance', 'simulation']:
-                step = self.steps[step_name]
-                # get the these properties from the config options
-                step.ntasks = config.getint('isomip_plus', 'forward_ntasks')
-                step.min_tasks = config.getint('isomip_plus',
-                                               'forward_min_tasks')
-                step.openmp_threads = config.getint('isomip_plus',
-                                                    'forward_threads')
-
-        # run the steps
-        super().run()
-
     def validate(self):
         """
         Perform validation of variables

--- a/compass/ocean/tests/planar_convergence/conv_test_case.py
+++ b/compass/ocean/tests/planar_convergence/conv_test_case.py
@@ -44,23 +44,6 @@ class ConvTestCase(TestCase):
 
         self.update_cores()
 
-    def run(self):
-        """
-        Run each step of the testcase
-        """
-        config = self.config
-        for resolution in self.resolutions:
-            ntasks = config.getint(f'planar_convergence',
-                                   f'{resolution}km_ntasks')
-            min_tasks = config.getint(f'planar_convergence',
-                                      f'{resolution}km_min_tasks')
-            step = self.steps['{}km_forward'.format(resolution)]
-            step.ntasks = ntasks
-            step.min_tasks = min_tasks
-
-        # run the step
-        super().run()
-
     def update_cores(self):
         """ Update the number of cores and min_tasks for each forward step """
 

--- a/compass/ocean/tests/planar_convergence/forward.py
+++ b/compass/ocean/tests/planar_convergence/forward.py
@@ -68,6 +68,14 @@ class Forward(Step):
         self.add_streams_file('compass.ocean.tests.planar_convergence',
                               'streams.template',
                               template_replacements=stream_replacements)
+        self._get_resources()
+
+    def constrain_resources(self, available_cores):
+        """
+        Update resources at runtime from config options
+        """
+        self._get_resources()
+        super().constrain_resources(available_cores)
 
     def run(self):
         """
@@ -118,3 +126,11 @@ class Forward(Step):
         stream_replacements = {'output_interval': duration}
 
         return namelist_replacements, stream_replacements
+
+    def _get_resources(self):
+        config = self.config
+        resolution = self.resolution
+        self.ntasks = config.getint(f'planar_convergence',
+                                    f'{resolution}km_ntasks')
+        self.min_tasks = config.getint(f'planar_convergence',
+                                       f'{resolution}km_min_tasks')

--- a/compass/ocean/tests/sphere_transport/correlated_tracers_2d/__init__.py
+++ b/compass/ocean/tests/sphere_transport/correlated_tracers_2d/__init__.py
@@ -57,23 +57,6 @@ class CorrelatedTracers2D(TestCase):
 
         self.update_cores()
 
-    def run(self):
-        """
-        Run each step of the testcase
-        """
-        config = self.config
-        for resolution in self.resolutions:
-            ntasks = config.getint('correlated_tracers_2d',
-                                   f'QU{resolution}_ntasks')
-            min_tasks = config.getint('correlated_tracers_2d',
-                                      f'QU{resolution}_min_tasks')
-            step = self.steps[f'QU{resolution}_forward']
-            step.ntasks = ntasks
-            step.min_tasks = min_tasks
-
-        # run the step
-        super().run()
-
     def update_cores(self):
         """ Update the number of cores and min_tasks for each forward step """
 

--- a/compass/ocean/tests/sphere_transport/correlated_tracers_2d/forward.py
+++ b/compass/ocean/tests/sphere_transport/correlated_tracers_2d/forward.py
@@ -62,6 +62,14 @@ class Forward(Step):
                                    config.get(
                                        'correlated_tracers_2d',
                                        'time_integrator')})
+        self._get_resources()
+
+    def constrain_resources(self, available_cores):
+        """
+        Update resources at runtime from config options
+        """
+        self._get_resources()
+        super().constrain_resources(available_cores)
 
     def run(self):
         """
@@ -100,3 +108,11 @@ class Forward(Step):
             dtminutes = dt / timedelta(minutes=1)
             dtstr = "00:" + str(int(dtminutes))[:2].zfill(2) + ":00"
         return dtstr
+
+    def _get_resources(self):
+        resolution = self.resolution
+        config = self.config
+        self.ntasks = config.getint('correlated_tracers_2d',
+                                    f'QU{resolution}_ntasks')
+        self.min_tasks = config.getint('correlated_tracers_2d',
+                                       f'QU{resolution}_min_tasks')

--- a/compass/ocean/tests/sphere_transport/correlated_tracers_2d/namelist.forward
+++ b/compass/ocean/tests/sphere_transport/correlated_tracers_2d/namelist.forward
@@ -1,5 +1,4 @@
 config_ocean_run_mode = 'forward'
-config_init_configuration = 'transport_tests'
 config_transport_tests_flow_id = 4
 config_run_duration = '0012_00:00:00'
 config_vert_coord_movement = 'impermeable_interfaces'

--- a/compass/ocean/tests/sphere_transport/divergent_2d/__init__.py
+++ b/compass/ocean/tests/sphere_transport/divergent_2d/__init__.py
@@ -53,23 +53,6 @@ class Divergent2D(TestCase):
 
         self.update_cores()
 
-    def run(self):
-        """
-        Run each step of the testcase
-        """
-        config = self.config
-        for resolution in self.resolutions:
-            ntasks = config.getint('divergent_2d',
-                                   f'QU{resolution}_ntasks')
-            min_tasks = config.getint('divergent_2d',
-                                      f'QU{resolution}_min_tasks')
-            step = self.steps[f'QU{resolution}_forward']
-            step.ntasks = ntasks
-            step.min_tasks = min_tasks
-
-        # run the step
-        super().run()
-
     def update_cores(self):
         """ Update the number of cores and min_tasks for each forward step """
 

--- a/compass/ocean/tests/sphere_transport/divergent_2d/forward.py
+++ b/compass/ocean/tests/sphere_transport/divergent_2d/forward.py
@@ -59,6 +59,14 @@ class Forward(Step):
         self.add_namelist_options({'config_dt': dtstr,
                                    'config_time_integrator': config.get(
                                        'divergent_2d', 'time_integrator')})
+        self._get_resources()
+
+    def constrain_resources(self, available_cores):
+        """
+        Update resources at runtime from config options
+        """
+        self._get_resources()
+        super().constrain_resources(available_cores)
 
     def run(self):
         """
@@ -97,3 +105,11 @@ class Forward(Step):
             dtminutes = dt / timedelta(minutes=1)
             dtstr = "00:" + str(int(dtminutes))[:2].zfill(2) + ":00"
         return dtstr
+
+    def _get_resources(self):
+        resolution = self.resolution
+        config = self.config
+        self.ntasks = config.getint('divergent_2d',
+                                    f'QU{resolution}_ntasks')
+        self.min_tasks = config.getint('divergent_2d',
+                                       f'QU{resolution}_min_tasks')

--- a/compass/ocean/tests/sphere_transport/divergent_2d/namelist.forward
+++ b/compass/ocean/tests/sphere_transport/divergent_2d/namelist.forward
@@ -1,5 +1,4 @@
 config_ocean_run_mode = 'forward'
-config_init_configuration = 'transport_tests'
 config_transport_tests_flow_id = 3
 config_run_duration = '0012_00:00:00'
 config_vert_coord_movement = 'impermeable_interfaces'

--- a/compass/ocean/tests/sphere_transport/nondivergent_2d/__init__.py
+++ b/compass/ocean/tests/sphere_transport/nondivergent_2d/__init__.py
@@ -55,23 +55,6 @@ class Nondivergent2D(TestCase):
 
         self.update_cores()
 
-    def run(self):
-        """
-        Run each step of the testcase
-        """
-        config = self.config
-        for resolution in self.resolutions:
-            ntasks = config.getint('nondivergent_2d',
-                                   f'QU{resolution}_ntasks')
-            min_tasks = config.getint('nondivergent_2d',
-                                      f'QU{resolution}_min_tasks')
-            step = self.steps[f'QU{resolution}_forward']
-            step.ntasks = ntasks
-            step.min_tasks = min_tasks
-
-        # run the step
-        super().run()
-
     def update_cores(self):
         """ Update the number of cores and min_tasks for each forward step """
 

--- a/compass/ocean/tests/sphere_transport/nondivergent_2d/forward.py
+++ b/compass/ocean/tests/sphere_transport/nondivergent_2d/forward.py
@@ -60,6 +60,14 @@ class Forward(Step):
         self.add_namelist_options({'config_dt': dtstr,
                                    'config_time_integrator': config.get(
                                        'nondivergent_2d', 'time_integrator')})
+        self._get_resources()
+
+    def constrain_resources(self, available_cores):
+        """
+        Update resources at runtime from config options
+        """
+        self._get_resources()
+        super().constrain_resources(available_cores)
 
     def run(self):
         """
@@ -98,3 +106,11 @@ class Forward(Step):
             dtminutes = dt / timedelta(minutes=1)
             dtstr = "00:" + str(int(dtminutes))[:2].zfill(2) + ":00"
         return dtstr
+
+    def _get_resources(self):
+        resolution = self.resolution
+        config = self.config
+        self.ntasks = config.getint('nondivergent_2d',
+                                    f'QU{resolution}_ntasks')
+        self.min_tasks = config.getint('nondivergent_2d',
+                                       f'QU{resolution}_min_tasks')

--- a/compass/ocean/tests/sphere_transport/nondivergent_2d/namelist.forward
+++ b/compass/ocean/tests/sphere_transport/nondivergent_2d/namelist.forward
@@ -1,5 +1,4 @@
 config_ocean_run_mode = 'forward'
-config_init_configuration = 'transport_tests'
 config_transport_tests_flow_id = 2
 config_run_duration = '0012_00:00:00'
 config_vert_coord_movement = 'impermeable_interfaces'

--- a/compass/ocean/tests/sphere_transport/rotation_2d/__init__.py
+++ b/compass/ocean/tests/sphere_transport/rotation_2d/__init__.py
@@ -52,23 +52,6 @@ class Rotation2D(TestCase):
 
         self.update_cores()
 
-    def run(self):
-        """
-        Run each step of the testcase
-        """
-        config = self.config
-        for resolution in self.resolutions:
-            ntasks = config.getint('rotation_2d',
-                                   f'QU{resolution}_ntasks')
-            min_tasks = config.getint('rotation_2d',
-                                      f'QU{resolution}_min_tasks')
-            step = self.steps[f'QU{resolution}_forward']
-            step.ntasks = ntasks
-            step.min_tasks = min_tasks
-
-        # run the step
-        super().run()
-
     def update_cores(self):
         """ Update the number of cores and min_tasks for each forward step """
 

--- a/compass/ocean/tests/sphere_transport/rotation_2d/forward.py
+++ b/compass/ocean/tests/sphere_transport/rotation_2d/forward.py
@@ -59,6 +59,14 @@ class Forward(Step):
         self.add_namelist_options({'config_dt': dtstr,
                                    'config_time_integrator': config.get(
                                        'rotation_2d', 'time_integrator')})
+        self._get_resources()
+
+    def constrain_resources(self, available_cores):
+        """
+        Update resources at runtime from config options
+        """
+        self._get_resources()
+        super().constrain_resources(available_cores)
 
     def run(self):
         """
@@ -97,3 +105,11 @@ class Forward(Step):
             dtminutes = dt / timedelta(minutes=1)
             dtstr = "00:" + str(int(dtminutes))[:2].zfill(2) + ":00"
         return dtstr
+
+    def _get_resources(self):
+        resolution = self.resolution
+        config = self.config
+        self.ntasks = config.getint('rotation_2d',
+                                    f'QU{resolution}_ntasks')
+        self.min_tasks = config.getint('rotation_2d',
+                                       f'QU{resolution}_min_tasks')

--- a/compass/ocean/tests/sphere_transport/rotation_2d/namelist.forward
+++ b/compass/ocean/tests/sphere_transport/rotation_2d/namelist.forward
@@ -1,5 +1,4 @@
 config_ocean_run_mode = 'forward'
-config_init_configuration = 'transport_tests'
 config_transport_tests_flow_id = 1
 config_run_duration = '0012_00:00:00'
 config_vert_coord_movement = 'impermeable_interfaces'

--- a/compass/ocean/tests/tides/forward/forward.py
+++ b/compass/ocean/tests/tides/forward/forward.py
@@ -72,12 +72,24 @@ class ForwardStep(Step):
         Set up the test case in the work directory, including downloading any
         dependencies
         """
-        self.ntasks = self.config.getint('tides', 'forward_ntasks')
-        self.min_tasks = self.config.getint('tides', 'forward_min_tasks')
-        self.threads = self.config.getint('tides', 'forward_threads')
+        self._get_resources()
+
+    def constrain_resources(self, available_cores):
+        """
+        Update resources at runtime from config options
+        """
+        self._get_resources()
+        super().constrain_resources(available_cores)
 
     def run(self):
         """
         Run this step of the testcase
         """
         run_model(self)
+
+    def _get_resources(self):
+        # get the these properties from the config options
+        config = self.config
+        self.ntasks = config.getint('tides', 'forward_ntasks')
+        self.min_tasks = config.getint('tides', 'forward_min_tasks')
+        self.openmp_threads = config.getint('tides', 'forward_threads')

--- a/compass/ocean/tests/tides/init/initial_state.py
+++ b/compass/ocean/tests/tides/init/initial_state.py
@@ -85,14 +85,17 @@ class InitialState(Step):
 
     def setup(self):
         """
-        Set up the test case in the work directory, including downloading any
-        dependencies.
+        Get resources at setup from config options
         """
-        # get the these properties from the config options
-        config = self.config
-        self.ntasks = config.getint('tides', 'init_ntasks')
-        self.min_tasks = config.getint('tides', 'init_min_tasks')
-        self.threads = config.getint('tides', 'init_threads')
+        self._get_resources()
+
+
+    def constrain_resources(self, available_cores):
+        """
+        Update resources at runtime from config options
+        """
+        self._get_resources()
+        super().constrain_resources(available_cores)
 
     def run(self):
         """
@@ -119,3 +122,10 @@ class InitialState(Step):
         init["layerThickness"][0, :, 0] = init["bottomDepth"][:]
         init["restingThickness"][:, 0] = init["bottomDepth"][:]
         init.close()
+
+    def _get_resources(self):
+        # get the these properties from the config options
+        config = self.config
+        self.ntasks = config.getint('tides', 'init_ntasks')
+        self.min_tasks = config.getint('tides', 'init_min_tasks')
+        self.openmp_threads = config.getint('tides', 'init_threads')

--- a/compass/run/serial.py
+++ b/compass/run/serial.py
@@ -431,6 +431,15 @@ def _run_step(test_case, step, new_log_file):
                         log_filename=log_filename) as step_logger:
         step.logger = step_logger
         os.chdir(step.work_dir)
+
+        # runtime_setup() will perform small tasks that require knowing the
+        # resources of the task before the step runs (such as creating
+        # graph partitions)
+        step_logger.info('')
+        log_method_call(method=step.runtime_setup, logger=step_logger)
+        step_logger.info('')
+        step.runtime_setup()
+
         step_logger.info('')
         log_method_call(method=step.run, logger=step_logger)
         step_logger.info('')


### PR DESCRIPTION
This merge drops calls to `Testcase.run()` and instead override `step.constrain_resources()` in individual steps.

We have deprecated `Testcase.run()` because its use is not compatible with the task parallelism approach we (@altheaden and I) are developing.  Instead, the individual steps in a test case that need to set the number of tasks or cpus per task should override `constrain_resources()`, set `self.ntasks`, `self.min_tasks`, etc., and then call `super().constrian_resources()`.

In the near future (again related to task parallelism), it will also be useful to override `step.runtime_setup()` for tasks like creating graph partitions before running an MPAS component.  In anticipation of this change and to be consistent with the deprecation warning about `Testcase.run()`, this merge adds a call to `runtime_setup()` when a step gets run.  Currently, no steps override this function.

<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->

<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [x] Developer's Guide has been updated
* [x] API documentation in the Developer's Guide (`api.rst`) has any new or modified class, method and/or functions listed
* [x] Document (in a comment titled `Testing` in this PR) any testing that was used to verify the changes

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->
