### PR TITLE
Add VLR test to internal wave case

### DIFF
--- a/compass/ocean/suites/pr.txt
+++ b/compass/ocean/suites/pr.txt
@@ -3,6 +3,9 @@ ocean/baroclinic_channel/10km/threads_test
 ocean/baroclinic_channel/10km/decomp_test
 ocean/baroclinic_channel/10km/restart_test
 
+ocean/internal_wave/default
+ocean/internal_wave/vlr/default
+
 ocean/global_convergence/qu/cosine_bell
   cached: QU60_mesh QU60_init QU90_mesh QU90_init QU120_mesh QU120_init
   cached: QU150_mesh QU150_init QU180_mesh QU180_init QU210_mesh QU210_init

--- a/compass/ocean/tests/internal_wave/__init__.py
+++ b/compass/ocean/tests/internal_wave/__init__.py
@@ -1,7 +1,7 @@
-from compass.testgroup import TestGroup
 from compass.ocean.tests.internal_wave.default import Default
 from compass.ocean.tests.internal_wave.rpe_test import RpeTest
 from compass.ocean.tests.internal_wave.ten_day_test import TenDayTest
+from compass.testgroup import TestGroup
 
 
 class InternalWave(TestGroup):
@@ -17,5 +17,7 @@ class InternalWave(TestGroup):
         super().__init__(mpas_core=mpas_core, name='internal_wave')
 
         self.add_test_case(Default(test_group=self))
+        self.add_test_case(Default(test_group=self, vlr=True))
         self.add_test_case(RpeTest(test_group=self))
+        self.add_test_case(RpeTest(test_group=self, vlr=True))
         self.add_test_case(TenDayTest(test_group=self))

--- a/compass/ocean/tests/internal_wave/default/__init__.py
+++ b/compass/ocean/tests/internal_wave/default/__init__.py
@@ -18,12 +18,12 @@ class Default(TestCase):
         ----------
         test_group : compass.ocean.tests.internal_wave.InternalWave
             The test group that this test case belongs to
-        vlr : boolean
+        vlr : boolean, optional
             Whether vertical Lagrangian remapping will be tested
         """
         name = 'default'
         if vlr:
-            subdir = 'vlr/' + name
+            subdir = f'vlr/{name}'
         else:
             subdir = name
         super().__init__(test_group=test_group, subdir=subdir, name=name)

--- a/compass/ocean/tests/internal_wave/default/__init__.py
+++ b/compass/ocean/tests/internal_wave/default/__init__.py
@@ -18,7 +18,8 @@ class Default(TestCase):
         ----------
         test_group : compass.ocean.tests.internal_wave.InternalWave
             The test group that this test case belongs to
-        vlr : boolean, optional
+
+        vlr : bool, optional
             Whether vertical Lagrangian remapping will be tested
         """
         name = 'default'

--- a/compass/ocean/tests/internal_wave/default/__init__.py
+++ b/compass/ocean/tests/internal_wave/default/__init__.py
@@ -1,7 +1,7 @@
-from compass.testcase import TestCase
-from compass.ocean.tests.internal_wave.initial_state import InitialState
 from compass.ocean.tests.internal_wave.forward import Forward
+from compass.ocean.tests.internal_wave.initial_state import InitialState
 from compass.ocean.tests.internal_wave.viz import Viz
+from compass.testcase import TestCase
 from compass.validate import compare_variables
 
 
@@ -10,7 +10,7 @@ class Default(TestCase):
     The default test case for the internal wave test
     """
 
-    def __init__(self, test_group):
+    def __init__(self, test_group, vlr=False):
         """
         Create the test case
 
@@ -18,10 +18,18 @@ class Default(TestCase):
         ----------
         test_group : compass.ocean.tests.internal_wave.InternalWave
             The test group that this test case belongs to
