### PR TITLE
Allow test cases to run on login nodes

### DIFF
--- a/compass/default.cfg
+++ b/compass/default.cfg
@@ -28,6 +28,9 @@ verify = True
 # the program to use for graph partitioning
 partition_executable = gpmetis
 
+# the number of cores a user can use on a login node
+login_cores = 4
+
 
 # The io section describes options related to file i/o
 [io]

--- a/compass/ocean/tests/global_convergence/cosine_bell/forward.py
+++ b/compass/ocean/tests/global_convergence/cosine_bell/forward.py
@@ -32,7 +32,7 @@ class Forward(Step):
 
         mesh_name : str
             The name of the mesh
-        """
+        """  # noqa: E501
         super().__init__(test_case=test_case,
                          name=f'{mesh_name}_forward',
                          subdir=f'{mesh_name}/forward')
@@ -67,12 +67,12 @@ class Forward(Step):
         self.add_namelist_options({'config_dt': dt})
         self._get_resources()
 
-    def constrain_resources(self, available_cores):
+    def constrain_resources(self, available_resources):
         """
         Update resources at runtime from config options
         """
         self._get_resources()
-        super().constrain_resources(available_cores)
+        super().constrain_resources(available_resources)
 
     def run(self):
         """

--- a/compass/ocean/tests/global_ocean/forward.py
+++ b/compass/ocean/tests/global_ocean/forward.py
@@ -138,12 +138,12 @@ class ForwardStep(Step):
         """
         self._get_resources()
 
-    def constrain_resources(self, available_cores):
+    def constrain_resources(self, available_resources):
         """
         Update resources at runtime from config options
         """
         self._get_resources()
-        super().constrain_resources(available_cores)
+        super().constrain_resources(available_resources)
 
     def run(self):
         """

--- a/compass/ocean/tests/global_ocean/init/initial_state.py
+++ b/compass/ocean/tests/global_ocean/init/initial_state.py
@@ -1,10 +1,11 @@
 from importlib.resources import contents
 
-from compass.ocean.tests.global_ocean.metadata import \
-    add_mesh_and_init_metadata
 from compass.model import run_model
+from compass.ocean.plot import plot_initial_state, plot_vertical_grid
+from compass.ocean.tests.global_ocean.metadata import (
+    add_mesh_and_init_metadata,
+)
 from compass.ocean.vertical.grid_1d import generate_1d_grid, write_1d_grid
-from compass.ocean.plot import plot_vertical_grid, plot_initial_state
 from compass.step import Step
 
 
@@ -80,7 +81,7 @@ class InitialState(Step):
 
         self.add_input_file(
             filename='topography.nc',
-            target='BedMachineAntarctica_v2_and_GEBCO_2022_0.05_degree_20220729.nc',
+            target='BedMachineAntarctica_v2_and_GEBCO_2022_0.05_degree_20220729.nc',  # noqa: E501
             database='bathymetry_database')
 
         self.add_input_file(
@@ -152,13 +153,12 @@ class InitialState(Step):
         """
         self._get_resources()
 
-
-    def constrain_resources(self, available_cores):
+    def constrain_resources(self, available_resources):
         """
         Update resources at runtime from config options
         """
         self._get_resources()
-        super().constrain_resources(available_cores)
+        super().constrain_resources(available_resources)
 
     def run(self):
         """

--- a/compass/ocean/tests/global_ocean/init/ssh_adjustment.py
+++ b/compass/ocean/tests/global_ocean/init/ssh_adjustment.py
@@ -1,5 +1,5 @@
-from compass.step import Step
 from compass.ocean.iceshelf import adjust_ssh
+from compass.step import Step
 
 
 class SshAdjustment(Step):
@@ -55,12 +55,12 @@ class SshAdjustment(Step):
         """
         self._get_resources()
 
-    def constrain_resources(self, available_cores):
+    def constrain_resources(self, available_resources):
         """
         Update resources at runtime from config options
         """
         self._get_resources()
-        super().constrain_resources(available_cores)
+        super().constrain_resources(available_resources)
 
     def run(self):
         """

--- a/compass/ocean/tests/hurricane/forward/forward.py
+++ b/compass/ocean/tests/hurricane/forward/forward.py
@@ -71,12 +71,12 @@ class ForwardStep(Step):
         """
         self._get_resources()
 
-    def constrain_resources(self, available_cores):
+    def constrain_resources(self, available_resources):
         """
         Update resources at runtime from config options
         """
         self._get_resources()
