### PR TITLE
Add instructions for deploying spack

### DIFF
--- a/docs/developers_guide/deploying_spack.rst
+++ b/docs/developers_guide/deploying_spack.rst
@@ -1,0 +1,454 @@
+.. _dev_deploying_spack:
+
+*********************************
+Deploying a new spack environment
+*********************************
+
+Where do we update compass dependencies?
+========================================
+
+Mache
+-----
+
+If system modules change in E3SM, we try to stay in sync:
+
+* compilers
+
+* MPI libraries
+
+* netcdf-C
+
+* netcdf-fortran
+
+* pnetcdf
+
+* mkl (or other linear algebra libs)
+
+Spack
+-----
+
+Spack is for libraries used by MPAS and tools that need system MPI:
+
+* ESMF
+
+* SCORPIO
+
+* Albany
+
+* PETSc
+
+* Netlib LAPACK
+
+
+Conda
+-----
+
+Conda (via conda-forge) is used for python packages and related dependencies
+that don’t need system MPI. Conda environments aren’t shared between
+developers because the compass you’re developing is part of the conda
+environment.
+
+Mache
+=====
+
+A brief tour of mache.
+
+Identifying E3SM machines
+-------------------------
+
+Compass and other packages use mache to identify what machine they’re on (when
+you’re on a login node).  This is used when configuring compass and creating a
+conda environment.  Because of this, there is a “bootstrapping” process where
+a conda environment is created with mache installed in it, then the machine is
+identified and the rest of the compass setup can continue.
+
+Config options describing E3SM machines
+---------------------------------------
+
+Mache has config files for each E3SM machine that tell us where E3SM-Unified
+is, where to find diagnostics, and much more, see
+`machines <https://github.com/E3SM-Project/mache/tree/main/mache/machines>`_.
+These config options are shared across packages including:
+
+* MPAS-Analysis
+
+* E3SM_Diags
+
+* zppy
+
+* compass
+
+* E3SM-Unified
+
+Compass uses these config options to know how to make a job script, where to
+find locally cached files in its “databases” and much more.
+
+Modules, env. variables, etc. for  E3SM machines
+------------------------------------------------
+
+Mache keeps its own copy of the E3SM file
+`config_machines.xml <https://github.com/E3SM-Project/E3SM/blob/master/cime_config/machines/config_machines.xml>`_
+in the package `here <https://github.com/E3SM-Project/mache/blob/main/mache/cime_machine_config/config_machines.xml>`_.
+We try to keep a close eye on E3SM master and update mache when system modules
+for machines that mache knows about get updated.  When this happens, we update
+mache’s copy of ``config_machines.xml`` and that tells me which modules to
+update in spack, see below.dev_quick_start
+
+Creating spack environments
+---------------------------
+
+Mache has templates for making spack environments on some of the E3SM supported
+machines.  See `spack <https://github.com/E3SM-Project/mache/tree/main/mache/spack>`_.
+It also has functions for building the spack environments with these templates
+using E3SM’s fork of spack (see below).
+
+
+Updating spack from compass with mache from a remote branch
+===========================================================
+
+If you haven’t cloned compass and added my fork, here’s the process:
+
+.. code-block:: bash
+
+    mkdir compass
+    cd compass/
+    git clone git@github.com:MPAS-Dev/compass.git main
+    cd main/
+    git remote add xylar/compass git@github.com:xylar/compass.git
+
+Now, we need to set up compass and build spack packages making use of the
+updated mache.  This involves changing the mache version in a couple of places
+in compass and updating the version of compass itself to a new alpha, beta or
+rc.  As an example, we will use the branch
+`simplify_local_mache <https://github.com/xylar/compass/tree/simplify_local_mache>`_.
+
+Often, we will need to test with a ``mache`` branch that has changes needed
+by compass.  Here, we will use the ``update_cime_machines`` on the fork
+``xylar/mache`` as an example.
+
+We also need to make sure there is a spack branch for the version of mache.
+This is a branch off of the develop branch on
+`E3SM’s spack repo <https://github.com/E3SM-Project/spack>`_ that has any
+updates to packages required for this version of mache and compass. The
+spack branch will omit any alpha, beta or rc suffix on the mache version
+because it is intended to be the spack branch we will use once the `mache`
+release happens.  In this example, we will work with the branch
+`spack_for_mache_1.12.0 <https://github.com/E3SM-Project/spack/tree/spack_for_mache_1.12.0>`_.
+
+Here's how to get a branch of compass we're testing (``simplify_local_mache``
+in this case) as a local worktree:
+
+.. code-block:: bash
+
+    # get my branch
+    git fetch --all -p
+    # make a worktree for checking out my branch
+    git worktree add ../simplify_local_mache -b simplify_local_mache \
+        --checkout xylar/compass/simplify_local_mache
+    cd ../simplify_local_mache/
+
+You will also need a local installation of
+`Mambaforge <https://github.com/conda-forge/miniforge#mambaforge>`_.
+Compass can do this for you if you haven't already installed it.  If you want
+to download it manually, use the Linux x86_64 version for all our supported
+machines.
+
+.. note::
+
+    We have found that an existing Miniconda3 installation **does not** always
+    work well for compass, so please start with Mambaforge instead.
+
+.. note::
+
+  You definitely need your own local Mambaforge installation -- you can’t use
+  a system version or a shared one like E3SM-Unified.
+
+Define a location where Mambaforge is installed or where you want to install
+it:
+
+.. code-block:: bash
+
+    # change to your conda installation
+    export CONDA_BASE=${HOME}/mambaforge
+
+Okay, we're finally ready to do a test spack build for compass.
+To do this, we call the ``configure_compass_env.py`` script using
+``--mache_fork``, ``--mache_branch``, ``--update_spack``, ``--spack`` and
+``--tmpdir``. Here is an example appropriate for Anvil or Chrysalis:
+
+.. code-block:: bash
+
+    export TMPDIR=/lcrc/group/e3sm/${USER}/spack_temp
+    ./conda/configure_compass_env.py \
+        --conda ${CONDA_BASE} \
+        --mache_fork xylar/mache \
+        --mache_branch update_cime_machines \
+        --update_spack \
+        --spack /lcrc/group/e3sm/${USER}/spack_test \
+        --tmpdir ${TMPDIR} \
+        --compiler intel intel gnu \
+        --mpi openmpi impi openmpi \
+        --recreate
+
+The directory you point to with ``--conda`` either doesn't exist or contains
+your existing installation of Mambaforge.
+
+When you supply ``--mache_fork`` and ``--mache_branch``, compass will clone
+a fork of the ``mache`` repo and check out the requested branch, then install
+that version of mache into both the compass installation conda environment and
+the final compass environment.
+
+``mache`` gets installed twice because the deployment tools need ``mache`` to
+even know how to install compass and build the spack environment on supported
+machines.  The "prebootstrap" step in deployment is creating the installation
+conda environment.  The "bootstrap" step is creating the conda environment that
+compass will actually use and (in this case with ``--update_spack``) building
+spack packages, then creating the "load" or "activation" script that you will
+need to build MPAS components and run compass.
+
+For testing, you want to point to a different location for installing spack
+using ``--spack``.
+
+On many machines, the ``/tmp`` directory is not a safe place to build spack
+packages.  Use ``--tmpdir`` to point to another place.
+
+The ``--recreate`` flag may not be strictly necessary but it’s a good idea.
+This will make sure both the bootstrapping conda environment (the one that
+installs mache to identify the machine) and the compass conda environment are
+created fresh.
+
+The ``--compiler`` flag is a list of one or more compilers to build for and the
+``--mpi`` flag is the corresponding list of MPI libraries.  To see what is
+supported on each machine, take a look at :ref:`dev_supported_machines`.
+
+Be aware that not all compilers and MPI libraries support Albany and PETSc, as
+discussed below.
+
+During the spack build, you may see:
+
+.. code-block:: none
+
+    ==> Error: no such environment 'dev_compass_1_2_0-alpha_5_intel_openmpi'
+    creating new environment: dev_compass_1_2_0-alpha_5_intel_openmpi
+
+That’s okay, this isn’t a real error and should hopefully be hidden soon.
+
+Testing spack with Albany
+-------------------------
+
+If you also want to build Albany, use the ``--with_albany`` flag.  Currently,
+this only works with Gnu compilers.  There is a file,
+`albany_support.txt <https://github.com/MPAS-Dev/compass/blob/main/conda/albany_supported.txt>`_,
+that lists supported compilers and MPI libraries on each machine.
+
+Here is an example:
+
+.. code-block:: bash
+
+    export TMPDIR=/lcrc/group/e3sm/${USER}/spack_temp
+    ./conda/configure_compass_env.py \
+        --conda ${CONDA_BASE} \
+        --mache_fork xylar/mache \
+        --mache_branch update_cime_machines \
+        --update_spack \
+        --spack /lcrc/group/e3sm/${USER}/spack_test \
+        --tmpdir ${TMPDIR} \
+        --compiler gnu \
+        --mpi openmpi \
+        --with_albany \
+        --recreate
+
+Testing spack with PETSc (and Netlib LAPACK)
+--------------------------------------------
+
+If you want to build PETSc (and Netlib LAPACK), use the ``--with_petsc`` and
+``--with_netlib_lapack`` flags.  Currently, this only works with some
+compilers, but that may be more that I was trying to limit the amount of work
+for the compass support team.  There is a file,
+`petsc_supported.txt <https://github.com/MPAS-Dev/compass/blob/main/conda/petsc_supported.txt>`_,
+that lists supported compilers and MPI libraries on each machine.
+
+Here is an example:
+
+.. code-block:: bash
+
+    export TMPDIR=/lcrc/group/e3sm/${USER}/spack_temp
+    ./conda/configure_compass_env.py \
+        --conda ${CONDA_BASE} \
+        --mache_fork xylar/mache \
+        --mache_branch update_cime_machines \
+        --update_spack \
+        --spack /lcrc/group/e3sm/${USER}/spack_test \
+        --tmpdir ${TMPDIR} \
+        --compiler intel gnu \
+        --mpi openmpi openmpi \
+        --with_netlib_lapack \
+        --with_petsc \
+        --recreate
+
+Testing compass
+===============
+
+Testing MPAS-Ocean without PETSc
+--------------------------------
+
+Please use the E3SM-Project submodule in compass for testing, rather than
+E3SM’s master branch.  The submodule is the version we know works with compass
+and serves as kind of a baseline for other testing.
+
+.. code-block:: bash
+
+    # source whichever load script is appropriate
+    source load_dev_compass_1.2.0-alpha.5_chrysalis_intel_openmpi.sh
+    git submodule update --init --recursive
+    cd E3SM-Project/components/mpas-ocean
+    # this will build with scorpio and openmp
+    make ifort
+    compass suite -s -c ocean -t pr -p . \
+        -w /lcrc/group/e3sm/ac.xylar/compass/test_20230202/ocean_pr_chrys_intel_openmpi
+    cd /lcrc/group/e3sm/ac.xylar/compass/test_20230202/ocean_pr_chrys_intel_openmpi
+    sbatch job_script.pr.bash
+
+You can make other worktrees of E3SM-Project for testing other compilers if
+that’s helpful.  It also might be good to open a fresh terminal to source a
+new load script.  This isn’t required but you’ll get some warnings.
+
+.. code-block:: bash
+
+    source load_dev_compass_1.2.0-alpha.5_chrysalis_gnu_openmpi.sh
+    cd E3SM-Project
+    git worktree add ../e3sm_chrys_gnu_openmpi
+    cd ../e3sm_chrys_gnu_openmpi
+    git submodule update --init --recursive
+    cd components/mpas-ocean
+    make gfortran
+    compass suite -s -c ocean -t pr -p . \
+        -w /lcrc/group/e3sm/ac.xylar/compass/test_20230202/ocean_pr_chrys_gnu_openmpi
+    cd /lcrc/group/e3sm/ac.xylar/compass/test_20230202/ocean_pr_chrys_gnu_openmpi
+    sbatch job_script.pr.bash
+
+You can also explore the utility in
+`utils/matrix <https://github.com/MPAS-Dev/compass/tree/main/utils/matrix>`_ to
+test on several compilers automatically.
+
+Testing MALI with Albany
+------------------------
+
+Please use the MALI-Dev submodule in compass for testing, rather than MALI-Dev
+develop branch.  The submodule is the version we know works with compass and
+serves as kind of a baseline for other testing.
+
+.. code-block:: bash
+
+    # source whichever load script is appropriate
+    source load_dev_compass_1.2.0-alpha.5_chrysalis_gnu_openmpi_albany.sh
+    git submodule update --init --recursive
+    cd MALI-Dev/components/mpas-albany-landice
+    # you need to tell it to build with Albany
+    make ALBANY=true gfortran
+    compass suite -s -c landice -t full_integration -p . \
+        -w /lcrc/group/e3sm/ac.xylar/compass/test_20230202/landice_full_chrys_gnu_openmpi
+    cd /lcrc/group/e3sm/ac.xylar/compass/test_20230202/landice_full_chrys_gnu_openmpi
+    sbatch job_script.full_integration.bash
+
+Testing MPAS-Ocean with PETSc
+-----------------------------
+
+The tests for PETSc use nonhydrostatic capabilities not yet integrated into
+E3SM.  So you can’t use the E3SM-Project submodule.  You need to use Sara
+Calandrini’s `nonhydro <https://github.com/scalandr/E3SM/tree/ocean/nonhydro>`_
+branch.
+
+.. code-block:: bash
+
+    # source whichever load script is appropriate
+    source load_dev_compass_1.2.0-alpha.5_chrysalis_intel_openmpi_netlib_lapack_petsc.sh
+    git submodule update --init
+    cd E3SM-Project
+    git remote add scalandr/E3SM git@github.com:scalandr/E3SM.git
+    git worktree add ../nonhydro_chrys_intel_openmpi -b nonhydro_chrys_intel_openmpi \
+        --checkout scalandr/E3SM/ocean/nonhydro
+    cd ../nonhydro_chrys_intel_openmpi
+    git submodule update --init --recursive
+    cd components/mpas-ocean
+    # this will build with scorpio, Netlib LAPACK and PETSc
+    make ifort
+    compass list | grep nonhydro
+    # update these numbers for the 2 nonhydro test cases
+    compass setup -n 245 246 -p . \
+        -w /lcrc/group/e3sm/ac.xylar/compass/test_20230202/nonhydro_chrys_intel_openmpi
+    cd /lcrc/group/e3sm/ac.xylar/compass/test_20230202/nonhydro_chrys_intel_openmpi
+    sbatch job_script.custom.bash
+
+As with non-PETSc MPAS-Ocean and MALI, you can have different worktrees with
+Sara’s nonhydro branch for building with different compilers or use
+`utils/matrix <https://github.com/MPAS-Dev/compass/tree/main/utils/matrix>`_ to
+build (and run).
+
+Deploying shared spack environments
+===================================
+
+.. note::
+
+  Be careful about deploying shared spack environments, as changes you make
+  can affect other compass users.
+
+Once compass has been tested with the spack builds in a temporary location, it
+is time to deploy the shared spack environments for all developers to use.
+A ``mache`` developer will make a ``mache`` release (if needed) before this
+step begins.  So there is no need to build mache from a remote branch anymore.
+
+It is best to update the remote compass branch in case of changes:
+
+.. code-block:: bash
+
+    cd simplify_local_mache
+    # get any changes
+    git fetch --all -p
+    # hard reset if there are changes
+    git reset –hard xylar/compass/simplify_local_mache
+
+Deploy spack for compass without Albany or PETSc
+------------------------------------------------
+
+.. code-block:: bash
+
+    export TMPDIR=/lcrc/group/e3sm/${USER}/spack_temp
+    ./conda/configure_compass_env.py \
+        --conda ${CONDA_BASE} \
+        --update_spack \
+        --tmpdir ${TMPDIR} \
+        --compiler intel intel gnu \
+        --mpi openmpi impi openmpi \
+        --recreate
+
+Deploying spack with Albany
+---------------------------
+
+.. code-block:: bash
+
+    export TMPDIR=/lcrc/group/e3sm/${USER}/spack_temp
+    ./conda/configure_compass_env.py \
+        --conda ${CONDA_BASE} \
+        --update_spack \
+        --tmpdir ${TMPDIR} \
+        --compiler gnu \
+        --mpi openmpi \
+        --with_albany \
+        --recreate
+
+Deploying spack with PETSc (and Netlib LAPACK)
+----------------------------------------------
+
+.. code-block:: bash
+
+    export TMPDIR=/lcrc/group/e3sm/${USER}/spack_temp
+    ./conda/configure_compass_env.py \
+        --conda ${CONDA_BASE} \
+        --update_spack \
+        --tmpdir ${TMPDIR} \
+        --compiler intel gnu \
+        --mpi openmpi openmpi \
+        --with_netlib_lapack \
+        --with_petsc \
+        --recreate

