### PR TITLE
Update conda pnetcdf and scorpio versions

### DIFF
--- a/conda/bootstrap.py
+++ b/conda/bootstrap.py
@@ -886,8 +886,10 @@ def main():
                                f'echo Done.\n' \
                                f'echo\n'
             else:
-                env_vars = f'{env_vars}' \
-                           f'export PIO={conda_env_path}\n'
+                env_vars = \
+                    f'{env_vars}' \
+                    f'export PIO={conda_env_path}\n' \
+                    f'export OPENMP_INCLUDE=-I"{conda_env_path}/include"\n'
         else:
             env_vars = ''
 

--- a/conda/bootstrap.py
+++ b/conda/bootstrap.py
@@ -268,8 +268,15 @@ def build_conda_env(env_type, recreate, machine, mpi, conda_mpi, version,
 
     if env_type == 'dev':
         supports_otps = platform.system() == 'Linux'
+        if platform.system() == 'Linux':
+            conda_openmp = 'libgomp'
+        elif platform.system() == 'Darwin':
+            conda_openmp = 'llvm-openmp'
+        else:
+            conda_openmp = ''
         spec_file = template.render(supports_otps=supports_otps,
-                                    mpi=conda_mpi, mpi_prefix=mpi_prefix)
+                                    mpi=conda_mpi, openmp=conda_openmp,
+                                    mpi_prefix=mpi_prefix)
 
         spec_filename = f'spec-file-{conda_mpi}.txt'
         with open(spec_filename, 'w') as handle:

--- a/conda/compass_env/spec-file.template
+++ b/conda/compass_env/spec-file.template
@@ -43,8 +43,8 @@ cmake
 cxx-compiler
 fortran-compiler
 libnetcdf=4.8.1={{ mpi_prefix }}_*
-libpnetcdf=1.12.2={{ mpi_prefix }}_*
-scorpio=1.3.2={{ mpi_prefix }}_*
+libpnetcdf=1.12.3={{ mpi_prefix }}_*
+scorpio=1.4.1={{ mpi_prefix }}_*
 m4
 make
 {{ mpi }}

--- a/conda/compass_env/spec-file.template
+++ b/conda/compass_env/spec-file.template
@@ -48,6 +48,7 @@ scorpio=1.4.1={{ mpi_prefix }}_*
 m4
 make
 {{ mpi }}
+{{ openmp }}
 netcdf-fortran
 {% endif %}
 

--- a/conda/otps/ci/linux.yaml
+++ b/conda/otps/ci/linux.yaml
@@ -9,6 +9,6 @@ docker_image:
 fortran_compiler:
 - gfortran
 fortran_compiler_version:
-- '10'
+- '11'
 target_platform:
 - linux-64

--- a/conda/pnetcdf/ci/linux_mpi_mpich.yaml
+++ b/conda/pnetcdf/ci/linux_mpi_mpich.yaml
@@ -1,25 +1,32 @@
 c_compiler:
 - gcc
 c_compiler_version:
-- '10'
-cdt_name:
-- cos6
+- '11'
 channel_sources:
-- conda-forge,defaults
+- conda-forge
 channel_targets:
 - e3sm main
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '10'
+- '11'
+fortran_compiler:
+- gfortran
+fortran_compiler_version:
+- '11'
 hdf5:
 - 1.12.2
 libnetcdf:
 - 4.8.1
 mpi:
 - mpich
+mpich:
+- '4'
+netcdf_fortran:
+- '4.6'
 target_platform:
 - linux-64
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
+  - fortran_compiler_version

--- a/conda/pnetcdf/ci/linux_mpi_openmpi.yaml
+++ b/conda/pnetcdf/ci/linux_mpi_openmpi.yaml
@@ -1,25 +1,32 @@
 c_compiler:
 - gcc
 c_compiler_version:
-- '10'
-cdt_name:
-- cos6
+- '11'
 channel_sources:
-- conda-forge,defaults
+- conda-forge
 channel_targets:
 - e3sm main
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '10'
+- '11'
+fortran_compiler:
+- gfortran
+fortran_compiler_version:
+- '11'
 hdf5:
 - 1.12.2
 libnetcdf:
 - 4.8.1
 mpi:
 - openmpi
+netcdf_fortran:
+- '4.6'
+openmpi:
+- '4'
 target_platform:
 - linux-64
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
+  - fortran_compiler_version

--- a/conda/pnetcdf/ci/osx_mpi_mpich.yaml
+++ b/conda/pnetcdf/ci/osx_mpi_mpich.yaml
@@ -10,14 +10,23 @@ cxx_compiler:
 - clangxx
 cxx_compiler_version:
 - '11'
+fortran_compiler:
+- gfortran
+fortran_compiler_version:
+- '11'
 hdf5:
 - 1.12.2
 libnetcdf:
 - 4.8.1
 mpi:
 - mpich
+mpich:
+- '4'
+netcdf_fortran:
+- '4.6'
 target_platform:
 - osx-64
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
+  - fortran_compiler_version

--- a/conda/pnetcdf/ci/osx_mpi_openmpi.yaml
+++ b/conda/pnetcdf/ci/osx_mpi_openmpi.yaml
@@ -10,14 +10,24 @@ cxx_compiler:
 - clangxx
 cxx_compiler_version:
 - '11'
+fortran_compiler:
+- gfortran
+fortran_compiler_version:
+- '11'
 hdf5:
 - 1.12.2
 libnetcdf:
 - 4.8.1
 mpi:
 - openmpi
+netcdf_fortran:
+- '4.6'
+openmpi:
+- '4'
 target_platform:
 - osx-64
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
+  - fortran_compiler_version
+

--- a/conda/pnetcdf/recipe/build.sh
+++ b/conda/pnetcdf/recipe/build.sh
@@ -1,17 +1,21 @@
 #!/bin/bash
 
+set -xe
+
 export MPICC=mpicc
 export MPICXX=mpicxx
 export MPIF77=mpifort
 export MPIF90=mpifort
 
 ./configure --prefix=${PREFIX} \
-    --with-netcdf4=${PREFIX}
+    --with-netcdf4=${PREFIX} \
+    --enable-shared=yes \
+    --enable-static=no
 
 make
 # serial tests
-# make check
+make check
 # lighter weight parallel tests (4 MPI tasks)
-# make ptest
+make ptest
 
 make install

--- a/conda/pnetcdf/recipe/conda_build_config.yaml
+++ b/conda/pnetcdf/recipe/conda_build_config.yaml
@@ -2,7 +2,3 @@ mpi:
   - openmpi
   - mpich
 
-pin_run_as_build:
-  openmpi: x.x
-  mpich: x.x
-

--- a/conda/pnetcdf/recipe/meta.yaml
+++ b/conda/pnetcdf/recipe/meta.yaml
@@ -1,5 +1,5 @@
-{% set version = "1.12.2" %}
-{% set build = 6 %}
+{% set version = "1.12.3" %}
+{% set build = 0 %}
 
 # recipe-lint fails if mpi is undefined
 {% set mpi = mpi or 'mpich' %}
@@ -14,35 +14,29 @@ package:
 
 source:
   url: https://parallel-netcdf.github.io/Release/pnetcdf-{{ version }}.tar.gz
-  sha256: 3ef1411875b07955f519a5b03278c31e566976357ddfc74c2493a1076e7d7c74
+  sha256: 439e359d09bb93d0e58a6e3f928f39c2eae965b6c97f64e67cd42220d6034f77
 
 build:
   number: {{ build }}
   skip: True  # [win]
   {% set mpi_prefix = "mpi_" + mpi %}
-  # add build string so packages can depend on
-  # mpi variants
-  # dependencies:
+  # add build string so packages can depend on mpi variants dependencies:
   # `PKG_NAME * mpi_mpich_*` for mpich
   # `PKG_NAME * mpi_*` for any mpi
