### PR TITLE
Override mache yaml file for Anvil with Gnu and OpenMPI

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,4 @@
-exclude: "docs|.git"
+exclude: "docs|.git|conda/spack"
 default_stages: [commit]
 fail_fast: true
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,6 +9,7 @@ repos:
       - id: trailing-whitespace
       - id: end-of-file-fixer
       - id: check-yaml
+        exclude: conda
 
   # Can run individually with `pre-commit run isort --all-files`
   - repo: https://github.com/PyCQA/isort

--- a/compass/version.py
+++ b/compass/version.py
@@ -1,1 +1,1 @@
-__version__ = '1.2.0-alpha.4'
+__version__ = '1.2.0-alpha.5'

--- a/conda/bootstrap.py
+++ b/conda/bootstrap.py
@@ -386,6 +386,7 @@ def build_spack_env(config, update_spack, machine, compiler, mpi, spack_env,
                     spack_base, spack_template_path, env_vars, tmpdir, logger):
 
     albany = config.get('deploy', 'albany')
+    cmake = config.get('deploy', 'cmake')
     esmf = config.get('deploy', 'esmf')
     lapack = config.get('deploy', 'lapack')
     petsc = config.get('deploy', 'petsc')
@@ -394,6 +395,9 @@ def build_spack_env(config, update_spack, machine, compiler, mpi, spack_env,
     spack_branch_base = f'{spack_base}/spack_for_mache_{mache_version}'
 
     specs = list()
+
+    if cmake != 'None':
+        specs.append(f'cmake@{cmake}')
 
     e3sm_hdf5_netcdf = config.getboolean('deploy', 'use_e3sm_hdf5_netcdf')
     if not e3sm_hdf5_netcdf:

--- a/conda/bootstrap.py
+++ b/conda/bootstrap.py
@@ -397,7 +397,7 @@ def build_spack_env(config, update_spack, machine, compiler, mpi, spack_env,
     specs = list()
 
     if cmake != 'None':
-        specs.append(f'cmake@{cmake}')
+        specs.append(f'cmake "@{cmake}"')
 
     e3sm_hdf5_netcdf = config.getboolean('deploy', 'use_e3sm_hdf5_netcdf')
     if not e3sm_hdf5_netcdf:
@@ -406,27 +406,28 @@ def build_spack_env(config, update_spack, machine, compiler, mpi, spack_env,
         netcdf_fortran = config.get('deploy', 'netcdf_fortran')
         pnetcdf = config.get('deploy', 'pnetcdf')
         specs.extend([
-            f'hdf5@{hdf5}+cxx+fortran+hl+mpi+shared',
-            f'netcdf-c@{netcdf_c}+mpi~parallel-netcdf',
-            f'netcdf-fortran@{netcdf_fortran}',
-            f'parallel-netcdf@{pnetcdf}+cxx+fortran'])
+            f'hdf5 "@{hdf5}+cxx+fortran+hl+mpi+shared"',
+            f'netcdf-c "@{netcdf_c}+mpi~parallel-netcdf"',
+            f'netcdf-fortran "@{netcdf_fortran}"',
+            f'parallel-netcdf "@{pnetcdf}+cxx+fortran"'])
 
     if esmf != 'None':
-        specs.append(f'esmf@{esmf}+mpi+netcdf~pio+pnetcdf')
+        specs.append(f'esmf "@{esmf}+mpi+netcdf~pio+pnetcdf"')
     if lapack != 'None':
-        specs.append(f'netlib-lapack@{lapack}')
+        specs.append(f'netlib-lapack "@{lapack}"')
         include_e3sm_lapack = False
     else:
         include_e3sm_lapack = True
     if petsc != 'None':
-        specs.append(f'petsc@{petsc}+mpi+batch')
+        specs.append(f'petsc "@{petsc}+mpi+batch"')
 
     if scorpio != 'None':
         specs.append(
-            f'scorpio@{scorpio}+pnetcdf~timing+internal-timing~tools+malloc')
+            f'scorpio '
+            f'"@{scorpio}+pnetcdf~timing+internal-timing~tools+malloc"')
 
     if albany != 'None':