--- a/docs/developers_guide/deploying_spack.rst
+++ b/docs/developers_guide/deploying_spack.rst
@@ -131,7 +131,7 @@ This is a branch off of the develop branch on
 `E3SM’s spack repo <https://github.com/E3SM-Project/spack>`_ that has any
 updates to packages required for this version of mache and compass. The
 spack branch will omit any alpha, beta or rc suffix on the mache version
-because it is intended to be the spack branch we will use once the `mache`
+because it is intended to be the spack branch we will use once the ``mache``
 release happens.  In this example, we will work with the branch
 `spack_for_mache_1.12.0 <https://github.com/E3SM-Project/spack/tree/spack_for_mache_1.12.0>`_.
 
@@ -210,7 +210,8 @@ For testing, you want to point to a different location for installing spack
 using ``--spack``.
 
 On many machines, the ``/tmp`` directory is not a safe place to build spack
-packages.  Use ``--tmpdir`` to point to another place.
+packages.  Use ``--tmpdir`` to point to another place, e.g., your scratch
+space.
 
 The ``--recreate`` flag may not be strictly necessary but it’s a good idea.
 This will make sure both the bootstrapping conda environment (the one that
@@ -223,40 +224,6 @@ supported on each machine, take a look at :ref:`dev_supported_machines`.
 
 Be aware that not all compilers and MPI libraries support Albany and PETSc, as
 discussed below.
-
-During the spack build, you may see:
-
-.. code-block:: none
-
-    ==> Error: no such environment 'dev_compass_1_2_0-alpha_5_intel_openmpi'
-    creating new environment: dev_compass_1_2_0-alpha_5_intel_openmpi
-
-That’s okay, this isn’t a real error and should hopefully be hidden soon.
-
-Testing spack with Albany
--------------------------
-
-If you also want to build Albany, use the ``--with_albany`` flag.  Currently,
-this only works with Gnu compilers.  There is a file,
-`albany_support.txt <https://github.com/MPAS-Dev/compass/blob/main/conda/albany_supported.txt>`_,
-that lists supported compilers and MPI libraries on each machine.
-
-Here is an example:
-
-.. code-block:: bash
-
-    export TMPDIR=/lcrc/group/e3sm/${USER}/spack_temp
-    ./conda/configure_compass_env.py \
-        --conda ${CONDA_BASE} \
-        --mache_fork xylar/mache \
-        --mache_branch update_cime_machines \
-        --update_spack \
-        --spack /lcrc/group/e3sm/${USER}/spack_test \
-        --tmpdir ${TMPDIR} \
-        --compiler gnu \
-        --mpi openmpi \
-        --with_albany \
-        --recreate
 
 Testing spack with PETSc (and Netlib LAPACK)
 --------------------------------------------
@@ -286,19 +253,44 @@ Here is an example:
         --with_petsc \
         --recreate
 
+Testing spack with Albany
+-------------------------
+
+If you also want to build Albany, use the ``--with_albany`` flag.  Currently,
+this only works with Gnu compilers.  There is a file,
+`albany_support.txt <https://github.com/MPAS-Dev/compass/blob/main/conda/albany_supported.txt>`_,
+that lists supported compilers and MPI libraries on each machine.
+
+Here is an example:
+
+.. code-block:: bash
+
+    export TMPDIR=/lcrc/group/e3sm/${USER}/spack_temp
+    ./conda/configure_compass_env.py \
+        --conda ${CONDA_BASE} \
+        --mache_fork xylar/mache \
+        --mache_branch update_cime_machines \
+        --update_spack \
+        --spack /lcrc/group/e3sm/${USER}/spack_test \
+        --tmpdir ${TMPDIR} \
+        --compiler gnu \
+        --mpi openmpi \
+        --with_albany \
+        --recreate
 
 Troubleshooting spack
 ------------------------------
 
 If you encounter an error like:
-.. code-block:: bash
+.. code-block:: none
 
     ==>   spack env activate dev_compass_1_2_0-alpha_4_gnu_mpich
     ==> Error: Package 'armpl' not found.
     You may need to run 'spack clean -m'.
 
-during the attempt to build spack, you will first need to find the path to `setup-env.sh` (see 
-`compass/build_*/build*.sh`) and source that script to get the `spack` command, e.g.:
+during the attempt to build spack, you will first need to find the path to
+``setup-env.sh`` (see ``compass/build_*/build*.sh``) and source that script to
+get the ``spack`` command, e.g.:
 
 .. code-block:: bash
 
@@ -310,7 +302,7 @@ Then run the suggested command:
 
     spack clean -m
 
-After that, re-running `./conda/configure_compass_env.py` should work correctly.
+After that, re-running ``./conda/configure_compass_env.py`` should work correctly.
 
 This issue seems to be related to switching between spack v0.18 and v0.19 (used by different versions of compass).
 
@@ -425,6 +417,10 @@ Once compass has been tested with the spack builds in a temporary location, it
 is time to deploy the shared spack environments for all developers to use.
 A ``mache`` developer will make a ``mache`` release (if needed) before this
 step begins.  So there is no need to build mache from a remote branch anymore.
+
+Compass knows where to deploy spack on each machine because of the ``spack``
+config option specified in the ``[deploy]`` section of each machine's config
+file, see the `machine configs <https://github.com/MPAS-Dev/compass/tree/main/compass/machines>`_.
 
 It is best to update the remote compass branch in case of changes:
 

--- a/docs/developers_guide/deploying_spack.rst
+++ b/docs/developers_guide/deploying_spack.rst
@@ -123,8 +123,9 @@ rc.  As an example, we will use the branch
 `simplify_local_mache <https://github.com/xylar/compass/tree/simplify_local_mache>`_.
 
 Often, we will need to test with a ``mache`` branch that has changes needed
-by compass.  Here, we will use the ``update_cime_machines`` on the fork
-``xylar/mache`` as an example.
+by compass.  Here, we will use ``<fork>`` as a stand-in for the fork of mache
+to use (e.g. ``E3SM-Project/mache``) and ``<branch>`` as the stand-in for a branch on
+that fork (e.g. ``main``).
 
 We also need to make sure there is a spack branch for the version of mache.
 This is a branch off of the develop branch on
@@ -181,8 +182,8 @@ To do this, we call the ``configure_compass_env.py`` script using
     export TMPDIR=/lcrc/group/e3sm/${USER}/spack_temp
     ./conda/configure_compass_env.py \
         --conda ${CONDA_BASE} \
-        --mache_fork xylar/mache \
-        --mache_branch update_cime_machines \
+        --mache_fork <fork> \
+        --mache_branch <branch> \
         --update_spack \
         --spack /lcrc/group/e3sm/${USER}/spack_test \
         --tmpdir ${TMPDIR} \
@@ -242,8 +243,8 @@ Here is an example:
     export TMPDIR=/lcrc/group/e3sm/${USER}/spack_temp
     ./conda/configure_compass_env.py \
         --conda ${CONDA_BASE} \
-        --mache_fork xylar/mache \
-        --mache_branch update_cime_machines \
+        --mache_fork <fork> \
+        --mache_branch <branch> \
         --update_spack \
         --spack /lcrc/group/e3sm/${USER}/spack_test \
         --tmpdir ${TMPDIR} \
@@ -268,8 +269,8 @@ Here is an example:
     export TMPDIR=/lcrc/group/e3sm/${USER}/spack_temp
     ./conda/configure_compass_env.py \
         --conda ${CONDA_BASE} \
-        --mache_fork xylar/mache \
-        --mache_branch update_cime_machines \
+        --mache_fork <fork> \
+        --mache_branch <branch> \
         --update_spack \
         --spack /lcrc/group/e3sm/${USER}/spack_test \
         --tmpdir ${TMPDIR} \

--- a/docs/developers_guide/deploying_spack.rst
+++ b/docs/developers_guide/deploying_spack.rst
@@ -286,6 +286,34 @@ Here is an example:
         --with_petsc \
         --recreate
 
+
+Troubleshooting spack
+------------------------------
+
+If you encounter an error like:
+.. code-block:: bash
+
+    ==>   spack env activate dev_compass_1_2_0-alpha_4_gnu_mpich
+    ==> Error: Package 'armpl' not found.
+    You may need to run 'spack clean -m'.
+
+during the attempt to build spack, you will first need to find the path to `setup-env.sh` (see 
+`compass/build_*/build*.sh`) and source that script to get the `spack` command, e.g.:
+
+.. code-block:: bash
+
+    source ${PSCRATCH}/spack_test/spack_for_mache_1.12.0/share/spack/setup-env.sh
+
+Then run the suggested command:
+
+.. code-block:: bash
+
+    spack clean -m
+
+After that, re-running `./conda/configure_compass_env.py` should work correctly.
+
+This issue seems to be related to switching between spack v0.18 and v0.19 (used by different versions of compass).
+
 Testing compass
 ===============
 

--- a/docs/developers_guide/quick_start.rst
+++ b/docs/developers_guide/quick_start.rst
@@ -54,24 +54,30 @@ package because these don't get added automatically.
 
 Whether you are on one of the :ref:`dev_supported_machines` or an "unknown"
 machine, you will need to specify a path where
-`Miniconda3 <https://docs.conda.io/en/latest/miniconda.html>`_ either has
-already been installed or where the script can install it.  You must have write
-permission in the base environment.
+`Mambaforge <https://github.com/conda-forge/miniforge#mambaforge>`_ either has
+already been installed or an empty directory where the script can install it.
+You must have write permission in the base environment (if it exists).
 
 .. note::
 
-    It is *very* important that you not use a shared installation of Miniconda3
-    such as the base environment for E3SM-Unified for ``compass`` development.
-    Most developers will not have write access to shared environments, meaning
-    that you will get write-permission errors when you try to update the base
-    environment or create the compass development environment.
+    We have found that an existing Miniconda3 installation **does not** always
+    work well for ``compass``, so please start with Mambaforge instead.
+
+.. note::
+
+    It is *very* important that you not use a shared installation of Mambaforge
+    or Miniconda3 such as the base environment for E3SM-Unified for ``compass``
+    development. Most developers will not have write access to shared
+    environments, meaning that you will get write-permission errors when you
+    try to update the base environment or create the compass development
+    environment.
 
     For anyone who does have write permission to a shared environment, you
     would be creating your compass development environment in a shared space,
     which could cause confusion.
 
-    Please use your own personal installation of Miniconda3 for development,
-    letting ``configure_compass_env.py`` download and install Miniconda3 for
+    Please use your own personal installation of Mambaforge for development,
+    letting ``configure_compass_env.py`` download and install Mambaforge for
     you if you don't already have it installed.
 
 Supported machines
@@ -85,8 +91,8 @@ If you are on one of the :ref:`dev_supported_machines`, run:
         -c <compiler> [--mpi <mpi>] [-m <machine>] [--with_albany] \
         [--with_netlib_lapack] [--with_petsc]
 
-The ``<base_path_to_install_or_update_conda>`` is typically ``~/miniconda3``.
-This is the location where you would like to install Miniconda3 or where it is
+The ``<base_path_to_install_or_update_conda>`` is typically ``~/mambaforge``.
+This is the location where you would like to install Mambaforge or where it is
 already installed. If you have limited space in your home directory, you may
 want to give another path.  If you already have it installed, that path will
 be used to add (or update) the compass test environment.
@@ -136,8 +142,8 @@ workstation, you will need to specify which flavor of MPI you want to use
 
   ./conda/configure_compass_env.py --conda <conda_path> --mpi <mpi>
 
-Again, the ``<conda_path>`` is typically ``~/miniconda3``, and is the location
-where you would like to install Miniconda3 or where it is already installed.
+Again, the ``<conda_path>`` is typically ``~/mambaforge``, and is the location
+where you would like to install Mambaforge or where it is already installed.
 If you already have it installed, that path will be used to add (or update) the
 compass test environment.
 
@@ -163,14 +169,14 @@ in :ref:`config_files`.
 What the script does
 ~~~~~~~~~~~~~~~~~~~~
 
-In addition to installing Miniconda and creating the conda environment for you,
-this script will also:
+In addition to installing Mambaforge and creating the conda environment for
+you, this script will also:
 
 * install the ``compass`` package from the local branch in "development" mode
   so changes you make to the repo are immediately reflected in the conda
   environment.
 
-* with the ``--update_speck`` flag on supported machines, installs or
+* with the ``--update_spack`` flag on supported machines, installs or
   reinstalls a spack environment with various system libraries.  The
   ``--spack`` flag can be used to point to a location for the spack repo to be
   checked out.  Without this flag, a default location is used. Spack is used to
@@ -180,7 +186,8 @@ this script will also:
   in parallel), `Trilinos <https://trilinos.github.io/>`_,
   `Albany <https://github.com/sandialabs/Albany>`_,
   `Netlib-LAPACK <http://www.netlib.org/lapack/>`_ and
