### PR TITLE
Add a global ocean test case for computing and running with data (prescribed) melt rates

### DIFF
--- a/compass/ocean/suites/ecwisc30to60.txt
+++ b/compass/ocean/suites/ecwisc30to60.txt
@@ -1,5 +1,6 @@
 ocean/global_ocean/ECwISC30to60/mesh
 ocean/global_ocean/ECwISC30to60/WOA23/init
 ocean/global_ocean/ECwISC30to60/WOA23/performance_test
+ocean/global_ocean/ECwISC30to60/WOA23/data_ice_shelf_melt
 ocean/global_ocean/ECwISC30to60/WOA23/dynamic_adjustment
 ocean/global_ocean/ECwISC30to60/WOA23/files_for_e3sm

--- a/compass/ocean/suites/quwisc240.txt
+++ b/compass/ocean/suites/quwisc240.txt
@@ -5,11 +5,8 @@ ocean/global_ocean/QUwISC240/WOA23/restart_test
 ocean/global_ocean/QUwISC240/WOA23/decomp_test
 ocean/global_ocean/QUwISC240/WOA23/threads_test
 ocean/global_ocean/QUwISC240/WOA23/analysis_test
+ocean/global_ocean/QUwISC240/WOA23/data_ice_shelf_melt
 ocean/global_ocean/QUwISC240/WOA23/RK4/performance_test
 ocean/global_ocean/QUwISC240/WOA23/RK4/restart_test
 ocean/global_ocean/QUwISC240/WOA23/RK4/decomp_test
 ocean/global_ocean/QUwISC240/WOA23/RK4/threads_test
-ocean/global_ocean/QUwISC240/EN4_1900/init
-ocean/global_ocean/QUwISC240/EN4_1900/performance_test
-ocean/global_ocean/QUwISC240/WOA23_BGC/init
-ocean/global_ocean/QUwISC240/WOA23_BGC/performance_test

--- a/compass/ocean/suites/quwisc240_for_e3sm.txt
+++ b/compass/ocean/suites/quwisc240_for_e3sm.txt
@@ -1,4 +1,6 @@
 ocean/global_ocean/QUwISC240/mesh
 ocean/global_ocean/QUwISC240/WOA23/init
+ocean/global_ocean/QUwISC240/WOA23/performance_test
+ocean/global_ocean/QUwISC240/WOA23/data_ice_shelf_melt
 ocean/global_ocean/QUwISC240/WOA23/dynamic_adjustment
 ocean/global_ocean/QUwISC240/WOA23/files_for_e3sm

--- a/compass/ocean/suites/sowisc12to60.txt
+++ b/compass/ocean/suites/sowisc12to60.txt
@@ -1,5 +1,6 @@
 ocean/global_ocean/SOwISC12to60/mesh
 ocean/global_ocean/SOwISC12to60/WOA23/init
 ocean/global_ocean/SOwISC12to60/WOA23/performance_test
+ocean/global_ocean/SOwISC12to60/WOA23/data_ice_shelf_melt
 ocean/global_ocean/SOwISC12to60/WOA23/dynamic_adjustment
 ocean/global_ocean/SOwISC12to60/WOA23/files_for_e3sm

--- a/compass/ocean/tests/global_ocean/__init__.py
+++ b/compass/ocean/tests/global_ocean/__init__.py
@@ -1,5 +1,8 @@
 from compass.ocean.tests.global_ocean.analysis_test import AnalysisTest
 from compass.ocean.tests.global_ocean.daily_output_test import DailyOutputTest
+from compass.ocean.tests.global_ocean.data_ice_shelf_melt import (
+    DataIceShelfMelt,
+)
 from compass.ocean.tests.global_ocean.decomp_test import DecompTest
 from compass.ocean.tests.global_ocean.files_for_e3sm import FilesForE3SM
 from compass.ocean.tests.global_ocean.init import Init
@@ -127,6 +130,12 @@ class GlobalOcean(TestGroup):
                         test_group=self, mesh=mesh_test, init=init_test,
                         time_integrator=time_integrator))
 
+            if mesh_test.with_ice_shelf_cavities:
+                self.add_test_case(
+                    DataIceShelfMelt(
+                        test_group=self, mesh=mesh_test, init=init_test,
+                        time_integrator=time_integrator))
+
             dynamic_adjustment_test = DynamicAdjustment(
                 test_group=self, mesh=mesh_test, init=init_test,
                 time_integrator=time_integrator)