-        specs.append(f'albany@{albany}+mpas')
+        specs.append(f'albany "@{albany}+mpas"')
 
     yaml_template = f'{spack_template_path}/{machine}_{compiler}_{mpi}.yaml'
     if not os.path.exists(yaml_template):

--- a/conda/compass_env/spec-file.template
+++ b/conda/compass_env/spec-file.template
@@ -16,7 +16,7 @@ jigsawpy=0.3.3
 jupyter
 lxml
 {% if include_mache %}
-mache=1.10.0
+mache=1.13.0
 {% endif %}
 matplotlib-base
 metis

--- a/conda/configure_compass_env.py
+++ b/conda/configure_compass_env.py
@@ -98,7 +98,7 @@ def main():
     if local_mache:
         mache = ''
     else:
-        mache = '"mache=1.10.0"'
+        mache = '"mache=1.13.0"'
 
     setup_install_env(env_name, activate_base, args.use_local, logger,
                       args.recreate, conda_base, mache)

--- a/conda/default.cfg
+++ b/conda/default.cfg
@@ -21,6 +21,8 @@ mpi = nompi
 
 # the version of various packages to include if using spack
 albany = develop
+# cmake newer than 3.23.0 needed for Trilinos
+cmake = 3.23.0:
 esmf = 8.2.0
 hdf5 = 1.12.1
 lapack = 3.9.1

--- a/conda/recipe/meta.yaml
+++ b/conda/recipe/meta.yaml
@@ -52,7 +52,7 @@ requirements:
     - jigsawpy 0.3.3
     - jupyter
     - lxml
-    - mache 1.10.0
+    - mache 1.13.0
     - matplotlib-base
     - metis
     - mpas_tools 0.17.0

--- a/conda/recipe/meta.yaml
+++ b/conda/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "compass" %}
-{% set version = "1.2.0alpha.4" %}
+{% set version = "1.2.0alpha.5" %}
 {% set build = 0 %}
 
 {% if mpi == "nompi" %}

