### PR TITLE
Add `files_for_e3sm` steps for ocean and sea-ice meshes

### DIFF
--- a/compass/ocean/tests/global_ocean/files_for_e3sm/ocean_mesh.py
+++ b/compass/ocean/tests/global_ocean/files_for_e3sm/ocean_mesh.py
@@ -1,0 +1,115 @@
+import os
+
+import numpy as np
+import xarray as xr
+from mpas_tools.io import write_netcdf
+
+from compass.io import symlink
+from compass.ocean.tests.global_ocean.files_for_e3sm.files_for_e3sm_step import (  # noqa: E501
+    FilesForE3SMStep,
+)
+from compass.ocean.vertical import (
+    compute_cell_mask,
+    compute_ssh_from_layer_thickness,
+    compute_zmid_from_layer_thickness,
+)
+
+
+class OceanMesh(FilesForE3SMStep):
+    """
+    A step for creating an MPAS-Ocean mesh from variables from an MPAS-Ocean
+    initial state file
+    """
+    def __init__(self, test_case):
+        """
+        Create a new step
+
+        Parameters
+        ----------
+        test_case : compass.ocean.tests.global_ocean.files_for_e3sm.FilesForE3SM
+            The test case this step belongs to
+        """  # noqa: E501
+
+        super().__init__(test_case, name='ocean_mesh')
+
+        # for now, we won't define any outputs because they include the mesh
+        # short name, which is not known at setup time.  Currently, this is
+        # safe because no other steps depend on the outputs of this one.
+
+    def run(self):
+        """
+        Run this step of the testcase
+        """
+        super().run()
+
+        dest_filename = f'{self.mesh_short_name}.{self.creation_date}.nc'
+
+        with xr.open_dataset('initial_state.nc') as ds:
+
+            keep_vars = self.mesh_vars + [
+                'refBottomDepth', 'vertCoordMovementWeights',
+                'bottomDepth', 'maxLevelCell',
+                'layerThickness', 'restingThickness'
+            ]
+
+            if 'minLevelCell' in ds:
+                keep_vars.append('minLevelCell')
+
+            if self.with_ice_shelf_cavities:
+                keep_vars = keep_vars + [
+                    'landIceMask', 'landIceDraft', 'landIceFraction'
+                ]
+
+            ds = ds[keep_vars]
+            ds.load()
+
+            for attr in list(ds.attrs):
+                # drop config options from global attributes
+                if attr.startswith('config_'):
+                    ds.attrs.pop(attr)
+
+            ref_bot_depth = ds.refBottomDepth.values
+            interfaces = np.append([0], ref_bot_depth)
+
+            if 'minLevelCell' not in ds:
+                ds['minLevelCell'] = xr.ones_like(ds.maxLevelCell)
+                ds.minLevelCell.attrs['long_name'] = \
+                    'Index to the first active ocean cell in each column.'
+
+            ds['refTopDepth'] = ('nVertLevels', interfaces[0:-1])
+            ds.refTopDepth.attrs['units'] = 'm'
+            ds.refTopDepth.attrs['long_name'] = \
+                "Reference depth of ocean for each vertical level. Used in " \
+                "'z-level' type runs."
+            ds['refZMid'] = ('nVertLevels',
+                             -0.5 * (interfaces[1:] + interfaces[0:-1]))
+            ds.refZMid.attrs['units'] = 'm'
+            ds.refZMid.attrs['long_name'] = \
+                'Reference mid z-coordinate of ocean for each vertical ' \
+                'level. This has a negative value.'
+            ds['refLayerThickness'] = ('nVertLevels',
+                                       interfaces[1:] - interfaces[0:-1])
+            ds.refLayerThickness.attrs['units'] = 'm'
+            ds.refLayerThickness.attrs['long_name'] = \
+                'Reference layer thickness of ocean for each vertical level.'
+
+            ds['cellMask'] = compute_cell_mask(
+                ds.minLevelCell - 1, ds.maxLevelCell - 1,
+                ds.sizes['nVertLevels'])
+            ds.cellMask.attrs['long_name'] = \
+                'Mask on cells that determines if computations should be ' \
+                'done on cells.'
+            ds['ssh'] = compute_ssh_from_layer_thickness(
+                ds.layerThickness, ds.bottomDepth, ds.cellMask)
+            ds.ssh.attrs['units'] = 'm'
+            ds.ssh.attrs['long_name'] = 'sea surface height'
+            ds['zMid'] = compute_zmid_from_layer_thickness(
+                ds.layerThickness, ds.ssh, ds.cellMask)
+            ds.zMid.attrs['units'] = 'm'
+            ds.zMid.attrs['long_name'] = \
+                'z-coordinate of the mid-depth of the layer'
+
+            write_netcdf(ds, dest_filename)
+
+        symlink(os.path.abspath(dest_filename),
+                f'{self.ocean_mesh_dir}/{dest_filename}')

--- a/compass/ocean/tests/global_ocean/global_ocean.cfg
+++ b/compass/ocean/tests/global_ocean/global_ocean.cfg
@@ -136,6 +136,9 @@ mesh_short_name = autodetect
 # directory of an ocean restart file on the given mesh
 ocean_restart_filename = autodetect
 