-  string: "{{ mpi_prefix }}_h{{ PKG_HASH }}_{{ build }}"
-
-  # mpi builds require the right mpi
-  {% set build_pin = mpi_prefix + '_*' %}
+  string: {{ mpi_prefix }}_h{{ PKG_HASH }}_{{ build }}
 
   run_exports:
-    - {{ pin_subpackage('libpnetcdf', max_pin='x.x.x.x') }} {{ build_pin }}
+    - {{ pin_subpackage('libpnetcdf', max_pin='x.x.x') }} {{ mpi_prefix }}_*
+  ignore_run_exports_from:
+    - netcdf-fortran
 
 requirements:
   build:
-    - cmake
-    - make
-    - m4
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
     - {{ compiler('fortran') }}
-    - llvm-openmp  # [osx]
-    - libgomp      # [linux]
+    - m4
+    - make
   host:
     - {{ mpi }}
     # these need to be listed twice so conda build picks up the pins
@@ -52,17 +46,12 @@ requirements:
     - libnetcdf * {{ mpi_prefix }}_*
     - netcdf-fortran
     - netcdf-fortran * {{ mpi_prefix }}_*
-  run:
-    - {{ mpi }}
-    - hdf5 * {{ mpi_prefix }}_*
-    - libnetcdf * {{ mpi_prefix }}_*
-    - netcdf-fortran * {{ mpi_prefix }}_*
 
 test:
   commands:
     - pnetcdf-config --all
-    - test -f ${PREFIX}/lib/libpnetcdf.a
-    #- test -f ${PREFIX}/lib/libpnetcdf${SHLIB_EXT}
+    - test ! -f ${PREFIX}/lib/libpnetcdf.a
+    - test -f ${PREFIX}/lib/libpnetcdf${SHLIB_EXT}
 
 about:
   home: https://parallel-netcdf.github.io/

--- a/conda/scorpio/ci/linux_mpi_mpich.yaml
+++ b/conda/scorpio/ci/linux_mpi_mpich.yaml
@@ -1,27 +1,32 @@
 c_compiler:
 - gcc
 c_compiler_version:
-- '10'
-cdt_name:
-- cos6
+- '11'
 channel_sources:
-- conda-forge,defaults,e3sm
+- conda-forge,e3sm
 channel_targets:
 - e3sm main
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '10'
-hdf5:
-- 1.12.2
+- '11'
+fortran_compiler:
+- gfortran
+fortran_compiler_version:
+- '11'
 libnetcdf:
 - 4.8.1
 libpnetcdf:
-- 1.12.2
+- 1.12.3
 mpi:
 - mpich
+mpich:
+- '4'
+netcdf_fortran:
+- '4.6'
 target_platform:
 - linux-64
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
+  - fortran_compiler_version

--- a/conda/scorpio/ci/linux_mpi_openmpi.yaml
+++ b/conda/scorpio/ci/linux_mpi_openmpi.yaml
@@ -1,27 +1,32 @@
 c_compiler:
 - gcc
 c_compiler_version:
-- '10'
-cdt_name:
-- cos6
+- '11'
 channel_sources:
-- conda-forge,defaults,e3sm
+- conda-forge,e3sm
 channel_targets:
 - e3sm main
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '10'
-hdf5:
-- 1.12.2
+- '11'
+fortran_compiler:
+- gfortran
+fortran_compiler_version:
+- '11'
 libnetcdf:
 - 4.8.1
 libpnetcdf:
-- 1.12.2
+- 1.12.3
 mpi:
 - openmpi
+netcdf_fortran:
+- '4.6'
+openmpi:
+- '4'
 target_platform:
 - linux-64
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
+  - fortran_compiler_version

--- a/conda/scorpio/ci/osx_mpi_mpich.yaml
+++ b/conda/scorpio/ci/osx_mpi_mpich.yaml
@@ -10,16 +10,23 @@ cxx_compiler:
 - clangxx
 cxx_compiler_version:
 - '11'
-hdf5:
-- 1.12.2
+fortran_compiler:
+- gfortran
+fortran_compiler_version:
+- '11'
 libnetcdf:
 - 4.8.1
 libpnetcdf:
