### PR TITLE
Add information on enabling hyperthreading to docs

### DIFF
--- a/docs/developers_guide/machines/chicoma.rst
+++ b/docs/developers_guide/machines/chicoma.rst
@@ -1,6 +1,9 @@
 Chicoma
 =======
 
+For most machine-specific details (including config options and how to
+enable hyperthreading), see the User's Guide under :ref:`machine_chicoma`.
+
 chicoma-cpu, gnu
 ----------------
 

--- a/docs/developers_guide/machines/perlmutter.rst
+++ b/docs/developers_guide/machines/perlmutter.rst
@@ -1,6 +1,9 @@
 Perlmutter
 ==========
 
+For most machine-specific details (including config options and how to
+enable hyperthreading), see the User's Guide under :ref:`machine_perlmutter`.
+
 pm-cpu, gnu
 -----------
 

--- a/docs/users_guide/machines/chicoma.rst
+++ b/docs/users_guide/machines/chicoma.rst
@@ -177,6 +177,28 @@ Additionally, some relevant config options come from the
     # environment
     modules_after = False
 
+Hyperthreading
+~~~~~~~~~~~~~~
+
+By default, hyperthreading has been disable on Chicoma. We had found some
+some issues with runs hanging in early testing that seemed to be mitigated by
+disabling hyperthreading.  We disable hyperthreading by setting
+``threads_per_core = 1`` and reducing ``cores_per_node`` to not include the
+2 hyperthreads.  You can re-enable hyperthreading on Chicoma by providing a
+user config file where you set ``threads_per_core`` and ``cores_per_node``
+as follows:
+
+.. code-block:: cfg
+
+    # The parallel section describes options related to running jobs in parallel
+    [parallel]
+
+    # cores per node on the machine (including hyperthreading)
+    cores_per_node = 256
+
+    # threads per core with hyperthreading
+    threads_per_core = 2
+
 Gnu on Chicoma-CPU
 ~~~~~~~~~~~~~~~~~~
 

--- a/docs/users_guide/machines/perlmutter.rst
+++ b/docs/users_guide/machines/perlmutter.rst
@@ -1,3 +1,5 @@
+.. _machine_perlmutter:
+
 Perlmutter
 ==========
 
@@ -137,6 +139,28 @@ Additionally, some relevant config options come from the
 
     # whether the machine uses cray compilers
     cray_compilers = True
+
+Hyperthreading
+~~~~~~~~~~~~~~
+
+By default, hyperthreading has been disable on Perlmutter. We had found some
+some issues with runs hanging in early testing that seemed to be mitigated by
+disabling hyperthreading.  We disable hyperthreading by setting
+``threads_per_core = 1`` and reducing ``cores_per_node`` to not include the
+2 hyperthreads.  You can re-enable hyperthreading on Perlmutter by providing a
+user config file where you set ``threads_per_core`` and ``cores_per_node``
+as follows:
+
+.. code-block:: cfg
+
+    # The parallel section describes options related to running jobs in parallel
+    [parallel]
+
+    # cores per node on the machine (including hyperthreading)
+    cores_per_node = 256
+
+    # threads per core with hyperthreading
+    threads_per_core = 2
 
 Gnu on Perlmutter-CPU
 ~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
These are specific to Chicoma and Perlmutter, where we have disabled hyperthreading by default.

<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->

<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [x] User's Guide has been updated
* [x] Developer's Guide has been updated
* [x] Documentation has been [built locally](https://mpas-dev.github.io/compass/latest/developers_guide/building_docs.html) and changes look as expected

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->
