### PR TITLE
Don't allow version of scikit-image with bad dependencies

### DIFF
--- a/conda/compass_env/spec-file.template
+++ b/conda/compass_env/spec-file.template
@@ -32,6 +32,8 @@ pyamg >=4.2.2
 pyproj
 pyremap>=0.0.13,<0.1.0
 requests
+# having pip check problems with this version
+scikit-image !=0.20.0
 scipy>=1.8.0
 shapely>=2.0,<3.0
 xarray


### PR DESCRIPTION
This is necessary for CI to pass.

<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->
Should be fixed in https://github.com/conda-forge/scikit-image-feedstock/pull/102