### PR TITLE
Use Wedge elements for all MALI tests

### DIFF
--- a/compass/landice/tests/circular_shelf/albany_input.yaml
+++ b/compass/landice/tests/circular_shelf/albany_input.yaml
@@ -12,7 +12,6 @@ ANONYMOUS:
   Discretization:
     #Exodus Output File Name: albany_output.exo
     Workset Size: -1
-    Element Shape: Tetrahedron
 
   Piro:
 #   Nonlinear Solver Information

--- a/compass/landice/tests/circular_shelf/circular_shelf.cfg
+++ b/compass/landice/tests/circular_shelf/circular_shelf.cfg
@@ -15,7 +15,7 @@ levels = 5
 use_mu = False
 
 # option to make the grounded area 7 cells instead of 1
-use_7cells = False
+use_7cells = True
 
 # config options related to visualization for circular_shelf test cases
 [circular_shelf_viz]

--- a/compass/landice/tests/circular_shelf/decomposition_test/__init__.py
+++ b/compass/landice/tests/circular_shelf/decomposition_test/__init__.py
@@ -60,15 +60,15 @@ class DecompositionTest(TestCase):
         compare_variables(test_case=self, variables=['normalVelocity', ],
                           filename1='1proc_run/output.nc',
                           filename2='4proc_run/output.nc',
-                          l1_norm=1.0e-3, l2_norm=1.0e-5,
-                          linf_norm=1.0e-7, quiet=False)
+                          l1_norm=1.0e-12, l2_norm=1.0e-14,
+                          linf_norm=1.0e-15, quiet=False)
         compare_variables(test_case=self, variables=['uReconstructX', ],
                           filename1='1proc_run/output.nc',
                           filename2='4proc_run/output.nc',
-                          l1_norm=1.0e-4, l2_norm=2.0e-6,
-                          linf_norm=1.0e-7, quiet=False)
+                          l1_norm=1.0e-12, l2_norm=2.0e-14,
+                          linf_norm=1.0e-15, quiet=False)
         compare_variables(test_case=self, variables=['uReconstructY', ],
                           filename1='1proc_run/output.nc',
                           filename2='4proc_run/output.nc',
-                          l1_norm=1.0e-4, l2_norm=2.0e-6,
-                          linf_norm=1.0e-7, quiet=False)
+                          l1_norm=1.0e-12, l2_norm=2.0e-14,
+                          linf_norm=1.0e-15, quiet=False)

--- a/compass/landice/tests/dome/albany_input.yaml
+++ b/compass/landice/tests/dome/albany_input.yaml
@@ -11,7 +11,6 @@ ANONYMOUS:
 
 # Discretization Description
   Discretization:
-    Element Shape: Tetrahedron
     Exodus Output File Name: albany_output.exo
 
   Piro:

--- a/compass/landice/tests/greenland/albany_input.yaml
+++ b/compass/landice/tests/greenland/albany_input.yaml
@@ -7,7 +7,6 @@ ANONYMOUS:
 
 # Discretization Description
   Discretization:
-    Element Shape: Tetrahedron
     Exodus Output File Name: albany_output.exo
 
   Piro:

--- a/compass/landice/tests/greenland/albany_schoof_input.yaml
+++ b/compass/landice/tests/greenland/albany_schoof_input.yaml
@@ -32,7 +32,6 @@ ANONYMOUS:
 
 # Discretization Description
   Discretization:
-    Element Shape: Tetrahedron
     Exodus Output File Name: albany_output.exo
 
   Piro:

--- a/docs/users_guide/landice/test_groups/circular_shelf.rst
+++ b/docs/users_guide/landice/test_groups/circular_shelf.rst
@@ -57,7 +57,7 @@ The test group uses the following default config options:
     use_mu = False
 
     # option to make the grounded area 7 cells instead of 1
-    use_7cells = False
+    use_7cells = True
 
     # config options related to visualization for circular_shelf test cases
     [circular_shelf_viz]


### PR DESCRIPTION
<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->
Albany is going to remove the support for Tet elements for MPAS generated meshes. 
In this PR we change all the land ice tests to use Wedge elements instead of Tet elements.

We also constrain the velocity on a patch of points, instead of on a single point, for the circular shelves test to remove the degree of freedom associated to rotations around the center of the shelf.

`Testing` perfomed on a linux machine linking the head of Albany master, as well as the branch of Albany where the Tets are disabled.

<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [x] User's Guide has been updated
* [ ] Developer's Guide has been updated
* [ ] API documentation in the Developer's Guide (`api.rst`) has any new or modified class, method and/or functions listed
* [x] Documentation has been [built locally](https://mpas-dev.github.io/compass/latest/developers_guide/building_docs.html) and changes look as expected
* [ ] The `E3SM-Project` submodule has been updated with relevant E3SM changes
* [ ] The `MALI-Dev` submodule has been updated with relevant MALI changes
* [x] Document (in a comment titled `Testing` in this PR) any testing that was used to verify the changes
* [ ] New tests have been added to a test suite



@matthewhoffman  Let me know if this change requires an update to the documentation.

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->