@@ -173,6 +182,12 @@ class GlobalOcean(TestGroup):
                     PerformanceTest(
                         test_group=self, mesh=mesh_test, init=init_test,
                         time_integrator=time_integrator))
+
+                if mesh_test.with_ice_shelf_cavities:
+                    self.add_test_case(
+                        DataIceShelfMelt(
+                            test_group=self, mesh=mesh_test, init=init_test,
+                            time_integrator=time_integrator))
 
                 dynamic_adjustment_test = DynamicAdjustment(
                     test_group=self, mesh=mesh_test, init=init_test,

--- a/compass/ocean/tests/global_ocean/__init__.py
+++ b/compass/ocean/tests/global_ocean/__init__.py
@@ -131,10 +131,12 @@ class GlobalOcean(TestGroup):
                         time_integrator=time_integrator))
 
             if mesh_test.with_ice_shelf_cavities:
-                self.add_test_case(
-                    DataIceShelfMelt(
-                        test_group=self, mesh=mesh_test, init=init_test,
-                        time_integrator=time_integrator))
+                data_melt_test = DataIceShelfMelt(
+                    test_group=self, mesh=mesh_test, init=init_test,
+                    time_integrator=time_integrator)
+                self.add_test_case(data_melt_test)
+            else:
+                data_melt_test = None
 
             dynamic_adjustment_test = DynamicAdjustment(
                 test_group=self, mesh=mesh_test, init=init_test,
@@ -144,7 +146,8 @@ class GlobalOcean(TestGroup):
             self.add_test_case(
                 FilesForE3SM(
                     test_group=self, mesh=mesh_test, init=init_test,
-                    dynamic_adjustment=dynamic_adjustment_test))
+                    dynamic_adjustment=dynamic_adjustment_test,
+                    data_ice_shelf_melt=data_melt_test))
 
             if include_rk4:
                 time_integrator = 'RK4'
@@ -184,10 +187,12 @@ class GlobalOcean(TestGroup):
                         time_integrator=time_integrator))
 
                 if mesh_test.with_ice_shelf_cavities:
-                    self.add_test_case(
-                        DataIceShelfMelt(
-                            test_group=self, mesh=mesh_test, init=init_test,
-                            time_integrator=time_integrator))
+                    data_melt_test = DataIceShelfMelt(
+                        test_group=self, mesh=mesh_test, init=init_test,
+                        time_integrator=time_integrator)
+                    self.add_test_case(data_melt_test)
+                else:
+                    data_melt_test = None
 
                 dynamic_adjustment_test = DynamicAdjustment(
                     test_group=self, mesh=mesh_test, init=init_test,
@@ -197,4 +202,5 @@ class GlobalOcean(TestGroup):
                 self.add_test_case(
                     FilesForE3SM(
                         test_group=self, mesh=mesh_test, init=init_test,
-                        dynamic_adjustment=dynamic_adjustment_test))
+                        dynamic_adjustment=dynamic_adjustment_test,
+                        data_ice_shelf_melt=data_melt_test))

