### PR TITLE
Update to compass v1.2.0-alpha.4 and mache v1.10.0 

### DIFF
--- a/compass/version.py
+++ b/compass/version.py
@@ -1,1 +1,1 @@
-__version__ = '1.2.0-alpha.3'
+__version__ = '1.2.0-alpha.4'

--- a/conda/albany_supported.txt
+++ b/conda/albany_supported.txt
@@ -1,6 +1,5 @@
 # a list of supported machine, compiler and mpi combinations for Albany
 
-anvil, gnu, mvapich
 anvil, gnu, openmpi
 chrysalis, gnu, openmpi
 compy, gnu, openmpi

--- a/conda/bootstrap.py
+++ b/conda/bootstrap.py
@@ -392,7 +392,7 @@ def build_spack_env(config, update_spack, machine, compiler, mpi, spack_env,
         specs.append(f'scorpio@{scorpio}+pnetcdf~timing+internal-timing~tools+malloc')
 
     if albany != 'None':
-        specs.append(f'albany@{albany}+mpas')
+        specs.append(f'albany@{albany}+mpas+cxx17')
 
     yaml_template = f'{spack_template_path}/{machine}_{compiler}_{mpi}.yaml'
     if not os.path.exists(yaml_template):

--- a/conda/bootstrap.py
+++ b/conda/bootstrap.py
@@ -354,7 +354,7 @@ def get_env_vars(machine, compiler, mpilib):
 
 
 def build_spack_env(config, update_spack, machine, compiler, mpi, spack_env,
-                    spack_base, spack_template_path, env_vars, tmpdir):
+                    spack_base, spack_template_path, env_vars, tmpdir, logger):
 
     albany = config.get('deploy', 'albany')
     esmf = config.get('deploy', 'esmf')
