### PR TITLE
Fix deployment with latest conda (23.1.0)

### DIFF
--- a/conda/bootstrap.py
+++ b/conda/bootstrap.py
@@ -232,7 +232,7 @@ def get_env_setup(args, config, machine, compiler, mpi, env_type, source_path,
         f'source {conda_base}/etc/profile.d/conda.sh; ' \
         f'source {conda_base}/etc/profile.d/mamba.sh'
 
-    activate_env = f'{source_activation_scripts}; conda activate {env_name}'
+    activate_env = f'{source_activation_scripts}; mamba activate {env_name}'
 
     return python, recreate, conda_mpi, activ_suffix, env_suffix, \
         activ_path, env_path, env_name, activate_env, spack_env
@@ -268,7 +268,7 @@ def build_conda_env(env_type, recreate, machine, mpi, conda_mpi, version,
         f'{conda_base}/etc/profile.d/conda.sh')
 
     activate_env = \
-        f'source {base_activation_script}; conda activate {env_name}'
+        f'source {base_activation_script}; mamba activate {env_name}'
 
     with open(f'{conda_template_path}/spec-file.template', 'r') as f:
         template = Template(f.read())
@@ -830,7 +830,7 @@ def main():  # noqa: C901
         f'source {conda_base}/etc/profile.d/conda.sh; ' \
         f'source {conda_base}/etc/profile.d/mamba.sh'
 
-    activate_base = f'{source_activation_scripts}; conda activate'
+    activate_base = f'{source_activation_scripts}; mamba activate'
 
     compilers, mpis = get_compilers_mpis(config, machine, args.compilers,
                                          args.mpis, source_path)

--- a/conda/configure_compass_env.py
+++ b/conda/configure_compass_env.py
@@ -42,7 +42,7 @@ def bootstrap(activate_install_env, source_path, local_conda_build):
 
     print('Creating the compass conda environment\n')
     bootstrap_command = '{}/conda/bootstrap.py'.format(source_path)
-    command = '{}; ' \
+    command = '{} && ' \
               '{} {}'.format(activate_install_env, bootstrap_command,
                              ' '.join(sys.argv[1:]))
     if local_conda_build is not None:
@@ -61,13 +61,13 @@ def setup_install_env(env_name, activate_base, use_local, logger, recreate,
     packages = 'progressbar2 jinja2 "mache=1.10.0"'
     if recreate or not os.path.exists(env_path):
         print('Setting up a conda environment for installing compass\n')
-        commands = '{}; ' \
+        commands = '{} && ' \
                    'mamba create -y -n {} {} {}'.format(activate_base,
                                                         env_name, channels,
                                                         packages)
     else:
         print('Updating conda environment for installing compass\n')
-        commands = '{}; ' \
+        commands = '{} && ' \
                    'mamba install -y -n {} {} {}'.format(activate_base,
                                                          env_name, channels,
                                                          packages)
@@ -87,13 +87,13 @@ def main():
     env_name = 'compass_bootstrap'
 
     source_activation_scripts = \
-        'source {}/etc/profile.d/conda.sh; ' \
+        'source {}/etc/profile.d/conda.sh && ' \
         'source {}/etc/profile.d/mamba.sh'.format(conda_base, conda_base)
 
-    activate_base = '{}; mamba activate'.format(source_activation_scripts)
+    activate_base = '{} && mamba activate'.format(source_activation_scripts)
 
     activate_install_env = \
-        '{}; ' \
+        '{} && ' \
         'mamba activate {}'.format(source_activation_scripts, env_name)
     try:
         os.makedirs('conda/logs')

--- a/conda/configure_compass_env.py
+++ b/conda/configure_compass_env.py
@@ -8,16 +8,21 @@ import sys
 try:
     from configparser import ConfigParser
 except ImportError:
-    from six.moves import configparser
     import six
+    from six.moves import configparser
 
     if six.PY2:
         ConfigParser = configparser.SafeConfigParser
     else:
         ConfigParser = configparser.ConfigParser
 
-from shared import parse_args, get_conda_base, check_call, install_miniconda, \
-    get_logger
+from shared import (
+    check_call,
+    get_conda_base,
+    get_logger,
+    install_miniconda,
+    parse_args,
+)
 
 
 def get_config(config_file):
@@ -85,11 +90,11 @@ def main():
         'source {}/etc/profile.d/conda.sh; ' \
         'source {}/etc/profile.d/mamba.sh'.format(conda_base, conda_base)
 
-    activate_base = '{}; conda activate'.format(source_activation_scripts)
+    activate_base = '{}; mamba activate'.format(source_activation_scripts)
 
     activate_install_env = \
         '{}; ' \
-        'conda activate {}'.format(source_activation_scripts, env_name)
+        'mamba activate {}'.format(source_activation_scripts, env_name)
     try:
         os.makedirs('conda/logs')
     except OSError:

--- a/conda/shared.py
+++ b/conda/shared.py
@@ -171,9 +171,22 @@ def install_miniconda(conda_base, activate_base, logger):
     backup_bashrc()
 
     print('Doing initial setup\n')
+
     commands = '{} && ' \
                'conda config --add channels conda-forge && ' \
-               'conda config --set channel_priority strict && ' \
+               'conda config --set channel_priority strict' \
+               ''.format(activate_base)
+
+    check_call(commands, logger=logger)
+
+    commands = '{} && ' \
+               'conda remove -y boa'.format(activate_base)
+    try:
+        check_call(commands, logger=logger)
+    except subprocess.CalledProcessError:
+        pass
+
+    commands = '{} && ' \
                'mamba update -y --all && ' \
                'mamba init'.format(activate_base)
 

--- a/conda/shared.py
+++ b/conda/shared.py
@@ -116,7 +116,7 @@ def get_spack_base(spack_base, config):
 
 
 def check_call(commands, env=None, logger=None):
-    print_command = '\n   '.join(commands.split('; '))
+    print_command = '\n   '.join(commands.split(' && '))
     if logger is None:
         print('\n Running:\n   {}\n'.format(print_command))
     else:
@@ -171,11 +171,10 @@ def install_miniconda(conda_base, activate_base, logger):
     backup_bashrc()
 
     print('Doing initial setup\n')
-    commands = '{}; ' \
-               'conda config --add channels conda-forge; ' \
-               'conda config --set channel_priority strict; ' \
-               'mamba update -y --all; ' \
-               'mamba install -y boa; ' \
+    commands = '{} && ' \
+               'conda config --add channels conda-forge && ' \
+               'conda config --set channel_priority strict && ' \
+               'mamba update -y --all && ' \
                'mamba init'.format(activate_base)
 
     check_call(commands, logger=logger)

--- a/conda/shared.py
+++ b/conda/shared.py
@@ -1,17 +1,17 @@
 from __future__ import print_function
 
-import os
-import sys
 import argparse
-import subprocess
-import platform
 import logging
+import os
+import platform
 import shutil
+import subprocess
+import sys
 
 try:
-    from urllib.request import urlopen, Request
+    from urllib.request import Request, urlopen
 except ImportError:
-    from urllib2 import urlopen, Request
+    from urllib2 import Request, urlopen
 
 
 def parse_args(bootstrap):
@@ -155,7 +155,7 @@ def install_miniconda(conda_base, activate_base, logger):
         else:
             system = 'Linux'
         miniconda = 'Mambaforge-{}-x86_64.sh'.format(system)
-        url = 'https://github.com/conda-forge/miniforge/releases/latest/download/{}'.format(miniconda)
+        url = 'https://github.com/conda-forge/miniforge/releases/latest/download/{}'.format(miniconda)  # noqa: E501
         print(url)
         req = Request(url, headers={'User-Agent': 'Mozilla/5.0'})
         f = urlopen(req)
@@ -174,8 +174,8 @@ def install_miniconda(conda_base, activate_base, logger):
     commands = '{}; ' \
                'conda config --add channels conda-forge; ' \
                'conda config --set channel_priority strict; ' \
-               'conda install -y boa; ' \
-               'conda update -y --all; ' \
+               'mamba update -y --all; ' \
+               'mamba install -y boa; ' \
                'mamba init'.format(activate_base)
 
     check_call(commands, logger=logger)


### PR DESCRIPTION
<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->

It turns out that the `boa` package isn't compatible with the latest `mamba`, but the latest `mamba` is needed in order to use the latest `conda`.  So when compass tries to update everything, things end in a bad state. (An error message relate to a missing `no_user` attribute occurs when running `mamba`.)

The solution seems to be not to include `boa` in the base environment for now.  This won't affect compass, since `boa` is used to build conda packages and was just there for convenience (I sometimes need to build conda packages for compass maintenance).

<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [x] Document (in a comment titled `Testing` in this PR) any testing that was used to verify the changes

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->

closes #544 