### PR TITLE
Add bathymetry remapping

### DIFF
--- a/compass/ocean/mesh/remap_topography.cfg
+++ b/compass/ocean/mesh/remap_topography.cfg
@@ -1,0 +1,26 @@
+# config options related to remapping topography to an MPAS-Ocean mesh
+[remap_topography]
+
+# the name of the topography file in the bathymetry database
+topo_filename = BedMachineAntarctica_v3_and_GEBCO_2022_0.0125_degree_20230315.nc
+
+# variable names in topo_filename
+lon_var = lon
+lat_var = lat
+bathymetry_var = bathymetry
+ice_draft_var = ice_draft
+ice_thickness_var = thickness
+ice_frac_var = ice_mask
+grounded_ice_frac_var = grounded_mask
+ocean_frac_var = ocean_mask
+
+# the description to include in metadata
+description = Bathymetry is from GEBCO 2022, combined with BedMachine
+              Antarctica v3 around Antarctica.
+
+# the target and minimum number of MPI tasks to use in remapping
+ntasks = 1024
+min_tasks = 360
+
+# remapping method {'bilinear', 'neareststod', 'conserve'}
+method = conserve

--- a/compass/ocean/mesh/remap_topography.py
+++ b/compass/ocean/mesh/remap_topography.py
@@ -1,0 +1,139 @@
+import os
+
+import xarray as xr
+from mpas_tools.io import write_netcdf
+from pyremap import LatLonGridDescriptor, MpasMeshDescriptor, Remapper
+
+from compass.step import Step
+
+
+class RemapTopography(Step):
+    """
+    A step for remapping bathymetry and ice-shelf topography from a
+    latitude-longitude grid to a global MPAS-Ocean mesh
+
+    Attributes
+    ----------
+    base_mesh_step : compass.mesh.spherical.SphericalBaseStep
+        The base mesh step containing input files to this step
+
+    mesh_name : str
+        The name of the MPAS mesh to include in the mapping file
+    """
+
+    def __init__(self, test_case, base_mesh_step, name='remap_topography',
+                 subdir=None, mesh_name='MPAS_mesh'):
+        """
+        Create a new step
+
+        Parameters
+        ----------
+        test_case : compass.ocean.tests.global_ocean.mesh.Mesh
+            The test case this step belongs to
+
+        base_mesh_step : compass.mesh.spherical.SphericalBaseStep
+            The base mesh step containing input files to this step
+
+        name : str, optional
+            the name of the step
+
+        subdir : str, optional
+            the subdirectory for the step.  The default is ``name``
+
+        mesh_name : str, optional
+            The name of the MPAS mesh to include in the mapping file
+        """
+        super().__init__(test_case, name=name, subdir=subdir,
+                         ntasks=None, min_tasks=None)
+        self.base_mesh_step = base_mesh_step
+        self.mesh_name = mesh_name
+
+        self.add_output_file(filename='topography_remapped.nc')
+
+    def setup(self):
+        """
+        Set up the step in the work directory, including downloading any
+        dependencies.
+        """
+        super().setup()
+        topo_filename = self.config.get('remap_topography', 'topo_filename')
+        self.add_input_file(
+            filename='topography.nc',
+            target=topo_filename,
+            database='bathymetry_database')
+
+        base_path = self.base_mesh_step.path
+        base_filename = self.base_mesh_step.config.get(
+            'spherical_mesh', 'mpas_mesh_filename')
+        target = os.path.join(base_path, base_filename)
+        self.add_input_file(filename='base_mesh.nc', work_dir_target=target)
+
+        config = self.config
+        self.ntasks = config.getint('remap_topography', 'ntasks')
+        self.min_tasks = config.getint('remap_topography', 'min_tasks')
+
+    def constrain_resources(self, available_resources):
+        """
+        Constrain ``cpus_per_task`` and ``ntasks`` based on the number of
+        cores available to this step
+
+        Parameters
+        ----------
+        available_resources : dict
+            The total number of cores available to the step
+        """
+        config = self.config
+        self.ntasks = config.getint('remap_topography', 'ntasks')
+        self.min_tasks = config.getint('remap_topography', 'min_tasks')
+        super().constrain_resources(available_resources)
+
+    def run(self):
+        """
+        Run this step of the test case
+        """
+        config = self.config
+        logger = self.logger
+        parallel_executable = config.get('parallel', 'parallel_executable')
+
+        lon_var = config.get('remap_topography', 'lon_var')
+        lat_var = config.get('remap_topography', 'lat_var')
+        method = config.get('remap_topography', 'method')
+
+        in_descriptor = LatLonGridDescriptor.read(fileName='topography.nc',
+                                                  lonVarName=lon_var,
+                                                  latVarName=lat_var)
+
+        in_mesh_name = in_descriptor.meshName
+
+        out_mesh_name = self.mesh_name
+        out_descriptor = MpasMeshDescriptor(fileName='base_mesh.nc',
+                                            meshName=self.mesh_name)
+
+        mapping_file_name = \
+            f'map_{in_mesh_name}_to_{out_mesh_name}_{method}.nc'
+        remapper = Remapper(in_descriptor, out_descriptor, mapping_file_name)
+
+        remapper.build_mapping_file(method=method, mpiTasks=self.ntasks,
+                                    tempdir='.', logger=logger,
+                                    esmf_parallel_exec=parallel_executable)
+
+        remapper.remap_file(inFileName='topography.nc',
+                            outFileName='topography_ncremap.nc',
+                            logger=logger)
+
+        ds_in = xr.open_dataset('topography_ncremap.nc')
+        ds_in = ds_in.rename({'ncol': 'nCells'})
+        ds_out = xr.Dataset()
+        rename = {'bathymetry_var': 'bed_elevation',
+                  'ice_draft_var': 'landIceDraftObserved',
+                  'ice_thickness_var': 'landIceThkObserved',
+                  'ice_frac_var': 'landIceFracObserved',
+                  'grounded_ice_frac_var': 'landIceGroundedFracObserved',
+                  'ocean_frac_var': 'oceanFracObserved'}
+
+        for option in rename:
+            in_var = config.get('remap_topography', option)
+            out_var = rename[option]
+            ds_out[out_var] = ds_in[in_var]
+
+        write_netcdf(ds_out, 'topography_remapped.nc')