-  `PETSc <https://petsc.org/>`_.
+  `PETSc <https://petsc.org/>`_. **Please uses these flags with caution, as
+  they can affect shared environments!**  See :ref:`dev_deploying_spack`.
 
 * with the ``--with_albany`` flag, creates or uses an existing Spack
   environment that includes Albany and Trilinos.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -63,6 +63,7 @@ components themselves evolves and new functionality is added.
    developers_guide/troubleshooting
    developers_guide/docs
    developers_guide/building_docs
+   developers_guide/deploying_spack
    developers_guide/api
 
    design_docs/index

--- a/docs/tutorials/dev_add_test_group.rst
+++ b/docs/tutorials/dev_add_test_group.rst
@@ -34,9 +34,9 @@ your needs.
 .. code-block:: bash
 
   # this one will take a while the first time
-  ./conda/configure_compass_env.py --conda $HOME/miniconda3
+  ./conda/configure_compass_env.py --conda $HOME/mambaforge
 
-If you don't already have Miniconda3 installed in the directory pointed to by
+If you don't already have Mambaforge installed in the directory pointed to by
 ``--conda``, it will be installed automatically for you.  If all goes well, you
 will have a file named ``load_dev_compass_1.0.0*.sh``, where the details of the
 ``*`` depend on your specific machine and compilers.  For example, on