--- a/compass/ocean/tests/global_ocean/data_ice_shelf_melt/__init__.py
+++ b/compass/ocean/tests/global_ocean/data_ice_shelf_melt/__init__.py
@@ -1,0 +1,93 @@
+from compass.ocean.tests.global_ocean.data_ice_shelf_melt.remap_ice_shelf_melt import (  # noqa: E501
+    RemapIceShelfMelt,
+)
+from compass.ocean.tests.global_ocean.forward import (
+    ForwardStep,
+    get_forward_subdir,
+)
+from compass.testcase import TestCase
+from compass.validate import compare_variables
+
+
+class DataIceShelfMelt(TestCase):
+    """
+    A test case for remapping observed melt rates to the MPAS grid and then
+    performing a short forward run with these data (prescribed) melt rates
+
+    Attributes
+    ----------
+    mesh : compass.ocean.tests.global_ocean.mesh.Mesh
+        The test case that produces the mesh for this run
+
+    init : compass.ocean.tests.global_ocean.init.Init
+        The test case that produces the initial condition for this run
+    """
+
+    def __init__(self, test_group, mesh, init, time_integrator):
+        """
+        Create test case
+
+        Parameters
+        ----------
+        test_group : compass.ocean.tests.global_ocean.GlobalOcean
+            The global ocean test group that this test case belongs to
+
+        mesh : compass.ocean.tests.global_ocean.mesh.Mesh
+            The test case that produces the mesh for this run
+
+        init : compass.ocean.tests.global_ocean.init.Init
+            The test case that produces the initial condition for this run
+
+        time_integrator : {'split_explicit', 'RK4'}
+            The time integrator to use for the forward run
+        """
+        self.mesh = mesh
+        self.init = init
+        name = 'data_ice_shelf_melt'
+        subdir = get_forward_subdir(init.init_subdir, time_integrator, name)
+        super().__init__(test_group=test_group, name=name, subdir=subdir)
+
+        self.add_step(RemapIceShelfMelt(test_case=self, mesh=mesh))
+
+        step = ForwardStep(test_case=self, mesh=mesh, init=init,
+                           time_integrator=time_integrator)
+
+        module = self.__module__
+        step.add_input_file(
+            filename='prescribed_ismf_adusumilli2020.nc',
+            target='../remap_ice_shelf_melt/prescribed_ismf_adusumilli2020.nc')
+        step.add_namelist_file(module, 'namelist.forward')
+        step.add_streams_file(module, 'streams.forward')
+        step.add_output_file(filename='land_ice_fluxes.nc')
+        step.add_output_file(filename='output.nc')
+        self.add_step(step)
+
+    def configure(self):
+        """
+        Modify the configuration options for this test case
+        """
+        self.init.configure(config=self.config)
+
+    def validate(self):
+        """
+        Test cases can override this method to perform validation of variables
+        and timers
+        """
+        variables = ['temperature', 'salinity', 'layerThickness',
+                     'normalVelocity']
+
+        compare_variables(test_case=self, variables=variables,
+                          filename1='forward/output.nc')
+
+        variables = [
+            'ssh', 'landIcePressure', 'landIceDraft', 'landIceFraction',
+            'landIceMask', 'landIceFrictionVelocity', 'topDrag',
+            'topDragMagnitude', 'landIceFreshwaterFlux', 'landIceHeatFlux',
+            'heatFluxToLandIce', 'landIceBoundaryLayerTemperature',
+            'landIceBoundaryLayerSalinity', 'landIceHeatTransferVelocity',
+            'landIceSaltTransferVelocity', 'landIceInterfaceTemperature',
+            'landIceInterfaceSalinity', 'accumulatedLandIceMass',
+            'accumulatedLandIceHeat']
+
+        compare_variables(test_case=self, variables=variables,
+                          filename1='forward/land_ice_fluxes.nc')

--- a/compass/ocean/tests/global_ocean/data_ice_shelf_melt/namelist.forward
+++ b/compass/ocean/tests/global_ocean/data_ice_shelf_melt/namelist.forward
@@ -1,0 +1,2 @@
+config_check_ssh_consistency = .false.
+config_land_ice_flux_mode = 'prescribed'

--- a/compass/ocean/tests/global_ocean/data_ice_shelf_melt/namelist.forward
+++ b/compass/ocean/tests/global_ocean/data_ice_shelf_melt/namelist.forward
@@ -1,2 +1,2 @@
 config_check_ssh_consistency = .false.
-config_land_ice_flux_mode = 'prescribed'
+config_land_ice_flux_mode = 'data'

