### PR TITLE
Only cull topography for cull_mesh steps that have it

### DIFF
--- a/compass/ocean/mesh/cull.py
+++ b/compass/ocean/mesh/cull.py
@@ -383,7 +383,8 @@ def _cull_mesh_with_logging(logger, with_cavities, with_critical_passages,
                 '--engine', netcdf_engine]
         check_call(args, logger=logger)
 
-    _cull_topo()
+    if has_remapped_topo:
+        _cull_topo()
 
     if with_cavities:
         if has_remapped_topo:


### PR DESCRIPTION
Some `cull_mesh` steps take a remapped topography as an input, while others do not (for added speed and to keep resources under control).  This merge fixes a bug in which the `cull_mesh` step was trying to cull the topogrpahy file even if none is present.

<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->

<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [ ] Document (in a comment titled `Testing` in this PR) any testing that was used to verify the changes

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->

closes #593 