--- a/docs/tutorials/dev_porting_legacy.rst
+++ b/docs/tutorials/dev_porting_legacy.rst
@@ -41,7 +41,7 @@ your needs.
 .. code-block:: bash
 
   # this one will take a while the first time
-  ./conda/configure_compass_env.py --conda $HOME/miniconda3
+  ./conda/configure_compass_env.py --conda $HOME/mambaforge
 
 If all goes well, you will have a file named ``load_dev_compass_1.0.0*.sh``, where
 the details of the ``*`` depend on your specific machine and compilers.  For

--- a/docs/users_guide/machines/index.rst
+++ b/docs/users_guide/machines/index.rst
@@ -181,19 +181,11 @@ probably via a
 `conda environment <https://docs.conda.io/projects/conda/en/latest/index.html>`_.
 In this case, the ``parallel_executable`` is ``mpirun``.
 
-To install the `compass` package into a conda environment, you will first need
-to install `Miniconda3 <https://docs.conda.io/en/latest/miniconda.html>`_ (if
-miniconda is not already installed), then add the
-`conda-forge channel <https://conda-forge.org/#about>`_:
-
-.. code-block:: bash
-
-    conda config --add channels conda-forge
-    conda config --set channel_priority strict
-
-
-Then, you will run one of the following three commands, depending on how you
-would like to handle MPI support in the conda packages.
+To install the ``compass`` package into a conda environment, you will first
+need to install `Mambaforge <https://github.com/conda-forge/miniforge#mambaforge>`_
+(if it is not already installed).  Then, you will run one of the following
+three commands, depending on how you would like to handle MPI support in the
+conda packages.
 
 MPICH
 -----