-        super().constrain_resources(available_cores)
+        super().constrain_resources(available_resources)
 
     def run(self):
         """

--- a/compass/ocean/tests/hurricane/init/initial_state.py
+++ b/compass/ocean/tests/hurricane/init/initial_state.py
@@ -60,12 +60,12 @@ class InitialState(Step):
         """
         self._get_resources()
 
-    def constrain_resources(self, available_cores):
+    def constrain_resources(self, available_resources):
         """
         Update resources at runtime from config options
         """
         self._get_resources()
-        super().constrain_resources(available_cores)
+        super().constrain_resources(available_resources)
 
     def run(self):
         """

--- a/compass/ocean/tests/isomip_plus/forward.py
+++ b/compass/ocean/tests/isomip_plus/forward.py
@@ -1,13 +1,13 @@
 import os
 import shutil
-import xarray
 import time
 
-from compass.model import run_model
-from compass.step import Step
+import xarray
 
+from compass.model import run_model
 from compass.ocean.tests.isomip_plus.evap import update_evaporation_flux
 from compass.ocean.tests.isomip_plus.viz.plot import MoviePlotter
+from compass.step import Step
 
 
 class Forward(Step):
@@ -133,12 +133,12 @@ class Forward(Step):
         """
         self._get_resources()
 
-    def constrain_resources(self, available_cores):
+    def constrain_resources(self, available_resources):
         """
         Update resources at runtime from config options
         """
         self._get_resources()
-        super().constrain_resources(available_cores)
+        super().constrain_resources(available_resources)
 
     def run(self):
         """
@@ -192,6 +192,7 @@ class Forward(Step):
         self.min_tasks = config.getint('isomip_plus', 'forward_min_tasks')
         self.openmp_threads = config.getint('isomip_plus', 'forward_threads')
 
+
 def get_time_steps(resolution):
     """
     Get the time step namelist replacements for the resolution
@@ -208,10 +209,10 @@ def get_time_steps(resolution):
     """
 
     # 4 minutes at 2 km, and proportional to resolution
-    dt = 2.*60*resolution
+    dt = 2. * 60 * resolution
 
     # 10 sec at 2 km, and proportional to resolution
-    btr_dt = 5.*resolution
+    btr_dt = 5. * resolution
 
     # https://stackoverflow.com/a/1384565/7728169
     # Note: this will drop any fractional seconds, which is usually okay

--- a/compass/ocean/tests/isomip_plus/ssh_adjustment.py
+++ b/compass/ocean/tests/isomip_plus/ssh_adjustment.py
@@ -1,6 +1,6 @@
-from compass.step import Step
 from compass.ocean.iceshelf import adjust_ssh
 from compass.ocean.tests.isomip_plus.forward import get_time_steps
+from compass.step import Step
 
 
 class SshAdjustment(Step):
@@ -30,8 +30,9 @@ class SshAdjustment(Step):
         self.add_namelist_file('compass.ocean.tests.isomip_plus',
                                'namelist.forward_and_ssh_adjust')
         if vertical_coordinate == 'single_layer':
-            self.add_namelist_file('compass.ocean.tests.isomip_plus',
-                                   'namelist.single_layer.forward_and_ssh_adjust')
+            self.add_namelist_file(
+                'compass.ocean.tests.isomip_plus',
+                'namelist.single_layer.forward_and_ssh_adjust')
         if thin_film_present:
             self.add_namelist_file('compass.ocean.tests.isomip_plus',
                                    'namelist.thin_film.forward_and_ssh_adjust')
@@ -67,12 +68,12 @@ class SshAdjustment(Step):
         """
         self._get_resources()
 
-    def constrain_resources(self, available_cores):
+    def constrain_resources(self, available_resources):
         """
         Update resources at runtime from config options
         """
         self._get_resources()
-        super().constrain_resources(available_cores)
+        super().constrain_resources(available_resources)
 
     def run(self):
         """

--- a/compass/ocean/tests/planar_convergence/forward.py
+++ b/compass/ocean/tests/planar_convergence/forward.py
@@ -1,5 +1,5 @@
 import time
-from datetime import datetime, timedelta
+from datetime import timedelta
 from importlib.resources import contents
 
 from compass.model import run_model
@@ -28,7 +28,7 @@ class Forward(Step):
 
         resolution : int
             The resolution of the (uniform) mesh in km
-        """
+        """  # noqa: E501
         super().__init__(test_case=test_case,
                          name='{}km_forward'.format(resolution),
                          subdir='{}km/forward'.format(resolution))
@@ -70,12 +70,12 @@ class Forward(Step):
                               template_replacements=stream_replacements)
         self._get_resources()
 
-    def constrain_resources(self, available_cores):
+    def constrain_resources(self, available_resources):
         """
         Update resources at runtime from config options
         """
         self._get_resources()
-        super().constrain_resources(available_cores)
+        super().constrain_resources(available_resources)
 
     def run(self):
         """
