### PR TITLE
Remove Ifpack and ML preconditioners from landice test inputs

### DIFF
--- a/compass/landice/tests/circular_shelf/albany_input.yaml
+++ b/compass/landice/tests/circular_shelf/albany_input.yaml
@@ -90,12 +90,6 @@ ANONYMOUS:
 #             Preconditioner Information
               Preconditioner Type: Ifpack2
               Preconditioner Types:
-                Ifpack:
-                  Overlap: 1
-                  Prec Type: ILU
-                  Ifpack Settings:
-                    'fact: level-of-fill': 0
-
                 Ifpack2:
                   Overlap: 1
                   Prec Type: ILUT

--- a/compass/landice/tests/dome/albany_input.yaml
+++ b/compass/landice/tests/dome/albany_input.yaml
@@ -90,12 +90,6 @@ ANONYMOUS:
 #             Preconditioner Information
               Preconditioner Type: Ifpack2
               Preconditioner Types:
-                Ifpack:
-                  Overlap: 1
-                  Prec Type: ILU
-                  Ifpack Settings:
-                    'fact: level-of-fill': 0
-
                 Ifpack2:
                   Overlap: 1
                   Prec Type: ILUT

--- a/compass/landice/tests/ensemble_generator/thwaites/albany_input.yaml
+++ b/compass/landice/tests/ensemble_generator/thwaites/albany_input.yaml
@@ -1,8 +1,6 @@
 %YAML 1.1
 ---
 ANONYMOUS:
-# In order to use ML, change Tpetra to Epetra in the following line,
-# and "Preconditioner Type: MueLu" to " Preconditioner Type: ML" several lines below
   Build Type: Tpetra
 
   Problem:
@@ -248,29 +246,3 @@ ANONYMOUS:
                       A: myRebalanceAFact
                       Coordinates: myRebalanceProlongatorFact
                       Importer: myRepartitionFact
-
-                ML:
-                  Base Method Defaults: none
-                  ML Settings:
-                    default values: SA
-                    ML output: 0
-                    'repartition: enable': 1
-                    'repartition: max min ratio': 1.327e+00
-                    'repartition: min per proc': 600
-                    'repartition: Zoltan dimensions': 2
-                    'repartition: start level': 4
-                    'semicoarsen: number of levels': 2
-                    'semicoarsen: coarsen rate': 14
-                    'smoother: sweeps': 4
-                    'smoother: type': Gauss-Seidel
-                    'smoother: Chebyshev eig boost': 1.2e+00
-                    'smoother: sweeps (level 0)': 1
-                    'smoother: type (level 0)': line Gauss-Seidel
-                    'smoother: line GS Type': standard
-                    'smoother: damping factor': 1.0e+00
-                    'smoother: pre or post': both
-                    'coarse: type': Gauss-Seidel
-                    'coarse: sweeps': 4
-                    'coarse: max size': 2000
-                    'coarse: pre or post': pre
-                    max levels: 7

--- a/compass/landice/tests/ensemble_generator/thwaites/albany_input.yaml
+++ b/compass/landice/tests/ensemble_generator/thwaites/albany_input.yaml
@@ -104,12 +104,6 @@ ANONYMOUS:
               Preconditioner Type: Ifpack2
               Preconditioner Types:
 
-                Ifpack:
-                  Overlap: 1
-                  Prec Type: ILU
-                  Ifpack Settings:
-                    'fact: level-of-fill': 0
-
                 Ifpack2:
                   Overlap: 1
                   Prec Type: ILUT

--- a/compass/landice/tests/greenland/albany_input.yaml
+++ b/compass/landice/tests/greenland/albany_input.yaml
@@ -1,8 +1,6 @@
 %YAML 1.1
 ---
 ANONYMOUS:
-# In order to use ML, change Tpetra to Epetra in the following line,
-# and "Preconditioner Type: MueLu" to " Preconditioner Type: ML" several lines below
   Build Type: Tpetra
 
 # Discretization Description
@@ -231,29 +229,3 @@ ANONYMOUS:
                       A: myRebalanceAFact
                       Coordinates: myRebalanceProlongatorFact
                       Importer: myRepartitionFact
-
-                ML:
-                  Base Method Defaults: none
-                  ML Settings:
-                    default values: SA
-                    ML output: 0
-                    'repartition: enable': 1
-                    'repartition: max min ratio': 1.327e+00
-                    'repartition: min per proc': 600
-                    'repartition: Zoltan dimensions': 2
-                    'repartition: start level': 4
-                    'semicoarsen: number of levels': 2
-                    'semicoarsen: coarsen rate': 14
-                    'smoother: sweeps': 4
-                    'smoother: type': Gauss-Seidel
-                    'smoother: Chebyshev eig boost': 1.2e+00
-                    'smoother: sweeps (level 0)': 1
-                    'smoother: type (level 0)': line Gauss-Seidel
-                    'smoother: line GS Type': standard
-                    'smoother: damping factor': 1.0e+00
-                    'smoother: pre or post': both
-                    'coarse: type': Gauss-Seidel
-                    'coarse: sweeps': 4
-                    'coarse: max size': 2000
-                    'coarse: pre or post': pre
-                    max levels: 7