+        vlr : boolean
+            Whether vertical Lagrangian remapping will be tested
         """
-        super().__init__(test_group=test_group, name='default')
+        name = 'default'
+        if vlr:
+            subdir = 'vlr/' + name
+        else:
+            subdir = name
+        super().__init__(test_group=test_group, subdir=subdir, name=name)
         self.add_step(InitialState(test_case=self))
-        self.add_step(Forward(test_case=self, ntasks=4, openmp_threads=1))
+        self.add_step(Forward(test_case=self, ntasks=4, openmp_threads=1,
+                              vlr=vlr))
         self.add_step(Viz(test_case=self), run_by_default=False)
 
     def validate(self):

--- a/compass/ocean/tests/internal_wave/forward.py
+++ b/compass/ocean/tests/internal_wave/forward.py
@@ -8,7 +8,7 @@ class Forward(Step):
     test cases.
     """
     def __init__(self, test_case, name='forward', subdir=None, ntasks=1,
-                 min_tasks=None, openmp_threads=1, nu=None):
+                 min_tasks=None, openmp_threads=1, nu=None, vlr=False):
         """
         Create a new test case
 
@@ -49,6 +49,11 @@ class Forward(Step):
             # update the viscosity to the requested value
             options = {'config_mom_del2': '{}'.format(nu)}
             self.add_namelist_options(options)
+
+        if vlr:
+            # turn vertical Lagrangian-remapping on
+            self.add_namelist_options({
+                'config_vert_advection_method': '"remap"'})
 
         self.add_streams_file('compass.ocean.tests.internal_wave',
                               'streams.forward')

--- a/compass/ocean/tests/internal_wave/forward.py
+++ b/compass/ocean/tests/internal_wave/forward.py
@@ -37,6 +37,9 @@ class Forward(Step):
 
         nu : float, optional
             the viscosity (if different from the default for the test group)
+
+        vlr : boolean, optional
+            Whether vertical Lagrangian remapping will be tested
         """
         if min_tasks is None:
             min_tasks = ntasks
@@ -53,7 +56,7 @@ class Forward(Step):
         if vlr:
             # turn vertical Lagrangian-remapping on
             self.add_namelist_options({
-                'config_vert_advection_method': '"remap"'})
+                'config_vert_advection_method': "'remap'"})
 
         self.add_streams_file('compass.ocean.tests.internal_wave',
                               'streams.forward')

--- a/compass/ocean/tests/internal_wave/rpe_test/__init__.py
+++ b/compass/ocean/tests/internal_wave/rpe_test/__init__.py
@@ -19,6 +19,9 @@ class RpeTest(TestCase):
         ----------
         test_group : compass.ocean.tests.internal_wave.InternalWave
             The test group that this test case belongs to
+
+        vlr : boolean, optional
+            Whether vertical Lagrangian remapping will be tested
         """
         name = 'rpe_test'
         if vlr:

--- a/compass/ocean/tests/internal_wave/rpe_test/__init__.py
+++ b/compass/ocean/tests/internal_wave/rpe_test/__init__.py
@@ -1,7 +1,7 @@
-from compass.testcase import TestCase
-from compass.ocean.tests.internal_wave.initial_state import InitialState
 from compass.ocean.tests.internal_wave.forward import Forward
+from compass.ocean.tests.internal_wave.initial_state import InitialState
 from compass.ocean.tests.internal_wave.rpe_test.analysis import Analysis
+from compass.testcase import TestCase
 
 
 class RpeTest(TestCase):
@@ -11,7 +11,7 @@ class RpeTest(TestCase):
     5 different values of the viscosity at the given resolution.
     """
 
-    def __init__(self, test_group):
+    def __init__(self, test_group, vlr=False):
         """
         Create the test case
 
@@ -21,8 +21,12 @@ class RpeTest(TestCase):
             The test group that this test case belongs to
         """
         name = 'rpe_test'
-        super().__init__(test_group=test_group, name=name)
-
+        if vlr:
+            subdir = 'vlr/' + name
+        else:
+            subdir = name
+        self.vlr = vlr
+        super().__init__(test_group=test_group, subdir=subdir, name=name)
 
     def configure(self):
         """
@@ -36,7 +40,7 @@ class RpeTest(TestCase):
             name = f'rpe_test_{index + 1}_nu_{nu:g}'
             step = Forward(
                 test_case=self, name=name, subdir=name, ntasks=4,
-                openmp_threads=1, nu=float(nu))
+                openmp_threads=1, nu=float(nu), vlr=self.vlr)
 
             step.add_namelist_file(
                 'compass.ocean.tests.internal_wave.rpe_test',

--- a/compass/ocean/tests/internal_wave/rpe_test/__init__.py
+++ b/compass/ocean/tests/internal_wave/rpe_test/__init__.py
@@ -20,7 +20,7 @@ class RpeTest(TestCase):
         test_group : compass.ocean.tests.internal_wave.InternalWave
             The test group that this test case belongs to
 
-        vlr : boolean, optional
+        vlr : bool, optional
             Whether vertical Lagrangian remapping will be tested
         """
         name = 'rpe_test'