@@ -115,8 +115,8 @@ class Forward(Step):
         duration = \
             int(3600 * config.getfloat('planar_convergence', 'duration'))
         delta = timedelta(seconds=duration)
-        hours = delta.seconds//3600
-        minutes = delta.seconds//60 % 60
+        hours = delta.seconds // 3600
+        minutes = delta.seconds // 60 % 60
         seconds = delta.seconds % 60
         duration = f'{delta.days:03d}_{hours:02d}:{minutes:02d}:{seconds:02d}'
 
@@ -130,7 +130,7 @@ class Forward(Step):
     def _get_resources(self):
         config = self.config
         resolution = self.resolution
-        self.ntasks = config.getint(f'planar_convergence',
+        self.ntasks = config.getint('planar_convergence',
                                     f'{resolution}km_ntasks')
-        self.min_tasks = config.getint(f'planar_convergence',
+        self.min_tasks = config.getint('planar_convergence',
                                        f'{resolution}km_min_tasks')

--- a/compass/ocean/tests/sphere_transport/correlated_tracers_2d/forward.py
+++ b/compass/ocean/tests/sphere_transport/correlated_tracers_2d/forward.py
@@ -1,8 +1,7 @@
-import time
+from datetime import timedelta
 
 from compass.model import run_model
 from compass.step import Step
-from datetime import timedelta
 
 
 class Forward(Step):
@@ -29,7 +28,7 @@ class Forward(Step):
             The resolution of the (uniform) mesh in km
         dt_minutes : int
             The time step size in minutes.  **must divide 1 day (24*60)**
-        """
+        """  # noqa: E501
         super().__init__(test_case=test_case,
                          name='QU{}_forward'.format(resolution),
                          subdir='QU{}/forward'.format(resolution))
@@ -64,12 +63,12 @@ class Forward(Step):
                                        'time_integrator')})
         self._get_resources()
 
-    def constrain_resources(self, available_cores):
+    def constrain_resources(self, available_resources):
         """
         Update resources at runtime from config options
         """
         self._get_resources()
-        super().constrain_resources(available_cores)
+        super().constrain_resources(available_resources)
 
     def run(self):
         """

--- a/compass/ocean/tests/sphere_transport/divergent_2d/forward.py
+++ b/compass/ocean/tests/sphere_transport/divergent_2d/forward.py
@@ -1,8 +1,7 @@
-import time
+from datetime import timedelta
 
 from compass.model import run_model
 from compass.step import Step
-from datetime import timedelta
 
 
 class Forward(Step):
@@ -28,7 +27,7 @@ class Forward(Step):
             The resolution of the (uniform) mesh in km
         dt_minutes : int
             The time step size in minutes.  **must divide 1 day (24*60)**
-        """
+        """  # noqa: E501
         super().__init__(test_case=test_case,
                          name='QU{}_forward'.format(resolution),
                          subdir='QU{}/forward'.format(resolution))
@@ -61,12 +60,12 @@ class Forward(Step):
                                        'divergent_2d', 'time_integrator')})
         self._get_resources()
 
-    def constrain_resources(self, available_cores):
+    def constrain_resources(self, available_resources):
         """
         Update resources at runtime from config options
         """
         self._get_resources()
-        super().constrain_resources(available_cores)
+        super().constrain_resources(available_resources)
 
     def run(self):
         """

--- a/compass/ocean/tests/sphere_transport/nondivergent_2d/forward.py
+++ b/compass/ocean/tests/sphere_transport/nondivergent_2d/forward.py
@@ -1,8 +1,7 @@
-import time
+from datetime import timedelta
 
 from compass.model import run_model
 from compass.step import Step
-from datetime import timedelta
 
 
 class Forward(Step):
@@ -29,7 +28,7 @@ class Forward(Step):
             The resolution of the (uniform) mesh in km
         dt_minutes : int
             The time step size in minutes.  **must divide 1 day (24*60)**
