### PR TITLE
Remove critical passages stream for tides init

### DIFF
--- a/compass/ocean/tests/tides/init/streams.init
+++ b/compass/ocean/tests/tides/init/streams.init
@@ -92,14 +92,5 @@
     <var name="xtime"/>
 </stream>
 
-<stream name="critical_passages"
-        filename_template="critical_passages.nc"
-        input_interval="initial_only"
-        type="input">
-
-    <var name="transectCellMasks"/>
-    <var name="depthTransects"/>
-</stream>
-
 </streams>
 


### PR DESCRIPTION
This addresses errors in the tides initial_state step related to an unused critical_passages stream. 

Checklist
* [ ] Document (in a comment titled `Testing` in this PR) any testing that was used to verify the changes

Fixes #483 