--- a/compass/ocean/tests/global_ocean/__init__.py
+++ b/compass/ocean/tests/global_ocean/__init__.py
@@ -46,6 +46,7 @@ class GlobalOcean(TestGroup):
         # we do a lot of tests for QU240/QUwISC240
         self._add_tests(mesh_names=['QU240', 'Icos240', 'QUwISC240'],
                         DynamicAdjustment=QU240DynamicAdjustment,
+                        remap_topography=False,
                         include_rk4=True,
                         include_regression=True,
                         include_en4_1900=True,
@@ -74,13 +75,14 @@ class GlobalOcean(TestGroup):
         # A test case for making E3SM support files from an existing mesh
         self.add_test_case(FilesForE3SM(test_group=self))
 
-    def _add_tests(self, mesh_names, DynamicAdjustment, include_rk4=False,
-                   include_regression=False, include_en4_1900=False,
-                   include_bgc=False):
+    def _add_tests(self, mesh_names, DynamicAdjustment, remap_topography=True,
+                   include_rk4=False, include_regression=False,
+                   include_en4_1900=False, include_bgc=False):
         """ Add test cases for the given mesh(es) """
 
         for mesh_name in mesh_names:
-            mesh_test = Mesh(test_group=self, mesh_name=mesh_name)
+            mesh_test = Mesh(test_group=self, mesh_name=mesh_name,
+                             remap_topography=remap_topography)
             self.add_test_case(mesh_test)
 
             init_test = Init(test_group=self, mesh=mesh_test,

--- a/compass/ocean/tests/global_ocean/global_ocean.cfg
+++ b/compass/ocean/tests/global_ocean/global_ocean.cfg
@@ -3,7 +3,7 @@
 
 ## config options related to the step for culling land from the mesh
 # number of cores to use
-cull_mesh_cpus_per_task = 18
+cull_mesh_cpus_per_task = 128
 # minimum of cores, below which the step fails
 cull_mesh_min_cpus_per_task = 1
 # maximum memory usage allowed (in MB)

--- a/compass/ocean/tests/global_ocean/init/streams.topo
+++ b/compass/ocean/tests/global_ocean/init/streams.topo
@@ -1,0 +1,15 @@
+<streams>
+<stream name="topography"
+        type="input"
+        filename_template="topography.nc"
+        input_interval="initial_only" >
+
+	<var name="bed_elevation"/>
+	<var name="landIceDraftObserved"/>
+	<var name="landIceThkObserved"/>
+	<var name="landIceFracObserved"/>
+	<var name="landIceGroundedFracObserved"/>
+	<var name="oceanFracObserved"/>
+</stream>
+
+</streams>

--- a/docs/developers_guide/ocean/api.rst
+++ b/docs/developers_guide/ocean/api.rst
@@ -839,6 +839,12 @@ ocean framework
    mesh.floodplain.FloodplainMeshStep
    mesh.floodplain.FloodplainMeshStep.run
 
+   mesh.remap_topography.RemapTopography
+   mesh.remap_topography.RemapTopography.setup
+   mesh.remap_topography.RemapTopography.constrain_resources
+   mesh.remap_topography.RemapTopography.run
+
+
    haney.compute_haney_number
 
    iceshelf.compute_land_ice_pressure_and_draft

--- a/docs/developers_guide/ocean/framework.rst
+++ b/docs/developers_guide/ocean/framework.rst
@@ -42,8 +42,38 @@ as config options from ``vertical_grid``.
 Mesh
 ----
 
-The ``compass.ocean.mesh`` package includes modules for spherical ocean meshes
-shared across test groups.
+The ``compass.ocean.mesh`` package includes modules for modifying spherical
+ocean meshes shared across test groups.
+
+.. _dev_ocean_framework_remap_topogrpahy:
+
+Remapping Topography
+~~~~~~~~~~~~~~~~~~~~
+
+After building a base spherical mesh (see :ref:`dev_spherical_meshes`),
+the global ocean :ref:`dev_ocean_global_ocean_mesh` includes a step for
+remapping topography data (bathymetry, ocean mask, land-ice draft, land-ice
+thickness, grounded and floating land-ice masks, etc.) to the MPAS mesh.  This
+step is controlled by config options described in
+:ref:`ocean_remap_topography`.
+
+The step uses the `pyremap <https://mpas-dev.github.io/pyremap/stable/>`_
+package to call
+`ESMF_RegridWeightGen <https://earthsystemmodeling.org/docs/release/ESMF_8_4_1/ESMF_refdoc/node3.html#SECTION03020000000000000000>`_
+to generate a mapping file, then it uses
+`ncremap <https://nco.sourceforge.net/nco.html#ncremap-netCDF-Remapper>`_
+to perform remapping to the MPAS mesh.  Then, it renames the
+topography variables to the following names, expected in MPAS-Ocean's init mode
+for the global ocean:
+
+.. code-block:: python
+
+    rename = {'bathymetry_var': 'bed_elevation',
+              'ice_draft_var': 'landIceDraftObserved',
+              'ice_thickness_var': 'landIceThkObserved',
+              'ice_frac_var': 'landIceFracObserved',
+              'grounded_ice_frac_var': 'landIceGroundedFracObserved',
+              'ocean_frac_var': 'oceanFracObserved'}
 
 
 .. _dev_ocean_framework_cull_mesh:

--- a/docs/users_guide/ocean/framework/index.rst
+++ b/docs/users_guide/ocean/framework/index.rst
@@ -11,4 +11,5 @@ test groups are added.
    :titlesonly:
 
    ice_shelf
+   mesh
    vertical

--- a/docs/users_guide/ocean/framework/mesh.rst
+++ b/docs/users_guide/ocean/framework/mesh.rst
@@ -1,0 +1,89 @@
+.. _ocean_mesh:
+
+Mesh
+====
+
+Several ocean test groups use a set of common functionality for manipulating
+MPAS-Ocean meshes.  This includes remapping topography datasets to the MPAS
+mesh, culling land from the mesh based on a series of masks.
+
+.. _ocean_remap_topography:
+
+Remapping topography
+--------------------
+
+After building a base spherical mesh (see :ref:`dev_spherical_meshes`),
+the global ocean :ref:`global_ocean_mesh` includes a step for remapping
+topography data (bathymetry, ocean mask, land-ice draft, land-ice thickness,
+grounded and floating land-ice masks, etc.) to the MPAS mesh.  This step is
+controlled by the following config options:
+
+.. code-block:: cfg
+
+    # config options related to remapping topography to an MPAS-Ocean mesh
+    [remap_topography]
+
+    # the name of the topography file in the bathymetry database
+    topo_filename = BedMachineAntarctica_v3_and_GEBCO_2022_0.0125_degree_20230315.nc
+
+    # variable names in topo_filename
+    lon_var = lon
+    lat_var = lat
+    bathymetry_var = bathymetry
+    ice_draft_var = ice_draft
+    ice_thickness_var = thickness
+    ice_frac_var = ice_mask
+    grounded_ice_frac_var = grounded_mask
+    ocean_frac_var = ocean_mask
+
+    # the description to include in metadata
+    description = Bathymetry is from GEBCO 2022, combined with BedMachine
+                  Antarctica v3 around Antarctica.
+
+    # the target and minimum number of MPI tasks to use in remapping
+    ntasks = 1024
+    min_tasks = 360
+
+    # remapping method {'bilinear', 'neareststod', 'conserve'}
+    method = conserve
+
+The topography filename should be something from the ocean
+`bathymetry database <https://web.lcrc.anl.gov/public/e3sm/mpas_standalonedata/mpas-ocean/bathymetry_database/>`_.
+
+The various variable names are designed to provide flexibility in case a given
+topography file used different variable names tha the defaults provided above.
+
+The ``description`` config option is passed on as part of the mesh metadata in
+global ocean files.
+
+The target and minimum number of MPI tasks (``ntasks`` and ``min_tasks``,
+respectively) will depend on the resolution of the topography file.  The
+default file is at 1/80 of a degree and typically requires at least 360 tasks
+to successfully remap the data even to relatively coarse MPAS meshes.  Coarser
+bathymetry datasets can likely get away with far fewer MPI tasks.  The method
+used for remapping (``conserve`` by default) also makes a difference in how
+many tasks are required.
+
+Culling land cells
+------------------
+
+The framework also includes a step for culling land from the MPAS mesh,
+including enforcing a series of critical passages (transects that must be
+ocean, such as narrow channels) and critical land blockages (transects that
+must be land, such as thin peninsulas).  The config options that can be used to
+control this step are:
+
+.. code-block:: cfg
+
+    # options for spherical meshes
+    [spherical_mesh]
+
+    ## config options related to the step for culling land from the mesh
+    # number of cores to use
+    cull_mesh_cpus_per_task = 128
+    # minimum of cores, below which the step fails
+    cull_mesh_min_cpus_per_task = 1
+
+To create various land masks, the culling step uses python multiprocessing.
+The target and minimum number of processes are controlled by
+``cull_mesh_cpus_per_task`` and ``cull_mesh_min_cpus_per_task``, respectively.


### PR DESCRIPTION
<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->

This merge adds a step for remapping bathymetry and ice-shelf topography to the ocean framework.  It also adds this step to the mesh test cases in `global_ocean`.  It updates the `cull_mesh` step to use the remapped bathymetry to determine the land mask if topography remapping was performed.  It updates most meshes to use the this new approach, leaving the QU240 and Icos240 meshes as they were for more efficient testing.  Finally, this merge modifies the topography output with the variable names expected in MPAS-Ocean init mode and creates a stream for reading them in.

An alteration is needed to MPAS-Ocean to bypass reading in the land-ice topography from a lon-lat file.  Such a bypass exists for the bathymetry but not for land-ice topography.

Needs: https://github.com/E3SM-Project/E3SM/pull/5553

<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [x] User's Guide has been updated
* [x] Developer's Guide has been updated
* [x] API documentation in the Developer's Guide (`api.rst`) has any new or modified class, method and/or functions listed
* [x] Documentation has been [built locally](https://mpas-dev.github.io/compass/latest/developers_guide/building_docs.html) and changes look as expected
* [x] The `E3SM-Project` submodule has been updated with relevant E3SM changes - merged in #585 
* [x] Document (in a comment titled `Testing` in this PR) any testing that was used to verify the changes

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->
