### PR TITLE
Update shapely, geometric_features and mpas_tools

### DIFF
--- a/conda/compass_env/spec-file.template
+++ b/conda/compass_env/spec-file.template
@@ -8,7 +8,7 @@ cartopy_offlinedata
 cmocean
 esmf=*={{ mpi_prefix }}_*
 ffmpeg
-geometric_features=0.7.0
+geometric_features=1.0.1
 git
 ipython
 jigsaw=0.9.14
@@ -18,7 +18,7 @@ lxml
 mache=1.9.0
 matplotlib-base
 metis
-mpas_tools=0.15.0
+mpas_tools=0.17.0
 nco
 netcdf4=*=nompi_*
 numpy
@@ -31,7 +31,7 @@ pyproj
 pyremap>=0.0.13,<0.1.0
 requests
 scipy>=1.8.0
-shapely>=1.8.0,<2.0.0
+shapely>=2.0,<3.0
 xarray
 
 # Development

--- a/conda/recipe/meta.yaml
+++ b/conda/recipe/meta.yaml
@@ -45,7 +45,7 @@ requirements:
     - cmocean
     - esmf * {{ mpi_prefix }}_*
     - ffmpeg
-    - geometric_features 0.7.0
+    - geometric_features 1.0.1
     - git
     - ipython
     - jigsaw 0.9.14
@@ -55,7 +55,7 @@ requirements:
     - mache 1.9.0
     - matplotlib-base
     - metis
-    - mpas_tools 0.15.0
+    - mpas_tools 0.17.0
     - nco
     - netcdf4 * nompi_*
     - numpy
@@ -66,7 +66,7 @@ requirements:
     - pyremap >=0.0.13,<0.1.0
     - requests
     - scipy >=1.8.0
-    - shapely >=1.8.0,<2.0.0
+    - shapely >=2.0,<3.0
     - xarray
 
 # tools for building MPAS components


### PR DESCRIPTION
New versions are needed to support shapely >=2.0

The only code in compass itself that uses shapely is for generating MISOMIP output from the `isomip_plus` test cases.  As this is rarely used, a considerable amount of work to test, and the calls did not look likely to be affected by the change in shapely, I will not test that part of the code here.

<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->

<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [x] Documentation has been [built locally](https://mpas-dev.github.io/compass/latest/developers_guide/building_docs.html) and changes look as expected
* [x] Document (in a comment titled `Testing` in this PR) any testing that was used to verify the changes

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->
