### PR TITLE
Skip cached steps when computing suite resources

### DIFF
--- a/compass/setup.py
+++ b/compass/setup.py
@@ -393,11 +393,13 @@ def main():
 def _get_required_cores(test_cases):
     """ Get the maximum number of target cores and the max of min cores """
 
-    max_cores = 0
-    max_of_min_cores = 0
+    max_cores = 1
+    max_of_min_cores = 1
     for test_case in test_cases.values():
         for step_name in test_case.steps_to_run:
             step = test_case.steps[step_name]
+            if step.cached:
+                continue
             if step.ntasks is None:
                 raise ValueError(
                     f'The number of tasks (ntasks) was never set for '


### PR DESCRIPTION
This merge skips cached steps when figuring out the target and minimum cores for a suite.  This is important because the cached steps require no resources at all.

It also sets the number of resources to 1 core by default (rather than zero) in case there are no uncached steps in a run.

<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->

<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [x] Document (in a comment titled `Testing` in this PR) any testing that was used to verify the changes

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->

closes #595 