--- a/compass/ocean/tests/internal_wave/viz.py
+++ b/compass/ocean/tests/internal_wave/viz.py
@@ -1,6 +1,6 @@
-import xarray
-import numpy
 import matplotlib.pyplot as plt
+import numpy
+import xarray
 
 from compass.step import Step
 
@@ -34,7 +34,6 @@ class Viz(Step):
 
         ds = xarray.open_dataset('output.nc')
         figsize = [6.4, 4.8]
-        markersize = 20
         if 'Time' not in ds.dims:
             print('Dataset missing time dimension')
             return
@@ -53,8 +52,6 @@ class Viz(Step):
 
             xEdge = numpy.zeros((nEdges))
             xEdge = ds1.xEdge
-            xCell = numpy.zeros((nCells))
-            xCell = ds1.xCell
             yCell = numpy.zeros((nCells))
             yCell = ds1.yCell
 
@@ -74,27 +71,27 @@ class Viz(Step):
 
             zMid = numpy.zeros((nCells, nVertLevels))
             for zIndex in range(nVertLevels):
-                zMid[:, zIndex] = (zInterface[:, zIndex]
-                                   + numpy.divide(zInterface[:, zIndex + 1]
-                                                  - zInterface[:, zIndex], 2.))
+                zMid[:, zIndex] = (zInterface[:, zIndex] +
+                                   numpy.divide(zInterface[:, zIndex + 1] -
+                                                zInterface[:, zIndex], 2.))
 
             # Solve for lateral boundaries of uNormal at cell centers for
             # x-section
             cellsOnEdge = ds1.cellsOnEdge
             cellsOnEdge_x = cellsOnEdge[edgeMask_x, :]
-            yEdges = numpy.zeros((len(cellsOnEdge_x)+1))
+            yEdges = numpy.zeros((len(cellsOnEdge_x) + 1))
             for i in range(len(cellsOnEdge_x)):
                 if cellsOnEdge[i, 1] == 0:
                     yEdges[i] = yCell[cellsOnEdge_x[i, 0] - 1]
-                    yEdges[i+1] = yCell[cellsOnEdge_x[i, 0] - 1]
+                    yEdges[i + 1] = yCell[cellsOnEdge_x[i, 0] - 1]
                 elif cellsOnEdge[i, 1] == 0:
                     yEdges[i] = yCell[cellsOnEdge_x[i, 1] - 1]
-                    yEdges[i+1] = yCell[cellsOnEdge_x[i, 1] - 1]
+                    yEdges[i + 1] = yCell[cellsOnEdge_x[i, 1] - 1]
                 else:
                     yEdges[i] = min(yCell[cellsOnEdge_x[i, 0] - 1],
                                     yCell[cellsOnEdge_x[i, 1] - 1])
-                    yEdges[i+1] = max(yCell[cellsOnEdge_x[i, 0] - 1],
-                                      yCell[cellsOnEdge_x[i, 1] - 1])
+                    yEdges[i + 1] = max(yCell[cellsOnEdge_x[i, 0] - 1],
+                                        yCell[cellsOnEdge_x[i, 1] - 1])
 
             zInterfaces_mesh, yEdges_mesh = numpy.meshgrid(zInterface[0, :],
                                                            yEdges)
@@ -109,7 +106,7 @@ class Viz(Step):
             plt.pcolormesh(numpy.divide(yEdges_mesh, 1e3),
                            zInterfaces_mesh,
                            normalVelocity_xmesh.values,
-                           cmap='RdBu', vmin=-1.*cmax, vmax=cmax)
+                           cmap='RdBu', vmin=-1. * cmax, vmax=cmax)
             plt.xlabel('y (km)')
             plt.ylabel('z (m)')
             cbar = plt.colorbar()