@@ -203,7 +195,7 @@ package, run:
 
 .. code-block:: bash
 
-    conda create -n compass -c conda-forge -c e3sm/label/compass python=3.9 "compass=*=mpi_mpich*"
+    conda create -n compass -c conda-forge -c e3sm/label/compass python=3.10 "compass=*=mpi_mpich*"
 
 This is the recommended default for single-node Linux and OSX machines.
 
@@ -215,7 +207,7 @@ package, run:
 
 .. code-block:: bash
 
-    conda create -n compass -c conda-forge -c e3sm/label/compass python=3.9 "compass=*=mpi_openmpi*"
+    conda create -n compass -c conda-forge -c e3sm/label/compass python=3.10 "compass=*=mpi_openmpi*"
 
 No MPI from conda-forge
 -----------------------
@@ -225,7 +217,7 @@ conda-forge, run:
 
 .. code-block:: bash
 
-    conda create -n compass -c conda-forge -c e3sm/label/compass python=3.9 "compass=*=nompi*"
+    conda create -n compass -c conda-forge -c e3sm/label/compass python=3.10 "compass=*=nompi*"
 
 This would be the starting point for working with ``compass`` on an unknown
 HPC machine.  From there, you would also need to load modules and set

--- a/docs/users_guide/quick_start.rst
+++ b/docs/users_guide/quick_start.rst
@@ -70,21 +70,13 @@ other machines
 ~~~~~~~~~~~~~~
 
 To install your own ``compass`` conda environment on other machines, first,
