### PR TITLE
Remove xtime variable from ocean climatology

### DIFF
--- a/compass/landice/tests/ismip6_forcing/ocean_thermal/process_thermal_forcing.py
+++ b/compass/landice/tests/ismip6_forcing/ocean_thermal/process_thermal_forcing.py
@@ -213,8 +213,6 @@ class ProcessThermalForcing(Step):
             ismip6_to_mali_dims = dict(
                 z="nISMIP6OceanLayers",
                 ncol="nCells")
-            ds["xtime"] = ("Time", ["2015-01-01_00:00:00".ljust(64)])
-            ds["xtime"] = ds.xtime.astype("S")
             ds["thermal_forcing"] = ds["thermal_forcing"].expand_dims(
                 dim="Time", axis=0)
             ds = ds.rename(ismip6_to_mali_dims)


### PR DESCRIPTION
This PR address the issue created by @trhille (https://github.com/MPAS-Dev/compass/issues/463) on having the `xtime` variable in the processed ocean climatology thermal forcing file in the `ismip6_forcing` landice test group. 

closes #463