-- 1.12.2
+- 1.12.3
 mpi:
 - mpich
+mpich:
+- '4'
+netcdf_fortran:
+- '4.6'
 target_platform:
 - osx-64
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
+  - fortran_compiler_version

--- a/conda/scorpio/ci/osx_mpi_openmpi.yaml
+++ b/conda/scorpio/ci/osx_mpi_openmpi.yaml
@@ -10,16 +10,23 @@ cxx_compiler:
 - clangxx
 cxx_compiler_version:
 - '11'
-hdf5:
-- 1.12.2
+fortran_compiler:
+- gfortran
+fortran_compiler_version:
+- '11'
 libnetcdf:
 - 4.8.1
 libpnetcdf:
-- 1.12.2
+- 1.12.3
 mpi:
 - openmpi
+netcdf_fortran:
+- '4.6'
+openmpi:
+- '4'
 target_platform:
 - osx-64
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
+  - fortran_compiler_version

--- a/conda/scorpio/recipe/build.sh
+++ b/conda/scorpio/recipe/build.sh
@@ -1,27 +1,31 @@
 #!/bin/bash
 
-export NETCDF_C_PATH=$(dirname $(dirname $(which nc-config)))
-export NETCDF_FORTRAN_PATH=$(dirname $(dirname $(which nf-config)))
-export PNETCDF_PATH=$(dirname $(dirname $(which pnetcdf-config)))
+set -xe
 
 mkdir build
 cd build
-# turning TESTS off temporarily because of a bug in 1.3.2
+
+echo CMAKE_ARGS: ${CMAKE_ARGS}
+
 FC=mpifort CC=mpicc CXX=mpicxx cmake \
+    -DCMAKE_BUILD_TYPE=Release \
     -DCMAKE_INSTALL_PREFIX=$PREFIX \
+    -DBUILD_SHARED_LIBS:BOOL=ON \
     -DPIO_USE_MALLOC:BOOL=ON \
     -DPIO_ENABLE_TOOLS:BOOL=OFF \
-    -DPIO_ENABLE_TESTS:BOOL=OFF \
+    -DPIO_ENABLE_TESTS:BOOL=ON \
     -DPIO_ENABLE_EXAMPLES:BOOL=OFF \
     -DPIO_ENABLE_TIMING:BOOL=OFF \
-    -DPIO_ENABLE_INTERNAL_TIMING:BOOL=ON \
-    -DNetCDF_C_PATH=$NETCDF_C_PATH \
-    -DNetCDF_Fortran_PATH=$NETCDF_FORTRAN_PATH \
-    -DPnetCDF_PATH=$PNETCDF_PATH ..
+    -DWITH_HDF5:BOOL=OFF \
+    -DWITH_NETCDF:BOOL=ON \
+    -DWITH_PNETCDF:BOOL=ON \
+    -DNetCDF_C_PATH=$PREFIX \
+    -DNetCDF_Fortran_PATH=$PREFIX \
+    -DPnetCDF_PATH=$PREFIX \
+    ${SRC_DIR}
 
-make
+cmake --build .
 
-# make tests
-# ctest
+ctest --output-on-failure
 
-make install
+cmake --install .

--- a/conda/scorpio/recipe/conda_build_config.yaml
+++ b/conda/scorpio/recipe/conda_build_config.yaml
@@ -1,8 +1,3 @@
 mpi:
   - openmpi
   - mpich
-
-pin_run_as_build:
-  openmpi: x.x
-  mpich: x.x
-

--- a/conda/scorpio/recipe/meta.yaml
+++ b/conda/scorpio/recipe/meta.yaml
@@ -1,5 +1,5 @@
-{% set version = "1.3.2" %}
-{% set build = 1 %}
+{% set version = "1.4.1" %}
+{% set build = 0 %}
 
 # recipe-lint fails if mpi is undefined
 {% set mpi = mpi or 'mpich' %}
@@ -14,7 +14,7 @@ package:
 
 source:
   url: https://github.com/E3SM-Project/scorpio/archive/refs/tags/scorpio-v{{ version }}.tar.gz