-install `Miniconda3 <https://docs.conda.io/en/latest/miniconda.html>`_ (if
-miniconda is not already installed), then add the
-`conda-forge channel <https://conda-forge.org/#about>`_:
+install `Mambaforge <https://github.com/conda-forge/miniforge#mambaforge>`_
+(if it is not already installed), then create a new conda environment (called
+``compass`` in this example) as follows:
 
 .. code-block:: bash
 
-    conda config --add channels conda-forge
-    conda config --set channel_priority strict
-
-then, create a new conda environment (called ``compass`` in this example) as
-follows:
-
-.. code-block:: bash
-
-    conda create -n compass -c conda-forge -c e3sm/label/compass python=3.9 \
+    conda create -n compass -c conda-forge -c e3sm/label/compass python=3.10 \
         "compass=*=mpi_mpich*"
 
 This will install the version of the package with MPI from conda-forge's MPICH


### PR DESCRIPTION
This merge adds a kind of tutorial about testing and deploying shared spack environments for compass.

It also includes some updates to the documentation where we recommend installing (or letting the `configure_compass_env.py` script install) Mambaforge instead of Miniconda3.  @matthewhoffman found by painful trial and error that there doesn't seem to be a way to cleanly install mamba in a new Miniconda3 installation.  (This is also something I've been struggling with on CI lately.)

<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->

<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [x] Developer's Guide has been updated
* [x] Documentation has been [built locally](https://mpas-dev.github.io/compass/latest/developers_guide/building_docs.html) and changes look as expected

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->