@@ -182,7 +179,7 @@ class Viz(Step):
             plt.figure(figsize=figsize, dpi=100)
             plt.pcolormesh(numpy.divide(yCells_mesh, 1e3),
                            zInterfaces_mesh,
-                           w_x.values, cmap='viridis')
+                           w_x.values[:, :-1], cmap='viridis')
             plt.xlabel('y (km)')
             plt.ylabel('z (m)')
             cbar = plt.colorbar()

--- a/docs/developers_guide/ocean/test_groups/internal_wave.rst
+++ b/docs/developers_guide/ocean/test_groups/internal_wave.rst
@@ -42,9 +42,11 @@ The class :py:class:`compass.ocean.tests.internal_wave.forward.Forward`
 defines a step for running MPAS-Ocean from the initial condition produced in
 the ``initial_state`` step.  If ``nu`` is provided as an argument to the
 constructor, the associate namelist option (``config_mom_del2``) will be given
-this value. Namelist and streams files are generate during ``setup()`` and
-MPAS-Ocean is run (including updating PIO namelist options and generating a
-graph partition) in ``run()``.
+this value. If ``vlr`` is true, ``config_vertical_advection_method`` will be
+assigned ``"remap"`` rather than the default value of ``"flux-form"``.
+Namelist and streams files are generate during ``setup()`` and MPAS-Ocean is
+run (including updating PIO namelist options and generating a graph partition)
+in ``run()``.
 
 .. _dev_ocean_internal_wave_default:
 
@@ -55,6 +57,9 @@ The :py:class:`compass.ocean.tests.internal_wave.default.Default`
 test performs a 15-minute run on 4 cores.  It doesn't contain any
 :ref:`dev_validation`.
 
+There is also a variant for testing vertical Lagrangian remap capabilities at
+``ocean/internal_wave/vlr/default``.
+
 .. _dev_ocean_internal_wave_rpe_test:
 
 rpe_test
@@ -62,8 +67,9 @@ rpe_test
 
 The :py:class:`compass.ocean.tests.internal_wave.rpe_test.RpeTest`
 performs a longer (20 day) integration of the model forward in time at 5
-different values of the viscosity.  These ``nu`` values are later added as arguments to the ``Forward`` steps'
-constructors when they are added to the test case:
+different values of the viscosity.  These ``nu`` values are later added as
+arguments to the ``Forward`` steps' constructors when they are added to the
+test case:
 
 .. code-block:: python
 
@@ -79,6 +85,9 @@ makes plots of the final results with each value of the viscosity.
 
 This test is resource intensive enough that it is not used in regression
 testing.
+
+There is also a variant for testing vertical Lagrangian remap capabilities at
+``ocean/internal_wave/vlr/rpe_test``.
 
 .. _dev_ocean_internal_wave_ten_day_test:
 

--- a/docs/users_guide/ocean/test_groups/internal_wave.rst
+++ b/docs/users_guide/ocean/test_groups/internal_wave.rst
@@ -130,6 +130,9 @@ default
 internal wave test case for a short (15 min) test run and validation of
 prognostic variables for regression testing.
 
+There is also a variant for testing vertical Lagrangian remap capabilities at
+``ocean/internal_wave/vlr/default``.
+
 rpe_test
 --------
 
@@ -141,6 +144,11 @@ Results of these tests have been used
 to show that MPAS-Ocean has lower spurious dissipation of reference potential
 energy (RPE) than POP, MOM and MITgcm models
 (`Petersen et al. 2015 <https://doi.org/10.1016/j.ocemod.2014.12.004>`_).
+
+There is also a variant for testing vertical Lagrangian remap capabilities at
+``ocean/internal_wave/vlr/rpe_test``. The result of this test should show less
+RPE for all viscosity values at every time horizon compared with the flux-form
+vertical advection method.
 
 ten_day_test
 ------------


### PR DESCRIPTION
Currently, there are no tests of the vertical Lagrangian remapping capability in compass. This PR adds a VLR version for the default and RPE tests of the internal wave test group.

Checklist
* [X] User's Guide has been updated
* [X] Developer's Guide has been updated
* [X] Documentation has been [built locally](https://mpas-dev.github.io/compass/latest/developers_guide/building_docs.html) and changes look as expected
* [X] Document (in a comment titled `Testing` in this PR) any testing that was used to verify the changes
* [X] New tests have been added to a test suite