+# the initial state used to extract the ocean and sea-ice meshes
+ocean_initial_state_filename = ${ocean_restart_filename}
+
 # the absolute path or relative path with respect to the test case's work
 # directory of a graph file that corresponds to the mesh
 graph_filename = autodetect

--- a/docs/developers_guide/ocean/api.rst
+++ b/docs/developers_guide/ocean/api.rst
@@ -168,12 +168,16 @@ test cases and steps
    files_for_e3sm.ocean_graph_partition.OceanGraphPartition.run
    files_for_e3sm.ocean_initial_condition.OceanInitialCondition
    files_for_e3sm.ocean_initial_condition.OceanInitialCondition.run
+   files_for_e3sm.ocean_mesh.OceanMesh
+   files_for_e3sm.ocean_mesh.OceanMesh.run
    files_for_e3sm.scrip.Scrip
    files_for_e3sm.scrip.Scrip.run
    files_for_e3sm.seaice_graph_partition.SeaiceGraphPartition
    files_for_e3sm.seaice_graph_partition.SeaiceGraphPartition.run
    files_for_e3sm.seaice_initial_condition.SeaiceInitialCondition
    files_for_e3sm.seaice_initial_condition.SeaiceInitialCondition.run
+   files_for_e3sm.seaice_mesh.SeaiceMesh
+   files_for_e3sm.seaice_mesh.SeaiceMesh.run
    files_for_e3sm.e3sm_to_cmip_maps.E3smToCmipMaps
    files_for_e3sm.e3sm_to_cmip_maps.E3smToCmipMaps.run
    files_for_e3sm.diagnostic_maps.DiagnosticMaps

--- a/docs/developers_guide/ocean/test_groups/global_ocean.rst
+++ b/docs/developers_guide/ocean/test_groups/global_ocean.rst
@@ -925,7 +925,13 @@ The test case is constructed with an argument ``restart_filename``. the final
 restart file produced by the :ref:`dev_ocean_global_ocean_dynamic_adjustment`
 for the given mesh.
 
-The test case is made up of 8 steps:
+The test case is made up of 10 steps:
+
+:py:class:`compass.ocean.tests.global_ocean.files_for_e3sm.ocean_mesh.OceanMesh`
+    uses variables from the ocean initial condition and computes others to
+    create an ocean mesh file (with both horizontal and vertical coordinate
+    information), creating a symlink
+    at ``assembled_files/inputdata/share/meshes/mpas/ocean/<mesh_short_name>.<datestamp>.nc``
 
 :py:class:`compass.ocean.tests.global_ocean.files_for_e3sm.ocean_initial_condition.OceanInitialCondition`
     takes out the ``xtime`` variable from the restart file, creating a symlink
@@ -938,6 +944,11 @@ The test case is made up of 8 steps:
     are produced for each mesh (keeping only counts with small prime factors).
     Symlinks to the graph files are placed at
     ``assembled_files/inputdata/ocn/mpas-o/<mesh_short_name>/partitions/mpas-o.graph.info.<datestamp>.part.<core_count>``
+
+:py:class:`compass.ocean.tests.global_ocean.files_for_e3sm.seaice_mesh.SeaiceMesh`
+    uses variables from the ocean initial condition to create a sea-ice mesh
+    file (with horizontal coordinate information), creating a symlink
+    at ``assembled_files/inputdata/share/meshes/mpas/sea-ice/<mesh_short_name>.<datestamp>.nc``
 
 :py:class:`compass.ocean.tests.global_ocean.files_for_e3sm.seaice_initial_condition.SeaiceInitialCondition`
     extracts the following variables from the restart file:

--- a/docs/users_guide/ocean/test_groups/global_ocean.rst
+++ b/docs/users_guide/ocean/test_groups/global_ocean.rst
@@ -171,6 +171,9 @@ Note that meshes and test cases may modify these options, as noted below.
     # directory of an ocean restart file on the given mesh
     ocean_restart_filename = autodetect
 
+    # the initial state used to extract the ocean and sea-ice meshes
+    ocean_initial_state_filename = ${ocean_restart_filename}
+
     # the absolute path or relative path with respect to the test case's work
     # directory of a graph file that corresponds to the mesh
     graph_filename = autodetect


### PR DESCRIPTION
<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->

These also need to be added to `inputdata` in `shared/meshes/mpas`

This merge also makes public some functions from the `compass.ocean.vertical` module that are used to add `cellMask` and `zMid` variables to the MPAS-Ocean mesh.

<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [x] User's Guide has been updated
* [x] Developer's Guide has been updated
* [x] API documentation in the Developer's Guide (`api.rst`) has any new or modified class, method and/or functions listed
* [x] Documentation has been [built locally](https://mpas-dev.github.io/compass/latest/developers_guide/building_docs.html) and changes look as expected
* [x] Document (in a comment titled `Testing` in this PR) any testing that was used to verify the changes

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->

closes #569 