### PR TITLE
Fix `isomip_plus` streamfunction computation

### DIFF
--- a/compass/ocean/tests/isomip_plus/streamfunction.py
+++ b/compass/ocean/tests/isomip_plus/streamfunction.py
@@ -432,6 +432,7 @@ def _interpolate_horizontal_transport_zlevel(ds, z, outFileName,
             zBot = dsIn.zInterfaceEdge.isel(nVertLevelsP1=inZIndex + 1)
             inTransportPerDepth = \
                 dsIn.transportPerDepth.isel(nVertLevels=inZIndex)
+            inTransportPerDepth = inTransportPerDepth.fillna(value=0.)
 
             zt = numpy.minimum(zTop, z0)
             zb = numpy.maximum(zBot, z1)


### PR DESCRIPTION
<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->
The fix involves replacing NaNs in transport with zeros, so that the resulting sums are not themselves contaminated with NaNs.

This merge also contains some linting-related clean up.
<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [x] Document (in a comment titled `Testing` in this PR) any testing that was used to verify the changes

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->
