### PR TITLE
Fix handling of ntasks = 1 for single node

### DIFF
--- a/compass/parallel.py
+++ b/compass/parallel.py
@@ -151,8 +151,7 @@ def run_command(args, cpus_per_task, ntasks, openmp_threads, config, logger):
     if parallel_system == 'slurm':
         command_line_args.extend(['-c', f'{cpus_per_task}', '-n', f'{ntasks}'])
     elif parallel_system == 'single_node':
-        if ntasks > 1:
-            command_line_args.extend(['-n', f'{ntasks}'])
+        command_line_args.extend(['-n', f'{ntasks}'])
     else:
         raise ValueError(f'Unexpected parallel system: {parallel_system}')
 


### PR DESCRIPTION
Omitting `-n 1` (as was done previously) means the step runs on all cores, not just 1.

<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->

<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [ ] Document (in a comment titled `Testing` in this PR) any testing that was used to verify the changes

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->
closes #507 