--- a/compass/ocean/tests/global_ocean/data_ice_shelf_melt/remap_ice_shelf_melt.py
+++ b/compass/ocean/tests/global_ocean/data_ice_shelf_melt/remap_ice_shelf_melt.py
@@ -1,0 +1,208 @@
+import h5py
+import numpy as np
+import pyproj
+import xarray as xr
+from mpas_tools.cime.constants import constants
+from mpas_tools.io import write_netcdf
+from pyremap import MpasMeshDescriptor, ProjectionGridDescriptor, Remapper
+
+from compass.step import Step
+
+
+class RemapIceShelfMelt(Step):
+    """
+    A step for for remapping observed melt rates to the MPAS grid
+
+    Attributes
+    ----------
+    mesh : compass.ocean.tests.global_ocean.mesh.Mesh
+        The test case that produces the mesh for this run
+    """
+    def __init__(self, test_case, mesh):
+        """
+        Create a new step
+
+        Parameters
+        ----------
+        test_case : compass.TestCase
+            The test case this step belongs to
+
+        mesh : compass.ocean.tests.global_ocean.mesh.Mesh
+            The test case that produces the mesh for this run
+        """  # noqa: E501
+        super().__init__(test_case, name='remap_ice_shelf_melt', ntasks=512,
+                         min_tasks=1)
+
+        mesh_path = mesh.get_cull_mesh_path()
+
+        self.add_input_file(
+            filename='mesh.nc',
+            work_dir_target=f'{mesh_path}/culled_mesh.nc')
+
+        self.add_input_file(
+            filename='land_ice_mask.nc',
+            work_dir_target=f'{mesh_path}/land_ice_mask.nc')
+
+        self.add_input_file(
+            filename='Adusumilli_2020_iceshelf_melt_rates_2010-2018_v0.h5',
+            target='Adusumilli_2020_iceshelf_melt_rates_2010-2018_v0.h5',
+            database='initial_condition_database',
+            url='http://library.ucsd.edu/dc/object/bb0448974g/_3_1.h5')
+
+        self.add_output_file(filename='prescribed_ismf_adusumilli2020.nc')
+
+        self.mesh = mesh
+
+    def run(self):
+        """
+        Run this step of the test case
+        """
+        logger = self.logger
+        config = self.config
+        ntasks = self.ntasks
+
+        in_filename = 'Adusumilli_2020_iceshelf_melt_rates_2010-2018_v0.h5'
+
+        out_filename = 'prescribed_ismf_adusumilli2020.nc'
+
+        parallel_executable = config.get('parallel', 'parallel_executable')
+
+        mesh_filename = 'mesh.nc'
+        land_ice_mask_filename = 'land_ice_mask.nc'
+        mesh_name = self.mesh.mesh_name
+
+        remap_adusumilli(in_filename, mesh_filename, mesh_name,
+                         land_ice_mask_filename, out_filename,
+                         logger=logger, mpi_tasks=ntasks,
+                         parallel_executable=parallel_executable)
+
+
+def remap_adusumilli(in_filename, mesh_filename, mesh_name,
+                     land_ice_mask_filename, out_filename, logger,
+                     mapping_directory='.', method='conserve',
+                     renormalization_threshold=None, mpi_tasks=1,
+                     parallel_executable=None):
+    """
+    Remap the Adusumilli et al. (2020) melt rates at 1 km resolution to an MPAS
+    mesh
+
+    Parameters
+    ----------
+    in_filename : str
+        The original Adusumilli et al. (2020) melt rates
+
+    mesh_filename : str
+        The MPAS mesh
+
+    mesh_name : str
+        The name of the mesh (e.g. oEC60to30wISC), used in the name of the
+        mapping file
+
+    land_ice_mask_filename : str
+        A file containing the variable ``landIceMask`` on the MPAS mesh
+
+    out_filename : str
+        The melt rates interpolated to the MPAS mesh with ocean sensible heat
+        fluxes added on (assuming insulating ice)
+
+    logger : logging.Logger
+        A logger for output from the step
+
+    mapping_directory : str
+        The directory where the mapping file should be stored (if it is to be
+        computed) or where it already exists (if not)
+
+    method : {'bilinear', 'neareststod', 'conserve'}, optional
+        The method of interpolation used, see documentation for
+        `ESMF_RegridWeightGen` for details.
+
+    renormalization_threshold : float, optional
+        The minimum weight of a destination cell after remapping, below
+        which it is masked out, or ``None`` for no renormalization and
+        masking.
+
+    mpi_tasks : int, optional
+        The number of MPI tasks to use to compute the mapping file
+
+    parallel_executable : {'srun', 'mpirun'}, optional
+        The name of the parallel executable to use to launch ESMF tools.
+        But default, 'mpirun' from the conda environment is used
+    """
+
+    logger.info(f'Reading {in_filename}...')
+    h5_data = h5py.File(in_filename, 'r')
+
+    x = np.array(h5_data['/x'])[:, 0]
+    y = np.array(h5_data['/y'])[:, 0]
+    melt_rate = np.array(h5_data['/w_b'])
+    logger.info('done.')
+
+    lx = np.abs(1e-3 * (x[-1] - x[0]))
+    ly = np.abs(1e-3 * (y[-1] - y[0]))
+
+    in_grid_name = f'{lx}x{ly}km_0.5km_Antarctic_stereo'
+
+    projection = pyproj.Proj('+proj=stere +lat_ts=-71.0 +lat_0=-90 +lon_0=0.0 '
+                             '+k_0=1.0 +x_0=0.0 +y_0=0.0 +ellps=WGS84')
+
+    logger.info('Creating the source grid descriptor...')
+    in_descriptor = ProjectionGridDescriptor.create(
+        projection=projection, x=x, y=y, meshName=in_grid_name)
+    logger.info('done.')
+
+    logger.info('Creating the source xarray dataset...')
+    ds = xr.Dataset()
+
+    # convert to the units and variable names expected in MPAS-O
+
+    # Adusumilli et al. (2020) ice density (caption of Fig. 1 and Methods
+    # section)
+    rho_ice = 917.
+    s_per_yr = 365. * constants['SHR_CONST_CDAY']
+    latent_heat_of_fusion = constants['SHR_CONST_LATICE']
+    mask = np.isfinite(melt_rate)
+    melt_rate = np.where(mask, melt_rate, 0.)
+    ds['x'] = (('x',), x)
+    ds['y'] = (('y',), y)
+    ds['landIceFluxMask'] = (('y', 'x'), mask.astype(float))
+    ds['dataLandIceFreshwaterFlux'] = (('y', 'x'),
+                                       melt_rate * rho_ice / s_per_yr)
+    ds['dataLandIceHeatFlux'] = (latent_heat_of_fusion *
+                                 ds.dataLandIceFreshwaterFlux)
+    logger.info('Writing the source dataset...')
+    write_netcdf(ds, 'Adusumilli_2020_ismf_2010-2018_v0.nc')
+    logger.info('done.')
+
+    out_descriptor = MpasMeshDescriptor(mesh_filename, mesh_name)
+
+    mapping_filename = \
+        f'{mapping_directory}/map_{in_grid_name}_to_{mesh_name}.nc'
+
+    logger.info(f'Creating the mapping file {mapping_filename}...')
+    remapper = Remapper(in_descriptor, out_descriptor, mapping_filename)
+
+    remapper.build_mapping_file(method=method, mpiTasks=mpi_tasks,
+                                tempdir=mapping_directory, logger=logger,
+                                esmf_parallel_exec=parallel_executable)
+    logger.info('done.')
+
+    logger.info('Remapping...')
+    ds_remap = remapper.remap(
+        ds, renormalizationThreshold=renormalization_threshold)
+    logger.info('done.')
+
+    ds_mask = xr.open_dataset(land_ice_mask_filename)
+    mask = ds_mask.landIceMask
+
+    for field in ['dataLandIceFreshwaterFlux',
+                  'dataLandIceHeatFlux']:
+        # zero out the field where it's currently NaN, and mask only to
+        # regions with land ice
+        ds_remap[field] = \
+            mask * ds_remap[field].where(ds_remap[field].notnull(), 0.)
+
+    # deal with melting beyond the land-ice mask
+
+    ds_remap.attrs.pop('history')
+
+    write_netcdf(ds_remap, out_filename)