-  sha256: 663805fa24e85c88509ecd7893264e3d7d2ff27efb304e0f75dd1f0c450b08a6
+  sha256: 7cb4589410080d7e547ef17ddabe68f749e6af019c1d0e6ee9f11554f3ff6b1a
 
 build:
   number: {{ build }}
@@ -36,34 +36,27 @@ build:
 requirements:
   build:
     - cmake
-    - make
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
     - {{ compiler('fortran') }}
-    - llvm-openmp  # [osx]
-    - libgomp      # [linux]
+    - gnuconfig
+    - make
   host:
     - {{ mpi }}
     # these need to be listed twice so conda build picks up the pins
-    - hdf5
-    - hdf5 * {{ mpi_prefix }}_*
     - libnetcdf
     - libnetcdf * {{ mpi_prefix }}_*
     - netcdf-fortran
     - netcdf-fortran * {{ mpi_prefix }}_*
     - libpnetcdf
     - libpnetcdf * {{ mpi_prefix }}_*
-  run:
-    - {{ mpi }}
-    - hdf5 * {{ mpi_prefix }}_*
-    - libnetcdf * {{ mpi_prefix }}_*
-    - netcdf-fortran * {{ mpi_prefix }}_*
-    - libpnetcdf * {{ mpi_prefix }}_*
 
 test:
   commands:
-    - test -f ${PREFIX}/lib/libpioc.a
-    - test -f ${PREFIX}/lib/libpiof.a
+    - test ! -f ${PREFIX}/lib/libpioc.a
+    - test ! -f ${PREFIX}/lib/libpiof.a
+    - test -f ${PREFIX}/lib/libpioc${SHLIB_EXT}
+    - test -f ${PREFIX}/lib/libpiof${SHLIB_EXT}
 
 about:
   home: https://github.com/E3SM-Project/scorpio

--- a/conda/shared.py
+++ b/conda/shared.py
@@ -167,17 +167,39 @@ def install_miniconda(conda_base, activate_base, logger):
         check_call(command, logger=logger)
         os.remove(miniconda)
 
+    backup_bashrc()
+
     print('Doing initial setup\n')
     commands = '{}; ' \
                'conda config --add channels conda-forge; ' \
                'conda config --set channel_priority strict; ' \
                'conda install -y boa; ' \
                'conda update -y --all;' \
-               'cp ~/.bashrc ~/.bashrc.conda_bak; ' \
-               'mamba init; ' \
-               'mv ~/.bashrc.conda_bak ~/.bashrc'.format(activate_base)
+               'mamba init'.format(activate_base)
 
     check_call(commands, logger=logger)
+
+    restore_bashrc()
+
+
+def backup_bashrc():
+    home_dir = os.path.expanduser('~')
+    files = ['.bashrc', '.bash_profile']
+    for filename in files:
+        src = os.path.join(home_dir, filename)
+        dst = os.path.join(home_dir, f'{filename}.conda_bak')
+        if os.path.exists(filename):
+            shutil.copyfile(src, dst)
+
+
+def restore_bashrc():
+    home_dir = os.path.expanduser('~')
+    files = ['.bashrc', '.bash_profile']
+    for filename in files:
+        src = os.path.join(home_dir, f'{filename}.conda_bak')
+        dst = os.path.join(home_dir, filename)
+        if os.path.exists(filename):
+            shutil.move(src, dst)
 
 
 def get_logger(name, log_filename):


### PR DESCRIPTION
This merge updates the conda packages for linux and osx to:
* `pnetcdf 1.12.3`
* `scorpio 1.4.1`

<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->

<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [x] Document any testing that was used to verify the changes (see checklist below)

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->

A checkmark indicates that conda packages have been built, tested (with the ocean `nightly` suite) and uploaded for both `mpich` and `openmpi` variants:
- [x] linux `pnetcdf`
- [x] linux `scorpio`
- [x] osx `pnetcdf`
- [x] osx `scoprio`