--- a/compass/landice/tests/greenland/albany_input.yaml
+++ b/compass/landice/tests/greenland/albany_input.yaml
@@ -87,12 +87,6 @@ ANONYMOUS:
               Preconditioner Type: MueLu
               Preconditioner Types:
 
-                Ifpack:
-                  Overlap: 1
-                  Prec Type: ILU
-                  Ifpack Settings:
-                    'fact: level-of-fill': 0
-
                 Ifpack2:
                   Overlap: 1
                   Prec Type: ILUT

--- a/compass/landice/tests/greenland/albany_schoof_input.yaml
+++ b/compass/landice/tests/greenland/albany_schoof_input.yaml
@@ -112,12 +112,6 @@ ANONYMOUS:
               Preconditioner Type: MueLu
               Preconditioner Types:
 
-                Ifpack:
-                  Overlap: 1
-                  Prec Type: ILU
-                  Ifpack Settings:
-                    'fact: level-of-fill': 0
-
                 Ifpack2:
                   Overlap: 1
                   Prec Type: ILUT

--- a/compass/landice/tests/greenland/albany_schoof_input.yaml
+++ b/compass/landice/tests/greenland/albany_schoof_input.yaml
@@ -1,8 +1,6 @@
 %YAML 1.1
 ---
 ANONYMOUS:
-# In order to use ML, change Tpetra to Epetra in the following line,
-# and "Preconditioner Type: MueLu" to " Preconditioner Type: ML" several lines below
   Build Type: Tpetra
 
   Problem:
@@ -256,29 +254,3 @@ ANONYMOUS:
                       A: myRebalanceAFact
                       Coordinates: myRebalanceProlongatorFact
                       Importer: myRepartitionFact
-
-                ML:
-                  Base Method Defaults: none
-                  ML Settings:
-                    default values: SA
-                    ML output: 0
-                    'repartition: enable': 1
-                    'repartition: max min ratio': 1.327e+00
-                    'repartition: min per proc': 600
-                    'repartition: Zoltan dimensions': 2
-                    'repartition: start level': 4
-                    'semicoarsen: number of levels': 2
-                    'semicoarsen: coarsen rate': 14
-                    'smoother: sweeps': 4
-                    'smoother: type': Gauss-Seidel
-                    'smoother: Chebyshev eig boost': 1.2e+00
-                    'smoother: sweeps (level 0)': 1
-                    'smoother: type (level 0)': line Gauss-Seidel
-                    'smoother: line GS Type': standard
-                    'smoother: damping factor': 1.0e+00
-                    'smoother: pre or post': both
-                    'coarse: type': Gauss-Seidel
-                    'coarse: sweeps': 4
-                    'coarse: max size': 2000
-                    'coarse: pre or post': pre
-                    max levels: 7

--- a/compass/landice/tests/humboldt/albany_input.yaml
+++ b/compass/landice/tests/humboldt/albany_input.yaml
@@ -1,8 +1,6 @@
 %YAML 1.1
 ---
 ANONYMOUS:
-# In order to use ML, change Tpetra to Epetra in the following line,
-# and "Preconditioner Type: MueLu" to " Preconditioner Type: ML" several lines below
   Build Type: Tpetra
 
   Problem:
@@ -243,29 +241,3 @@ ANONYMOUS:
                       A: myRebalanceAFact
                       Coordinates: myRebalanceProlongatorFact
                       Importer: myRepartitionFact
-
-                ML:
-                  Base Method Defaults: none
-                  ML Settings:
-                    default values: SA
-                    ML output: 0
-                    'repartition: enable': 1
-                    'repartition: max min ratio': 1.327e+00
-                    'repartition: min per proc': 600
-                    'repartition: Zoltan dimensions': 2
-                    'repartition: start level': 4
-                    'semicoarsen: number of levels': 2
-                    'semicoarsen: coarsen rate': 14
-                    'smoother: sweeps': 4
-                    'smoother: type': Gauss-Seidel
-                    'smoother: Chebyshev eig boost': 1.2e+00
-                    'smoother: sweeps (level 0)': 1
-                    'smoother: type (level 0)': line Gauss-Seidel
-                    'smoother: line GS Type': standard
-                    'smoother: damping factor': 1.0e+00
-                    'smoother: pre or post': both
-                    'coarse: type': Gauss-Seidel
-                    'coarse: sweeps': 4
-                    'coarse: max size': 2000
-                    'coarse: pre or post': pre
-                    max levels: 7

--- a/compass/landice/tests/humboldt/albany_input.yaml
+++ b/compass/landice/tests/humboldt/albany_input.yaml
@@ -99,12 +99,6 @@ ANONYMOUS:
               Preconditioner Type: MueLu
               Preconditioner Types:
 
-                Ifpack:
-                  Overlap: 1
-                  Prec Type: ILU
-                  Ifpack Settings:
-                    'fact: level-of-fill': 0
-
                 Ifpack2:
                   Overlap: 1
                   Prec Type: ILUT

