### PR TITLE
Replace deprecated `importlib.resources.path()` call

### DIFF
--- a/conda/bootstrap.py
+++ b/conda/bootstrap.py
@@ -11,7 +11,7 @@ import grp
 import shutil
 import progressbar
 from jinja2 import Template
-from importlib.resources import path
+import importlib.resources
 from configparser import ConfigParser
 
 from mache import discover_machine, MachineInfo
@@ -30,8 +30,9 @@ def get_config(config_file, machine):
 
     if machine is not None:
         if not machine.startswith('conda'):
-            with path('mache.machines', f'{machine}.cfg') as machine_config:
-                config.read(str(machine_config))
+            machine_config = \
+                importlib.resources.files('mache.machines') / f'{machine}.cfg'
+            config.read(str(machine_config))
 
         machine_config = os.path.join(here, '..', 'compass', 'machines',
                                       '{}.cfg'.format(machine))


### PR DESCRIPTION
<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->

<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [ ] Document (in a comment titled `Testing` in this PR) any testing that was used to verify the changes

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->