--- a/compass/ocean/tests/global_ocean/data_ice_shelf_melt/streams.forward
+++ b/compass/ocean/tests/global_ocean/data_ice_shelf_melt/streams.forward
@@ -1,0 +1,44 @@
+<streams>
+
+<stream name="data_land_ice_fluxes"
+        filename_template="prescribed_ismf_adusumilli2020.nc"
+        input_interval="initial_only"
+        type="input">
+
+    <var name="dataLandIceFreshwaterFlux"/>
+    <var name="dataLandIceHeatFlux"/>
+
+</stream>
+
+
+<stream name="land_ice_fluxes"
+        type="output"
+        filename_template="land_ice_fluxes.nc"
+        output_interval="0000_00:00:01"
+		reference_time="0001-01-01_00:00:00"
+        clobber_mode="truncate">
+
+    <stream name="mesh"/>
+    <var name="xtime"/>
+    <var name="daysSinceStartOfSim"/>
+    <var name="ssh"/>
+    <var name="landIcePressure"/>
+    <var name="landIceDraft"/>
+    <var name="landIceFraction"/>
+    <var name="landIceMask"/>
+    <var name="landIceFrictionVelocity"/>
+    <var name="topDrag"/>
+    <var name="topDragMagnitude"/>
+    <var name="landIceFreshwaterFlux"/>
+    <var name="landIceHeatFlux"/>
+    <var name="heatFluxToLandIce"/>
+    <var name="effectiveDensityInLandIce"/>
+    <var_array name="landIceBoundaryLayerTracers"/>
+    <var_array name="landIceTracerTransferVelocities"/>
+    <var_array name="landIceInterfaceTracers"/>
+    <var name="accumulatedLandIceMass"/>
+    <var name="accumulatedLandIceHeat"/>
+
+</stream>
+
+</streams>

--- a/compass/ocean/tests/global_ocean/files_for_e3sm/__init__.py
+++ b/compass/ocean/tests/global_ocean/files_for_e3sm/__init__.py
@@ -19,6 +19,9 @@ from compass.ocean.tests.global_ocean.files_for_e3sm.ocean_initial_condition imp
 from compass.ocean.tests.global_ocean.files_for_e3sm.ocean_mesh import (  # noqa: E501
     OceanMesh,
 )
