### PR TITLE
Reduce no. of processes for QU240 cull_mesh step

### DIFF
--- a/compass/ocean/tests/global_ocean/mesh/qu240/qu240.cfg
+++ b/compass/ocean/tests/global_ocean/mesh/qu240/qu240.cfg
@@ -17,6 +17,18 @@ min_layer_thickness = 3.0
 max_layer_thickness = 500.0
 
 
+# options for spherical meshes
+[spherical_mesh]
+
+## config options related to the step for culling land from the mesh
+# number of cores to use
+cull_mesh_cpus_per_task = 18
+# minimum of cores, below which the step fails
+cull_mesh_min_cpus_per_task = 1
+# maximum memory usage allowed (in MB)
+cull_mesh_max_memory = 1000
+
+
 # options for global ocean testcases
 [global_ocean]
 


### PR DESCRIPTION
It appears that 128 processes are too many and slow down the step significantly.

<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->

<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [x] Document (in a comment titled `Testing` in this PR) any testing that was used to verify the changes

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->

closes #598 