-        """
+        """  # noqa: E501
         super().__init__(test_case=test_case,
                          name='QU{}_forward'.format(resolution),
                          subdir='QU{}/forward'.format(resolution))
@@ -62,12 +61,12 @@ class Forward(Step):
                                        'nondivergent_2d', 'time_integrator')})
         self._get_resources()
 
-    def constrain_resources(self, available_cores):
+    def constrain_resources(self, available_resources):
         """
         Update resources at runtime from config options
         """
         self._get_resources()
-        super().constrain_resources(available_cores)
+        super().constrain_resources(available_resources)
 
     def run(self):
         """

--- a/compass/ocean/tests/sphere_transport/rotation_2d/forward.py
+++ b/compass/ocean/tests/sphere_transport/rotation_2d/forward.py
@@ -1,8 +1,7 @@
-import time
+from datetime import timedelta
 
 from compass.model import run_model
 from compass.step import Step
-from datetime import timedelta
 
 
 class Forward(Step):
@@ -28,7 +27,7 @@ class Forward(Step):
             The resolution of the (uniform) mesh in km
         dt_minutes : int
             The time step size in minutes.  **must divide 1 day (24*60)**
-        """
+        """  # noqa: E501
         super().__init__(test_case=test_case,
                          name='QU{}_forward'.format(resolution),
                          subdir='QU{}/forward'.format(resolution))
@@ -61,12 +60,12 @@ class Forward(Step):
                                        'rotation_2d', 'time_integrator')})
         self._get_resources()
 
-    def constrain_resources(self, available_cores):
+    def constrain_resources(self, available_resources):
         """
         Update resources at runtime from config options
         """
         self._get_resources()
-        super().constrain_resources(available_cores)
+        super().constrain_resources(available_resources)
 
     def run(self):
         """

--- a/compass/ocean/tests/tides/forward/forward.py
+++ b/compass/ocean/tests/tides/forward/forward.py
@@ -74,12 +74,12 @@ class ForwardStep(Step):
         """
         self._get_resources()
 
-    def constrain_resources(self, available_cores):
+    def constrain_resources(self, available_resources):
         """
         Update resources at runtime from config options
         """
         self._get_resources()
-        super().constrain_resources(available_cores)
+        super().constrain_resources(available_resources)
 
     def run(self):
         """

--- a/compass/ocean/tests/tides/init/initial_state.py
+++ b/compass/ocean/tests/tides/init/initial_state.py
@@ -1,10 +1,10 @@
-from compass.model import run_model
-from compass.step import Step
-
-from compass.ocean.vertical.grid_1d import generate_1d_grid, write_1d_grid
-from compass.ocean.plot import plot_vertical_grid
 import netCDF4
 import numpy as np
+
+from compass.model import run_model
+from compass.ocean.plot import plot_vertical_grid
+from compass.ocean.vertical.grid_1d import generate_1d_grid, write_1d_grid
+from compass.step import Step
 
 
 class InitialState(Step):
@@ -89,13 +89,12 @@ class InitialState(Step):
         """
         self._get_resources()
 
-
-    def constrain_resources(self, available_cores):
+    def constrain_resources(self, available_resources):
         """
         Update resources at runtime from config options
         """
         self._get_resources()
-        super().constrain_resources(available_cores)
+        super().constrain_resources(available_resources)
 
     def run(self):
         """

--- a/compass/parallel.py
+++ b/compass/parallel.py
@@ -6,7 +6,7 @@ import warnings
 from mpas_tools.logging import check_call
 
 
-def get_available_cores_and_nodes(config):
+def get_available_parallel_resources(config):
     """
     Get the number of total cores and nodes available for running steps
 
@@ -17,14 +17,15 @@ def get_available_cores_and_nodes(config):
 
     Returns
     -------
-    cores : int
-        The number of cores available for running steps
-
-    nodes : int
-        The number of cores available for running steps
+    available_resources : dict
+        A dictionary containing available resources (cores, tasks, nodes
+        and cores_per_node)
     """
 
     parallel_system = config.get('parallel', 'system')
+    if parallel_system == 'slurm' and 'SLURM_JOB_ID' not in os.environ:
+        parallel_system = 'login'
+
     if parallel_system == 'slurm':
         job_id = os.environ['SLURM_JOB_ID']
         node = os.environ['SLURMD_NODENAME']
@@ -41,61 +42,38 @@ def get_available_cores_and_nodes(config):
         args = ['squeue', '--noheader', '-j', job_id, '-o', '%D']
         nodes = _get_subprocess_int(args)
         cores = cores_per_node * nodes