@@ -412,6 +412,7 @@ def build_spack_env(config, update_spack, machine, compiler, mpi, spack_env,
             files = glob.glob(os.path.join(include_path, f'{prefix}*'))
             for filename in files:
                 os.remove(filename)
+        set_ld_library_path(spack_branch_base, spack_env, logger)
 
     spack_script = get_spack_script(
         spack_path=spack_branch_base, env_name=spack_env, compiler=compiler,
@@ -458,6 +459,15 @@ def build_spack_env(config, update_spack, machine, compiler, mpi, spack_env,
                    f'export USE_PETSC=true\n'
 
     return spack_branch_base, spack_script, env_vars
+
+
+def set_ld_library_path(spack_branch_base, spack_env, logger):
+    commands = \
+        f'source {spack_branch_base}/share/spack/setup-env.sh; ' \
+        f'spack env activate {spack_env}; ' \
+        f'spack config add modules:prefix_inspections:lib:[LD_LIBRARY_PATH]; ' \
+        f'spack config add modules:prefix_inspections:lib64:[LD_LIBRARY_PATH]'
+    check_call(commands, logger=logger)
 
 
 def write_load_compass(template_path, activ_path, conda_base, env_type,
@@ -863,7 +873,7 @@ def main():
                 spack_branch_base, spack_script, env_vars = build_spack_env(
                     config, args.update_spack, machine, compiler, mpi,
                     spack_env, spack_base, spack_template_path, env_vars,
-                    args.tmpdir)
+                    args.tmpdir, logger)
                 spack_script = f'echo Loading Spack environment...\n' \
                                f'{spack_script}\n' \
                                f'echo Done.\n' \

--- a/conda/compass_env/spec-file.template
+++ b/conda/compass_env/spec-file.template
@@ -15,7 +15,7 @@ jigsaw=0.9.14
 jigsawpy=0.3.3
 jupyter
 lxml
-mache=1.9.0
+mache=1.10.0
 matplotlib-base
 metis
 mpas_tools=0.17.0

--- a/conda/configure_compass_env.py
+++ b/conda/configure_compass_env.py
@@ -53,7 +53,7 @@ def setup_install_env(env_name, activate_base, use_local, logger, recreate,
         channels = '--use-local'
     else:
         channels = ''
-    packages = 'progressbar2 jinja2 "mache=1.9.0"'
+    packages = 'progressbar2 jinja2 "mache=1.10.0"'
     if recreate or not os.path.exists(env_path):
         print('Setting up a conda environment for installing compass\n')
         commands = '{}; ' \

--- a/conda/recipe/meta.yaml
+++ b/conda/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "compass" %}
-{% set version = "1.2.0alpha.3" %}
+{% set version = "1.2.0alpha.4" %}
 {% set build = 0 %}
 
 {% if mpi == "nompi" %}
@@ -52,7 +52,7 @@ requirements:
     - jigsawpy 0.3.3
     - jupyter
     - lxml
-    - mache 1.9.0
+    - mache 1.10.0
     - matplotlib-base
     - metis
     - mpas_tools 0.17.0

--- a/conda/unsupported.txt
+++ b/conda/unsupported.txt
@@ -3,9 +3,15 @@
 # no spack available
 anvil, gnu, impi
 chrysalis, gnu, impi
+chrysalis, oneapi-ifx, openmpi
+chrysalis, oneapi-ifx, impi
 compy, intel, mvapich2
 compy, pgi, impi
 compy, pgi, mvapich2
+pm-cpu, nvidia, mpich
+pm-cpu, aocc, mpich
+pm-cpu, amdclang, mpich
+
 
 # compiles but tests unreliable (errors or hanging),
 # see https://github.com/MPAS-Dev/compass/issues/336

--- a/docs/developers_guide/machines/cori.rst
+++ b/docs/developers_guide/machines/cori.rst
@@ -16,7 +16,7 @@ Then, you can build the MPAS model with
 
 .. code-block:: bash
 
-    make [DEBUG=true] [OPENMP=true] intel-nersc
+    make [DEBUG=true] [OPENMP=true] intel-cray
 
 cori-haswell, gnu
 -----------------
@@ -31,4 +31,4 @@ Then, you can build the MPAS model with
 
 .. code-block:: bash
 
-    make [DEBUG=true] [OPENMP=true] [ALBANY=true] gnu-nersc
+    make [DEBUG=true] [OPENMP=true] [ALBANY=true] gnu-cray

--- a/docs/developers_guide/machines/index.rst
+++ b/docs/developers_guide/machines/index.rst
@@ -61,11 +61,11 @@ the MPAS model.
 |              +------------+-----------+-------------------+
 |              | gnu        | openmpi   | gfortran          |
 +--------------+------------+-----------+-------------------+
-| cori-haswell | intel      | mpt       | intel-nersc       |
+| cori-haswell | intel      | mpt       | intel-cray        |
 |              +------------+-----------+-------------------+
-|              | gnu        | mpt       | gnu-nersc         |
+|              | gnu        | mpt       | gnu-cray          |
 +--------------+------------+-----------+-------------------+
-| pm-cpu       | gnu        | mpich     | gnu-nersc         |
+| pm-cpu       | gnu        | mpich     | gnu-cray          |
 +--------------+------------+-----------+-------------------+
 
 Below are specifics for each supported machine

--- a/docs/developers_guide/machines/perlmutter.rst
+++ b/docs/developers_guide/machines/perlmutter.rst
@@ -15,4 +15,4 @@ Then, you can build the MPAS model with
 
 .. code-block:: bash
 
-    make [DEBUG=true] gnu-nersc
+    make [DEBUG=true] gnu-cray

--- a/docs/users_guide/machines/anvil.rst
+++ b/docs/users_guide/machines/anvil.rst
@@ -105,7 +105,7 @@ variables:
 
 .. code-block:: bash
 
-    source /lcrc/soft/climate/compass/anvil/load_latest_compass_gnu_mvapich.sh
+    source /lcrc/soft/climate/compass/anvil/load_latest_compass_gnu_openmpi.sh
 
 To build the MPAS model with
 

--- a/docs/users_guide/machines/cori.rst
+++ b/docs/users_guide/machines/cori.rst
@@ -138,7 +138,7 @@ To build the MPAS model with
 
 .. code-block:: bash
 
-    make [DEBUG=true] [OPENMP=true] intel-nersc
+    make [DEBUG=true] [OPENMP=true] intel-cray
 
 
 Gnu on Cori-Haswell
@@ -155,7 +155,7 @@ To build the MPAS model with
 
 .. code-block:: bash
 
-    make [DEBUG=true] [OPENMP=true] [ALBANY=true] gnu-nersc
+    make [DEBUG=true] [OPENMP=true] [ALBANY=true] gnu-cray
 
 
 Jupyter notebook on remote data

--- a/docs/users_guide/machines/perlmutter.rst
+++ b/docs/users_guide/machines/perlmutter.rst
@@ -152,7 +152,7 @@ To build the MPAS model with
 
 .. code-block:: bash
 
-    make [DEBUG=true] [OPENMP=true] [ALBANY=true] gnu-nersc
+    make [DEBUG=true] [OPENMP=true] [ALBANY=true] gnu-cray
 
 
 Jupyter notebook on remote data

--- a/utils/matrix/setup_matrix.py
+++ b/utils/matrix/setup_matrix.py
@@ -36,10 +36,10 @@ all_build_targets = {
         ('intel', 'impi'): 'intel-mpi',
         ('gnu', 'openmpi'): 'gfortran'},
     'cori-haswell': {
-        ('intel', 'mpt'): 'intel-nersc',
-        ('gnu', 'mpt'): 'gnu-nersc'},
+        ('intel', 'mpt'): 'intel-cray',
+        ('gnu', 'mpt'): 'gnu-cray'},
     'pm-cpu': {
-        ('gnu', 'mpich'): 'gnu-nersc'},
+        ('gnu', 'mpich'): 'gnu-cray'},
     'conda-linux': {
         ('gfortran', 'mpich'): 'gfortran',
         ('gfortran', 'openmpi'): 'gfortran'},


### PR DESCRIPTION
<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->

<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [x] User's Guide has been updated
* [x] Developer's Guide has been updated
* [x] Documentation has been [built locally](https://mpas-dev.github.io/compass/latest/developers_guide/building_docs.html) and changes look as expected
* [x] Document (in a comment titled `Testing` in this PR) any testing that was used to verify the changes

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->

## Testing

Spack builds tested:
- [x] Anvil
  - [x] No extras - hanging tests reported in #499 
  - [x] Albany - MVAPICH environment manually fixed to address https://github.com/E3SM-Project/mache/issues/92 but getting seg faults in several tests so disabling
  - [x] PETSc
- [x] Chrysalis
  - [x] No extras - failing/hanging tests reported in #499 and #500
  - [x] Albany
  - [x] PETSc - Intel works but gnu fails to build as documented in #498
- [x] Compy
  - [x] No extras - one test is failing on Intel as reported in #502; All tests failing for Gnu as reported in #503
  - [ ] ~~Albany~~ - MALI fails to run with Gnu on Compy, see https://github.com/MALI-Dev/E3SM/issues/63
  - [x] PETSc  - Intel works but gnu fails to build as documented in #498
- [x] Cori
  - [x] No extras
  - [x] Albany
  - [x] PETSc - gnu fails to build as documented in #498 
- [x] Perlmutter
  - [x] No extras
  - [x] Albany
  - [ ] ~~PETSc~~ failing to build as documented in #498 