--- a/compass/landice/tests/mismipplus/albany_input.yaml
+++ b/compass/landice/tests/mismipplus/albany_input.yaml
@@ -1,8 +1,6 @@
 %YAML 1.1
 ---
 ANONYMOUS:
-# In order to use ML, change Tpetra to Epetra in the following line,
-# and "Preconditioner Type: MueLu" to " Preconditioner Type: ML" several lines below
   Build Type: Tpetra
 
 # Discretization Description
@@ -231,29 +229,3 @@ ANONYMOUS:
                       A: myRebalanceAFact
                       Coordinates: myRebalanceProlongatorFact
                       Importer: myRepartitionFact
-
-                ML:
-                  Base Method Defaults: none
-                  ML Settings:
-                    default values: SA
-                    ML output: 0
-                    'repartition: enable': 1
-                    'repartition: max min ratio': 1.327e+00
-                    'repartition: min per proc': 600
-                    'repartition: Zoltan dimensions': 2
-                    'repartition: start level': 4
-                    'semicoarsen: number of levels': 2
-                    'semicoarsen: coarsen rate': 14
-                    'smoother: sweeps': 4
-                    'smoother: type': Gauss-Seidel
-                    'smoother: Chebyshev eig boost': 1.2e+00
-                    'smoother: sweeps (level 0)': 1
-                    'smoother: type (level 0)': line Gauss-Seidel
-                    'smoother: line GS Type': standard
-                    'smoother: damping factor': 1.0e+00
-                    'smoother: pre or post': both
-                    'coarse: type': Gauss-Seidel
-                    'coarse: sweeps': 4
-                    'coarse: max size': 2000
-                    'coarse: pre or post': pre
-                    max levels: 7

--- a/compass/landice/tests/mismipplus/albany_input.yaml
+++ b/compass/landice/tests/mismipplus/albany_input.yaml
@@ -87,12 +87,6 @@ ANONYMOUS:
               Preconditioner Type: MueLu
               Preconditioner Types:
 
-                Ifpack:
-                  Overlap: 1
-                  Prec Type: ILU
-                  Ifpack Settings:
-                    'fact: level-of-fill': 0
-
                 Ifpack2:
                   Overlap: 1
                   Prec Type: ILUT

--- a/compass/landice/tests/thwaites/albany_input.yaml
+++ b/compass/landice/tests/thwaites/albany_input.yaml
@@ -1,8 +1,6 @@
 %YAML 1.1
 ---
 ANONYMOUS:
-# In order to use ML, change Tpetra to Epetra in the following line,
-# and "Preconditioner Type: MueLu" to " Preconditioner Type: ML" several lines below
   Build Type: Tpetra
 
 # Discretization Description
@@ -231,29 +229,3 @@ ANONYMOUS:
                       A: myRebalanceAFact
                       Coordinates: myRebalanceProlongatorFact
                       Importer: myRepartitionFact
-
-                ML:
-                  Base Method Defaults: none
-                  ML Settings:
-                    default values: SA
-                    ML output: 0
-                    'repartition: enable': 1
-                    'repartition: max min ratio': 1.327e+00
-                    'repartition: min per proc': 600
-                    'repartition: Zoltan dimensions': 2
-                    'repartition: start level': 4
-                    'semicoarsen: number of levels': 2
-                    'semicoarsen: coarsen rate': 14
-                    'smoother: sweeps': 4
-                    'smoother: type': Gauss-Seidel
-                    'smoother: Chebyshev eig boost': 1.2e+00
-                    'smoother: sweeps (level 0)': 1
-                    'smoother: type (level 0)': line Gauss-Seidel
-                    'smoother: line GS Type': standard
-                    'smoother: damping factor': 1.0e+00
-                    'smoother: pre or post': both
-                    'coarse: type': Gauss-Seidel
-                    'coarse: sweeps': 4
-                    'coarse: max size': 2000
-                    'coarse: pre or post': pre
-                    max levels: 7

--- a/compass/landice/tests/thwaites/albany_input.yaml
+++ b/compass/landice/tests/thwaites/albany_input.yaml
@@ -87,12 +87,6 @@ ANONYMOUS:
               Preconditioner Type: MueLu
               Preconditioner Types:
 
-                Ifpack:
-                  Overlap: 1
-                  Prec Type: ILU
-                  Ifpack Settings:
-                    'fact: level-of-fill': 0
-
                 Ifpack2:
                   Overlap: 1
                   Prec Type: ILUT


### PR DESCRIPTION
<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->

This PR removes optional/unused preconditioners from landice test inputs that use Trilinos packages (Ifpack/ML) that we no longer use for our builds. Having these optional preconditioners cause invalid parameter exceptions when running landice tests using newest Albany builds. These tests don't use the Ifpack/ML preconditioners anyway so this won't change the behavior of these tests.

<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [x] Document (in a comment titled `Testing` in this PR) any testing that was used to verify the changes

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->