+from compass.ocean.tests.global_ocean.files_for_e3sm.remap_ice_shelf_melt import (  # noqa: E501
+    RemapIceShelfMelt,
+)
 from compass.ocean.tests.global_ocean.files_for_e3sm.scrip import Scrip
 from compass.ocean.tests.global_ocean.files_for_e3sm.seaice_graph_partition import (  # noqa: E501
     SeaiceGraphPartition,
@@ -50,9 +53,12 @@ class FilesForE3SM(TestCase):
     dynamic_adjustment : compass.ocean.tests.global_ocean.dynamic_adjustment.DynamicAdjustment
         The test case that performs dynamic adjustment to dissipate
         fast-moving waves from the initial condition
+
+    data_ice_shelf_melt : compass.ocean.tests.global_ocean.data_ice_shelf_melt.DataIceShelfMelt
+        A test case for remapping observed melt rates to the MPAS grid
     """  # noqa: E501
     def __init__(self, test_group, mesh=None, init=None,
-                 dynamic_adjustment=None):
+                 dynamic_adjustment=None, data_ice_shelf_melt=None):
         """
         Create test case for creating a global MPAS-Ocean mesh
 
@@ -70,6 +76,9 @@ class FilesForE3SM(TestCase):
         dynamic_adjustment : compass.ocean.tests.global_ocean.dynamic_adjustment.DynamicAdjustment, optional
             The test case that performs dynamic adjustment to dissipate
             fast-moving waves from the initial condition
+
+        data_ice_shelf_melt : compass.ocean.tests.global_ocean.data_ice_shelf_melt.DataIceShelfMelt, optional
+            A test case for remapping observed melt rates to the MPAS grid
         """  # noqa: E501
         name = 'files_for_e3sm'
         if dynamic_adjustment is not None:
@@ -83,6 +92,7 @@ class FilesForE3SM(TestCase):
         self.mesh = mesh
         self.init = init
         self.dynamic_adjustment = dynamic_adjustment
+        self.data_ice_shelf_melt = data_ice_shelf_melt
 
         # add metadata if we're running this on an existing mesh
         add_metadata = (dynamic_adjustment is None)
@@ -97,6 +107,10 @@ class FilesForE3SM(TestCase):
         self.add_step(E3smToCmipMaps(test_case=self))
         self.add_step(DiagnosticMaps(test_case=self))
         self.add_step(DiagnosticMasks(test_case=self))
+
+        self.add_step(RemapIceShelfMelt(
+            test_case=self,
+            data_ice_shelf_melt=data_ice_shelf_melt))
 
     def configure(self):
         """

--- a/compass/ocean/tests/global_ocean/files_for_e3sm/remap_ice_shelf_melt.py
+++ b/compass/ocean/tests/global_ocean/files_for_e3sm/remap_ice_shelf_melt.py
@@ -1,0 +1,87 @@
+import os
+
+from compass.io import symlink
+from compass.ocean.tests.global_ocean.data_ice_shelf_melt.remap_ice_shelf_melt import (  # noqa: E501
+    remap_adusumilli,
+)
+from compass.ocean.tests.global_ocean.files_for_e3sm.files_for_e3sm_step import (  # noqa: E501
+    FilesForE3SMStep,
+)
+
+
+class RemapIceShelfMelt(FilesForE3SMStep):
+    """
+    A step for for remapping observed melt rates to the MPAS grid and staging
+    them in ``assembled_files``
+
+    Attributes
+    ----------
+    data_ice_shelf_melt : compass.ocean.tests.global_ocean.data_ice_shelf_melt.DataIceShelfMelt
+        A test case where remapping has already occurred
+    """  # noqa: E501
+    def __init__(self, test_case, data_ice_shelf_melt):
+        """
+        Create a new step
+
+        Parameters
+        ----------
+        test_case : compass.TestCase
+            The test case this step belongs to
+
+        data_ice_shelf_melt : compass.ocean.tests.global_ocean.data_ice_shelf_melt.DataIceShelfMelt
+            A test case where remapping has already occurred
+        """  # noqa: E501
+        super().__init__(test_case, name='remap_ice_shelf_melt', ntasks=512,
+                         min_tasks=1)
+        self.data_ice_shelf_melt = data_ice_shelf_melt
+        filename = 'prescribed_ismf_adusumilli2020.nc'
+        if data_ice_shelf_melt is None:
+            self.add_input_file(
+                filename='Adusumilli_2020_iceshelf_melt_rates_2010-2018_v0.h5',
+                target='Adusumilli_2020_iceshelf_melt_rates_2010-2018_v0.h5',
+                database='initial_condition_database',
+                url='http://library.ucsd.edu/dc/object/bb0448974g/_3_1.h5')
+
+            self.add_output_file(filename=filename)
+        else:
+            melt_path = \
+                data_ice_shelf_melt.steps['remap_ice_shelf_melt'].path
+
+            self.add_input_file(
+                filename=filename,
+                work_dir_target=f'{melt_path}/{filename}')
+
+    def run(self):
+        """
+        Run this step of the test case
+        """
+        super().run()
+
+        data_ice_shelf_melt = self.data_ice_shelf_melt
+
+        prefix = 'prescribed_ismf_adusumilli2020'
+        suffix = f'{self.mesh_short_name}.{self.creation_date}'
+
+        remapped_filename = f'{prefix}.nc'
+        dest_filename = f'{prefix}.{suffix}.nc'
+
+        if data_ice_shelf_melt is None:
+            logger = self.logger
+            config = self.config
+            ntasks = self.ntasks
+            in_filename = 'Adusumilli_2020_iceshelf_melt_rates_2010-2018_v0.h5'
+
+            parallel_executable = config.get('parallel', 'parallel_executable')
+
+            mesh_filename = 'initial_state.nc'
+            mesh_name = self.mesh_short_name
+            land_ice_mask_filename = 'initial_state.nc'
+
+            remap_adusumilli(in_filename, mesh_filename, mesh_name,
+                             land_ice_mask_filename, remapped_filename,
+                             logger=logger, mpi_tasks=ntasks,
+                             parallel_executable=parallel_executable)
+
+        symlink(
+            os.path.abspath(remapped_filename),
+            f'{self.ocean_inputdata_dir}/{dest_filename}')

--- a/conda/compass_env/spec-file.template
+++ b/conda/compass_env/spec-file.template
@@ -11,6 +11,7 @@ ffmpeg
 geometric_features=1.2.0
 git
 gsw
+h5py
 ipython
 jigsaw=0.9.14
 jigsawpy=0.3.3

--- a/conda/recipe/meta.yaml
+++ b/conda/recipe/meta.yaml
@@ -48,6 +48,7 @@ requirements:
     - geometric_features 1.2.0
     - git
     - gsw
+    - h5py
     - ipython
     - jigsaw 0.9.14
     - jigsawpy 0.3.3

--- a/docs/developers_guide/ocean/api.rst
+++ b/docs/developers_guide/ocean/api.rst
@@ -157,6 +157,14 @@ test cases and steps
    daily_output_test.DailyOutputTest.configure
    daily_output_test.DailyOutputTest.run
 
+   data_ice_shelf_melt.DataIceShelfMelt
+   data_ice_shelf_melt.DataIceShelfMelt.configure
+   data_ice_shelf_melt.DataIceShelfMelt.validate
+
+   data_ice_shelf_melt.remap_ice_shelf_melt.RemapIceShelfMelt
+   data_ice_shelf_melt.remap_ice_shelf_melt.RemapIceShelfMelt.run
+   data_ice_shelf_melt.remap_ice_shelf_melt.remap_adusumilli
+
    decomp_test.DecompTest
    decomp_test.DecompTest.configure
    decomp_test.DecompTest.run
@@ -184,6 +192,8 @@ test cases and steps
    files_for_e3sm.diagnostic_maps.DiagnosticMaps.run
    files_for_e3sm.diagnostic_masks.DiagnosticMasks
    files_for_e3sm.diagnostic_masks.DiagnosticMasks.run
+   files_for_e3sm.remap_ice_shelf_melt.RemapIceShelfMelt
+   files_for_e3sm.remap_ice_shelf_melt.RemapIceShelfMelt.run
 
    init.Init
    init.Init.configure

--- a/docs/developers_guide/ocean/test_groups/global_ocean.rst
+++ b/docs/developers_guide/ocean/test_groups/global_ocean.rst
@@ -958,6 +958,18 @@ ensures that the time average of the prognostic variables as well as the
 sea-surface height are identical to those from the baseline if one is provided
 when calling :ref:`dev_compass_setup`.
 
+.. _dev_ocean_global_ocean_data_ice_shelf_melt:
+
+data_ice_shelf_melt test case
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The class :py:class:`compass.ocean.tests.global_ocean.data_ice_shelf_melt.DataIceShelfMelt`
+defines a test case that remaps melt rates from the satellite-derived dataset
+from `Adusumilli et al. (2020) <https://doi.org/10.1038/s41561-020-0616-z>`_
+and then performs a performs a short forward run similar to
+:ref:`dev_ocean_global_ocean_performance_test` but with data ice-shelf melt
+fluxes enables.
+
 .. _dev_ocean_global_ocean_dynamic_adjustment:
 
 dynamic_adjustment test case
@@ -1196,6 +1208,12 @@ The test case is made up of 10 steps:
     basins and the transects representing their southern boundaries.
     The resulting region mask is in the same directory as above, and named
     ``<mesh_short_name>_moc_masks_and_transects.nc``
+
+:py:class:`compass.ocean.tests.global_ocean.files_for_e3sm.remap_ice_shelf_melt.RemapIceShelfMelt`
+    is used to remap ice-shelf melt rates from the dataset of
+    `Adusumilli et al. (2020) <https://doi.org/10.1038/s41561-020-0616-z>`_
+    to the MPAS mesh.  This dataset is used in E3SM for ``DISMF`` (data
+    ice-shelf melt flux) compsets.
 
 files_for_e3sm for an existing mesh
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/users_guide/ocean/test_groups/global_ocean.rst
+++ b/docs/users_guide/ocean/test_groups/global_ocean.rst
@@ -753,6 +753,22 @@ or more of these versions of the ``daily_output_test`` will be available:
 
 * ``ocean/global_ocean/QUwISC240/<ic>/daily_output_test/RK4``
 
+
+.. _global_ocean_data_ice_shelf_melt:
+
+data_ice_shelf_melt
+^^^^^^^^^^^^^^^^^^^
+
+For meshes with ice-shelf cavities, the ``data_ice_shelf_melt`` test case
+interpolates the
+`Adusumilli et al. (2020) <https://doi.org/10.1038/s41561-020-0616-z>`_
+annual mean Antarctic melt rates to the MPAS mesh for use in subsequent test
+cases and possible incorporation as a forcing dataset in E3SM.  It performs
+a short forward test equivalent to :ref:`global_ocean_performance_test` but
+with data ice-shelf melt fluxes enabled.  If a baseline is provided, the test
+case will compare a large number of variables related to ice-shelf fluxes to
+ensure that they are identical.
+
 .. _global_ocean_dynamic_adjustment:
 
 dynamic_adjustment test case
@@ -807,8 +823,10 @@ files include: MPAS-Ocean and MPAS-Seaice initial conditions (including
 partition files, created with
 `gpmetis <http://glaros.dtc.umn.edu/gkhome/metis/metis/overview>`_, for
 splitting the mesh across a number of possible core counts; a mask file for
-MPAS-Ocean's ``mocStreamfunction`` analysis member; and mask and mapping files
-for `MPAS-Analysis <https://mpas-dev.github.io/MPAS-Analysis/stable/>`_.
+MPAS-Ocean's ``mocStreamfunction`` analysis member; mask and mapping files
+for `MPAS-Analysis <https://mpas-dev.github.io/MPAS-Analysis/stable/>`_; and
+a file containing data ice-shelf melt rates for running ``DISMF`` (data
+ice-shelf melt flux) compsets in E3SM.
 
 The resulting files are symlinked in a subdirectory of the test case called
 ``assembled_files``.  This directory contains subdirectories with the same

--- a/setup.py
+++ b/setup.py
@@ -22,6 +22,7 @@ install_requires = \
     ['cartopy',
      'cmocean',
      'gsw',
+     'h5py',
      'ipython',
      'jigsawpy==0.3.3',
      'jupyter',


### PR DESCRIPTION
<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->

This merge also adds a step for staging the remapped melt fluxes in the appropriate directory for use in E3SM.  It can be used to compute data melt fluxes for existing meshes.

<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [x] User's Guide has been updated
* [x] Developer's Guide has been updated
* [x] API documentation in the Developer's Guide (`api.rst`) has any new or modified class, method and/or functions listed
* [x] Documentation has been [built locally](https://mpas-dev.github.io/compass/latest/developers_guide/building_docs.html) and changes look as expected
* [x] The `E3SM-Project` submodule has been updated with relevant E3SM changes
* [x] Document (in a comment titled `Testing` in this PR) any testing that was used to verify the changes
* [x] New tests have been added to a test suite

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->