--- a/conda/spack/anvil_gnu_openmpi.yaml
+++ b/conda/spack/anvil_gnu_openmpi.yaml
@@ -1,0 +1,124 @@
+spack:
+  specs:
+  - cmake
+  - gcc
+  - openmpi+cxx+pmi "schedulers=slurm"
+  - hdf5+cxx+fortran+hl+mpi
+  - netcdf-c+mpi~parallel-netcdf
+  - netcdf-fortran
+  - parallel-netcdf+cxx+fortran
+{{ specs }}
+  concretizer:
+    unify: true
+  packages:
+    all:
+      compiler: [gcc@11.3.0]
+      providers:
+        mpi: [openmpi]
+    bison:
+      externals:
+      - spec: bison@3.0.4
+        prefix: /usr
+      buildable: false
+    bzip2:
+      externals:
+      - spec: bzip2@1.0.6
+        prefix: /gpfs/fs1/software/centos7/spack-latest/opt/spack/linux-centos7-x86_64/gcc-6.5.0/bzip2-1.0.6-mbwr6sk
+      buildable: false
+    curl:
+      externals:
+      - spec: curl@7.72.0
+        prefix: /gpfs/fs1/software/centos7/spack-latest/opt/spack/linux-centos7-x86_64/gcc-6.5.0/curl-7.72.0-bnppi6e
+      buildable: false
+    diffutils:
+      externals:
+      - spec: diffutils@3.7
+        prefix: /gpfs/fs1/software/centos7/spack-latest/opt/spack/linux-centos7-x86_64/gcc-6.5.0/diffutils-3.7-lmwmgqg
+      buildable: false
+    findutils:
+      externals:
+      - spec: findutils@4.6.0
+        prefix: /gpfs/fs1/software/centos7/spack-latest/opt/spack/linux-centos7-x86_64/gcc-6.5.0/findutils-4.6.0-ef3lzvf
+      buildable: false
+    gettext:
+      externals:
+      - spec: gettext@0.19.8.1
+        prefix: /usr
+      buildable: false
+    libiconv:
+      externals:
+      - spec: libiconv@1.16
+        prefix: /gpfs/fs1/software/centos7/spack-latest/opt/spack/linux-centos7-x86_64/intel-20.0.4/libiconv-1.16-gcutq6m
+      buildable: false
+    libxml2:
+      externals:
+      - spec: libxml2@2.9.10
+        prefix: /gpfs/fs1/software/centos7/spack-latest/opt/spack/linux-centos7-x86_64/intel-20.0.4/libxml2-2.9.10-dwvqy3m
+      buildable: false
+    m4:
+      externals:
+      - spec: m4@1.4.16
+        prefix: /usr
+      buildable: false
+    openssl:
+      externals:
+      - spec: openssl@1.0.2k
+        prefix: /usr
+      buildable: false
+    tar:
+      externals:
+      - spec: tar@1.26
+        prefix: /usr
+      buildable: false
+    xz:
+      externals:
+      - spec: xz@5.2.5
+        prefix: /gpfs/fs1/software/centos7/spack-latest/opt/spack/linux-centos7-x86_64/intel-20.0.4/xz-5.2.5-6uopvxd
+      buildable: false
+    zlib:
+      externals:
+      - spec: zlib@1.2.11
+        prefix: /gpfs/fs1/soft/chrysalis/spack/opt/spack/linux-centos8-x86_64/intel-20.0.4/zlib-1.2.11-dudhhig
+      buildable: false
+    cmake:
+      externals:
+      - spec: cmake@3.20.3
+        prefix: /gpfs/fs1/software/centos7/spack-latest/opt/spack/linux-centos7-x86_64/gcc-6.5.0/cmake-3.20.3-vedypwm
+        modules:
+        - cmake/3.20.3-vedypwm
+      buildable: false
+    perl:
+      externals:
+      - spec: perl@5.30.3
+        prefix: /gpfs/fs1/software/centos7/spack-latest/opt/spack/linux-centos7-x86_64/gcc-6.5.0/perl-5.30.3-co3kopi
+        modules:
+          - perl/5.30.3-co3kopi
+      buildable: false
+    gcc:
+      externals:
+      - spec: gcc@11.3.0
+        prefix: /gpfs/fs1/soft/bebop/spack/opt/spack/linux-centos7-x86_64/gcc-4.8.5/gcc-11.3.0-zr6ek74
+        modules:
+        - gcc/11.3.0
+      buildable: false
+    slurm:
+      externals:
+      - spec: slurm@17-11-7-1
+        prefix: /usr
+      buildable: false
+  config:
+    install_missing_compilers: false
+  compilers:
+  - compiler:
+      spec: gcc@11.3.0
+      paths:
+        cc: /gpfs/fs1/soft/bebop/spack/opt/spack/linux-centos7-x86_64/gcc-4.8.5/gcc-11.3.0-zr6ek74/bin/gcc
+        cxx: /gpfs/fs1/soft/bebop/spack/opt/spack/linux-centos7-x86_64/gcc-4.8.5/gcc-11.3.0-zr6ek74/bin/g++
+        f77: /gpfs/fs1/soft/bebop/spack/opt/spack/linux-centos7-x86_64/gcc-4.8.5/gcc-11.3.0-zr6ek74/bin/gfortran
+        fc: /gpfs/fs1/soft/bebop/spack/opt/spack/linux-centos7-x86_64/gcc-4.8.5/gcc-11.3.0-zr6ek74/bin/gfortran
+      flags: {}
+      operating_system: centos7
+      target: x86_64
+      modules: []
+      environment: {}
+      extra_rpaths: []


### PR DESCRIPTION
This merge adds a yaml file for Anvil's Gnu and OpenMPI environment that uses a more recent `gcc`.  This appears to be necessary on Anvil to avoid problems when compiling Albany with `gcc` 8.2.0, see:
https://github.com/MPAS-Dev/compass/pull/523#issuecomment-1434678125
https://github.com/E3SM-Project/spack/issues/12

<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->

<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [x] Document (in a comment titled `Testing` in this PR) any testing that was used to verify the changes

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->
