### PR TITLE
Update albany_input.yaml with new basal pressure setting

### DIFF
--- a/compass/landice/tests/humboldt/albany_input.yaml
+++ b/compass/landice/tests/humboldt/albany_input.yaml
@@ -16,7 +16,7 @@ ANONYMOUS:
           Type: Power Law
           Power Exponent: 3.33333333333E-1
           Effective Pressure Type: Hydrostatic
-
+          Use Pressurized Bed Above Sea Level: False
 # Discretization Description
   Discretization:
     # Exodus Output File Name: albany_output.exo


### PR DESCRIPTION
Need to add `Use Pressurized Bed Above Sea Level: False` setting to albany_input.yaml for landice_humboldt_mesh-3km_restart_test_velo-fo_calving-von_mises_stress_damage-threshold_faceMelting test case to run, after https://github.com/sandialabs/Albany/pull/863

<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->

<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist

* [x] Document (in a comment titled `Testing` in this PR) any testing that was used to verify the changes

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->