+        mpi_allowed = True
+    elif parallel_system == 'login':
+        cores = min(multiprocessing.cpu_count(),
+                    config.getint('parallel', 'login_cores'))
+        cores_per_node = cores
+        nodes = 1
+        mpi_allowed = False
     elif parallel_system == 'single_node':
         cores = multiprocessing.cpu_count()
         if config.has_option('parallel', 'cores_per_node'):
-            cores_per_node = config.getint('parallel', 'cores_per_node')
-            cores = min(cores, cores_per_node)
-        else:
-            cores_per_node = cores
+            cores = min(cores, config.getint('parallel', 'cores_per_node'))
+        cores_per_node = cores
         nodes = 1
+        mpi_allowed = True
     else:
         raise ValueError(f'Unexpected parallel system: {parallel_system}')
 
-    return cores, nodes, cores_per_node
+    available_resources = dict(
+        cores=cores,
+        nodes=nodes,
+        cores_per_node=cores_per_node,
+        mpi_allowed=mpi_allowed
+    )
+    return available_resources
 
 
-def check_parallel_system(config):
-    """
-    Check whether we are in an appropriate state for the given queuing system.
-    For systems with Slurm, this means that we need to have an interactive
-    or batch job on a compute node, as determined by the ``$SLURM_JOB_ID``
-    environment variable.
-
-    Parameters
-    ----------
-    config : compass.config.CompassConfigParser
-        Configuration options
-
-    Raises
-    -------
-    ValueError
-        If using Slurm and not on a compute node
-    """
-
-    parallel_system = config.get('parallel', 'system')
-    if parallel_system == 'slurm':
-        if 'SLURM_JOB_ID' not in os.environ:
-            raise ValueError('SLURM_JOB_ID not defined.  You are likely not '
-                             'on a compute node.')
-    elif parallel_system == 'single_node':
-        pass
-    else:
-        raise ValueError(f'Unexpected parallel system: {parallel_system}')
-
-
-def set_cores_per_node(config):
+def set_cores_per_node(config, cores_per_node):
     """
     If the system has Slurm, find out the ``cpus_per_node`` and set the config
     option accordingly.
-
-    Parameters
-    ----------
-    config : compass.config.CompassConfigParser
-        Configuration options
     """
     parallel_system = config.get('parallel', 'system')
-    _, nodes, cores_per_node = get_available_cores_and_nodes(config)
     if parallel_system == 'slurm':
         old_cores_per_node = config.getint('parallel', 'cores_per_node')
         config.set('parallel', 'cores_per_node', f'{cores_per_node}')

--- a/compass/parallel.py
+++ b/compass/parallel.py
@@ -1,5 +1,5 @@
-import os
 import multiprocessing
+import os
 import subprocess
 import warnings
 
@@ -37,7 +37,7 @@ def get_available_cores_and_nodes(config):
         else:
             args = ['sinfo', '--noheader', '--node', node, '-o', '%Z']
             threads_per_core = _get_subprocess_int(args)
-        cores_per_node = sockets_per_node*cores_per_socket*threads_per_core
+        cores_per_node = sockets_per_node * cores_per_socket * threads_per_core
         args = ['squeue', '--noheader', '-j', job_id, '-o', '%D']
         nodes = _get_subprocess_int(args)
         cores = cores_per_node * nodes

--- a/docs/developers_guide/api.rst
+++ b/docs/developers_guide/api.rst
@@ -252,8 +252,7 @@ parallel
 .. autosummary::
    :toctree: generated/
 
-   get_available_cores_and_nodes
-   check_parallel_system
+   get_available_parallel_resources
    set_cores_per_node
    run_command
 


### PR DESCRIPTION
If you are on a slurm system but a slurm job is not detected, you are assumed to be on a login node.  In that case, it is like being on a single node system, restricted to a small number of cores (set with the config option `login_cores = 4` in the `[parallel]` config section).  In addition, you are not allowed to run MPI jobs (steps with `ntasks` > 1).

This is enforced by modifying the `Step.constrain_resources()` method, which now takes a dictionary of `available_resources` rather than a single `available_cores` argument.  (Many tasks have their overridden `constrain_resources()` method changed as a result.)

The new, stricter linter required cleaning up some code in the process.

<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->

<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [x] Document (in a comment titled `Testing` in this PR) any testing that was used to verify the changes

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->

closes #495 
