### PR TITLE
Add a test case for extrapolating WOA 2023 data

### DIFF
--- a/compass/ocean/__init__.py
+++ b/compass/ocean/__init__.py
@@ -6,8 +6,8 @@ from compass.ocean.tests.global_convergence import GlobalConvergence
 from compass.ocean.tests.global_ocean import GlobalOcean
 from compass.ocean.tests.gotm import Gotm
 from compass.ocean.tests.hurricane import Hurricane
-from compass.ocean.tests.internal_wave import InternalWave
 from compass.ocean.tests.ice_shelf_2d import IceShelf2d
+from compass.ocean.tests.internal_wave import InternalWave
 from compass.ocean.tests.isomip_plus import IsomipPlus
 from compass.ocean.tests.merry_go_round import MerryGoRound
 from compass.ocean.tests.nonhydro import Nonhydro
@@ -15,9 +15,11 @@ from compass.ocean.tests.overflow import Overflow
 from compass.ocean.tests.planar_convergence import PlanarConvergence
 from compass.ocean.tests.soma import Soma
 from compass.ocean.tests.sphere_transport import SphereTransport
-from compass.ocean.tests.spherical_harmonic_transform import \
-    SphericalHarmonicTransform
+from compass.ocean.tests.spherical_harmonic_transform import (
+    SphericalHarmonicTransform,
+)
 from compass.ocean.tests.tides import Tides
+from compass.ocean.tests.utility import Utility
 from compass.ocean.tests.ziso import Ziso
 
 
@@ -50,4 +52,5 @@ class Ocean(MpasCore):
         self.add_test_group(SphereTransport(mpas_core=self))
         self.add_test_group(SphericalHarmonicTransform(mpas_core=self))
         self.add_test_group(Tides(mpas_core=self))
+        self.add_test_group(Utility(mpas_core=self))
         self.add_test_group(Ziso(mpas_core=self))

--- a/compass/ocean/tests/utility/__init__.py
+++ b/compass/ocean/tests/utility/__init__.py
@@ -1,0 +1,17 @@
+from compass.ocean.tests.utility.extrap_woa import ExtrapWoa
+from compass.testgroup import TestGroup
+
+
+class Utility(TestGroup):
+    """
+    A test group for general ocean utilities
+    """
+
+    def __init__(self, mpas_core):
+        """
+        mpas_core : compass.MpasCore
+            the MPAS core that this test group belongs to
+        """
+        super().__init__(mpas_core=mpas_core, name='utility')
+
+        self.add_test_case(ExtrapWoa(test_group=self))

--- a/compass/ocean/tests/utility/extrap_woa/__init__.py
+++ b/compass/ocean/tests/utility/extrap_woa/__init__.py
@@ -1,0 +1,29 @@
+from compass.ocean.tests.utility.extrap_woa.combine import Combine
+from compass.ocean.tests.utility.extrap_woa.extrap_step import ExtrapStep
+from compass.ocean.tests.utility.extrap_woa.remap_topography import (
+    RemapTopography,
+)
+from compass.testcase import TestCase
+
+
+class ExtrapWoa(TestCase):
+    """
+    A test case for first remapping a topography dataset to the WOA 2023 grid,
+    then extrapolating the WOA23 data into missing ocean regions such as
+    ice-shelf cavities, then extrapolating into grounded ice and land
+    """
+
+    def __init__(self, test_group):
+        """
+        Create the test case
+
+        Parameters
+        ----------
+        test_group : compass.ocean.tests.utility.Utility
+            The test group that this test case belongs to
+        """
+        super().__init__(test_group=test_group, name='extrap_woa')
+
+        self.add_step(Combine(test_case=self))
+        self.add_step(RemapTopography(test_case=self))
+        self.add_step(ExtrapStep(test_case=self))

--- a/compass/ocean/tests/utility/extrap_woa/combine.py
+++ b/compass/ocean/tests/utility/extrap_woa/combine.py
@@ -1,0 +1,92 @@
+import xarray as xr
+
+from compass.step import Step
+
+
+class Combine(Step):
+    """
+    A step for combining a January and an annual WOA 2023 climatology into
+    a single file, where the January data is used where available and the
+    annual in the deeper ocean where monthly data is not provided.
+    """
+
+    def __init__(self, test_case):
+        """
+        Create a new step
+
+        Parameters
+        ----------
+        test_case : compass.ocean.tests.utility.extrap_woa.ExtraWoa
+            The test case this step belongs to
+        """
+        super().__init__(test_case, name='combine', ntasks=1, min_tasks=1)
+        self.add_output_file(filename='woa_combined.nc')
+
+    def setup(self):
+        """
+        Set up the step in the work directory, including downloading any
+        dependencies.
+        """
+        super().setup()
+
+        base_url = \
+            'https://www.ncei.noaa.gov/thredds-ocean/fileServer/woa23/DATA'
+
+        dirs = dict(
+            temp=dict(ann='temperature/netcdf/decav91C0/0.25',
+                      jan='temperature/netcdf/decav91C0/0.25'),
+            salin=dict(ann='salinity/netcdf/decav91C0/0.25',
+                       jan='salinity/netcdf/decav91C0/0.25'))
+
+        woa_files = dict(
+            temp=dict(ann='woa23_decav91C0_t00_04.nc',
+                      jan='woa23_decav91C0_t01_04.nc'),
+            salin=dict(
+                ann='woa23_decav91C0_s00_04.nc',
+                jan='woa23_decav91C0_s01_04.nc'))
+
+        for field in ['temp', 'salin']:
+            for season in ['jan', 'ann']:
+                woa_dir = dirs[field][season]
+                woa_filename = woa_files[field][season]
+                woa_url = f'{base_url}/{woa_dir}/{woa_filename}'
+
+                self.add_input_file(
+                    filename=f'woa_{field}_{season}.nc',
+                    target=woa_filename,
+                    database='initial_condition_database',
+                    url=woa_url)
+
+    def run(self):
+        """
+        Run this step of the test case
+        """
+        ds_ann = xr.open_dataset('woa_temp_ann.nc', decode_times=False)
+
+        ds_out = xr.Dataset()
+
+        for var in ['lon', 'lat', 'depth']:
+            ds_out[var] = ds_ann[var]
+            ds_out[f'{var}_bnds'] = ds_ann[f'{var}_bnds']
+
+        var_map = dict(temp='t_an', salin='s_an')
+
+        for field, var in var_map.items():
+            slices = list()
+            ds_ann = xr.open_dataset(
+                f'woa_{field}_ann.nc',
+                decode_times=False).isel(time=0).drop_vars('time')
+            ds_jan = xr.open_dataset(
+                f'woa_{field}_jan.nc',
+                decode_times=False).isel(time=0).drop_vars('time')
+            for index in range(ds_ann.sizes['depth']):
+                if index < ds_jan.sizes['depth']:
+                    ds = ds_jan
+                else:
+                    ds = ds_ann
+                slices.append(ds[var].isel(depth=index))
+
+            ds_out[var] = xr.concat(slices, dim='depth')
+            ds_out[var].attrs = ds_ann[var].attrs
+
+        ds_out.to_netcdf('woa_combined.nc')

--- a/compass/ocean/tests/utility/extrap_woa/extrap_step.py
+++ b/compass/ocean/tests/utility/extrap_woa/extrap_step.py
@@ -122,7 +122,7 @@ class ExtrapStep(Step):
 
         with xr.open_dataset(in_filename) as ds_woa:
             ndepth = ds_woa.sizes['depth']
-            dims = ds_woa.t_an.dims
+            dims = ds_woa.pt_an.dims
 
         logger.info('  Horizontally extrapolating WOA data...')
         progress = self.log_filename is None
@@ -150,7 +150,7 @@ class ExtrapStep(Step):
             bar.finish()
 
         ds_out = xr.open_mfdataset(files, combine='nested', concat_dim='depth')
-        for field_name in ['t_an', 's_an']:
+        for field_name in ['pt_an', 's_an']:
             ds_out[field_name] = ds_out[field_name].transpose(*dims)
         ds_out.to_netcdf(out_filename)
 
@@ -177,7 +177,7 @@ class ExtrapStep(Step):
         logger.info('  Vertically extrapolating WOA data...')
         progress = self.log_filename is None
         if progress:
-            widgets = [f'  t_an z=1/{ndepth}: ',
+            widgets = [f'  pt_an z=1/{ndepth}: ',
                        progressbar.Percentage(), ' ',
                        progressbar.Bar(), ' ', progressbar.ETA()]
             bar = progressbar.ProgressBar(widgets=widgets,
@@ -186,7 +186,7 @@ class ExtrapStep(Step):
             bar = None
 
         count = 0
-        for field_name in ['t_an', 's_an']:
+        for field_name in ['pt_an', 's_an']:
             slices = [ds[field_name].isel(depth=0).drop_vars(['depth'])]
             for depth_index in range(1, ndepth):
                 field = ds[field_name]
@@ -228,7 +228,7 @@ def _extrap_level(use_ocean_mask, in_filename, progress_dir, depth_index):
     else:
         ocean_mask = None
 
-    field = ds.t_an.values
+    field = ds.pt_an.values
 
     # a small averaging kernel
     x = np.arange(-1, 2)
@@ -245,7 +245,7 @@ def _extrap_level(use_ocean_mask, in_filename, progress_dir, depth_index):
     else:
         invalid_after_fill = None
 
-    fields = dict(t_an=ds.t_an.values.copy(),
+    fields = dict(pt_an=ds.pt_an.values.copy(),
                   s_an=ds.s_an.values.copy())
 
     nlon = field.shape[1]

--- a/compass/ocean/tests/utility/extrap_woa/extrap_step.py
+++ b/compass/ocean/tests/utility/extrap_woa/extrap_step.py
@@ -1,0 +1,303 @@
+import os
+from functools import partial
+from multiprocessing import Pool
+
+import numpy as np
+import progressbar
+import xarray as xr
+from scipy.signal import convolve2d
+
+from compass.step import Step
+
+
+class ExtrapStep(Step):
+    """
+    Extrapolate WOA 2023 data into missing ocean regions, then land and
+    grounded ice
+
+    Attributes
+    ----------
+    woa_filename : str
+        The name of the output file name after extrapolation
+
+    """
+    def __init__(self, test_case):
+        """
+        Create a new test case
+
+        Parameters
+        ----------
+        test_case : compass.ocean.tests.utility.extrap_woa.ExtrapWoa
+            The test case this step belongs to
+
+        """
+        super().__init__(test_case=test_case, name='extrap', cpus_per_task=64,
+                         min_cpus_per_task=1, openmp_threads=1)
+
+        self.add_input_file(
+            filename='woa.nc',
+            target='../combine/woa_combined.nc')
+
+        self.add_input_file(
+            filename='topography.nc',
+            target='../remap_topography/topography_remapped.nc')
+
+        self.woa_filename = None
+
+    def setup(self):
+        """
+        Determine the output filename
+        """
+        self.woa_filename = 'woa23_decav_0.25_extrap.nc'
+        self.add_output_file(self.woa_filename)
+
+    def run(self):
+        """
+        Extrapolate WOA 2023 model temperature and salinity into ice-shelf
+        cavities.
+        """
+        pool = Pool(self.cpus_per_task)
+
+        self._make_3d_ocean_mask()
+
+        # extrapolate horizontally using the ocean mask
+        self._extrap_horiz(use_ocean_mask=True, pool=pool)
+
+        # extrapolate vertically using the ocean mask
+        self._extrap_vert(use_ocean_mask=True)
+
+        # extrapolate horizontally into land and grounded ice
+        self._extrap_horiz(use_ocean_mask=False, pool=pool)
+
+        # extrapolate vertically into land and grounded ice
+        self._extrap_vert(use_ocean_mask=False)
+
+        pool.terminate()
+
+    @staticmethod
+    def _make_3d_ocean_mask():
+        grid_filename = 'woa.nc'
+        topo_filename = 'topography.nc'
+        out_filename = 'ocean_mask.nc'
+
+        with xr.open_dataset(topo_filename) as ds_topo:
+            bathymetry = ds_topo.bathymetry
+            ocean_mask = ds_topo.ocean_mask
+
+            ds_out = xr.Dataset()
+            with xr.open_dataset(grid_filename) as ds_grid:
+                for var in ['lon', 'lat', 'depth']:
+                    ds_out[var] = ds_grid[var]
+                    ds_out[f'{var}_bnds'] = ds_grid[f'{var}_bnds']
+
+                z_top = -ds_grid.depth_bnds.isel(nbounds=0)
+
+                ocean_mask_3d = np.logical_and(
+                    bathymetry <= z_top,
+                    ocean_mask >= 0.5).astype(int)
+
+                ocean_mask_3d = \
+                    ocean_mask_3d.transpose('depth', 'lat', 'lon')
+
+                ds_out['ocean_mask'] = ocean_mask_3d
+
+                ds_out.to_netcdf(out_filename)
+
+    def _extrap_horiz(self, use_ocean_mask, pool):
+        logger = self.logger
+
+        if use_ocean_mask:
+            in_filename = 'woa.nc'
+            out_filename = 'extrap_ocean/woa_extrap_horiz.nc'
+            progress_dir = 'extrap_ocean/extrap_horiz'
+        else:
+            in_filename = 'extrap_ocean/woa_extrap.nc'
+            out_filename = 'extrap_land/woa_extrap_horiz.nc'
+            progress_dir = 'extrap_land/extrap_horiz'
+
+        try:
+            os.makedirs(progress_dir)
+        except FileExistsError:
+            pass
+
+        with xr.open_dataset(in_filename) as ds_woa:
+            ndepth = ds_woa.sizes['depth']
+            dims = ds_woa.t_an.dims
+
+        logger.info('  Horizontally extrapolating WOA data...')
+        progress = self.log_filename is None
+
+        if progress:
+            widgets = ['  ', progressbar.Percentage(), ' ',
+                       progressbar.Bar(), ' ', progressbar.ETA()]
+            bar = progressbar.ProgressBar(widgets=widgets,
+                                          maxval=ndepth).start()
+        else:
+            bar = None
+
+        partial_func = partial(_extrap_level, use_ocean_mask, in_filename,
+                               progress_dir)
+
+        depth_indices = range(ndepth)
+        files = list()
+        for depth_index, tmp_filename in enumerate(
+                pool.imap(partial_func, depth_indices)):
+            files.append(tmp_filename)
+            if progress:
+                bar.update(depth_index + 1)
+
+        if progress:
+            bar.finish()
+
+        ds_out = xr.open_mfdataset(files, combine='nested', concat_dim='depth')
+        for field_name in ['t_an', 's_an']:
+            ds_out[field_name] = ds_out[field_name].transpose(*dims)
+        ds_out.to_netcdf(out_filename)
+
+    def _extrap_vert(self, use_ocean_mask):
+        logger = self.logger
+
+        if use_ocean_mask:
+            in_filename = 'extrap_ocean/woa_extrap_horiz.nc'
+            out_filename = 'extrap_ocean/woa_extrap.nc'
+        else:
+            in_filename = 'extrap_land/woa_extrap_horiz.nc'
+            out_filename = 'woa23_decav_0.25_extrap.nc'
+
+        ds = xr.open_dataset(in_filename)
+
+        if use_ocean_mask:
+            ds_mask = xr.open_dataset('ocean_mask.nc')
+            ocean_mask = ds_mask.ocean_mask
+        else:
+            ocean_mask = None
+
+        ndepth = ds.sizes['depth']
+
+        logger.info('  Vertically extrapolating WOA data...')
+        progress = self.log_filename is None
+        if progress:
+            widgets = [f'  t_an z=1/{ndepth}: ',
+                       progressbar.Percentage(), ' ',
+                       progressbar.Bar(), ' ', progressbar.ETA()]
+            bar = progressbar.ProgressBar(widgets=widgets,
+                                          maxval=2 * ndepth).start()
+        else:
+            bar = None
+
+        count = 0
+        for field_name in ['t_an', 's_an']:
+            slices = [ds[field_name].isel(depth=0).drop_vars(['depth'])]
+            for depth_index in range(1, ndepth):
+                field = ds[field_name]
+                field_above = field.isel(depth=depth_index - 1)
+                field_local = field.isel(depth=depth_index)
+                mask = field_local.isnull()
+                if ocean_mask is not None:
+                    mask = np.logical_and(mask,
+                                          ocean_mask.isel(depth=depth_index))
+                field_local = xr.where(mask, field_above, field_local)
+                slices.append(field_local)
+
+                count += 1
+                if progress:
+                    bar.widgets[0] = \
+                        f'  {field_name} z={depth_index + 1}/{ndepth}: '
+                    bar.update(count)
+
+            field = xr.concat(slices, dim='depth')
+            attrs = ds[field_name].attrs
+            dims = ds[field_name].dims
+            ds[field_name] = field.transpose(*dims)
+            ds[field_name].attrs = attrs
+
+        if progress:
+            bar.finish()
+
+        ds.to_netcdf(out_filename)
+
+
+def _extrap_level(use_ocean_mask, in_filename, progress_dir, depth_index):
+
+    out_filename = os.path.join(progress_dir, f'woa_lev_{depth_index}.nc')
+    ds = xr.open_dataset(in_filename).isel(depth=depth_index)
+
+    if use_ocean_mask:
+        ds_mask = xr.open_dataset('ocean_mask.nc').isel(depth=depth_index)
+        ocean_mask = ds_mask.ocean_mask.values
+    else:
+        ocean_mask = None
+
+    field = ds.t_an.values
+
+    # a small averaging kernel
+    x = np.arange(-1, 2)
+    x, y = np.meshgrid(x, x)
+    kernel = np.exp(-0.5 * (x**2 + y**2))
+
+    # a threshold for extrapolation weights to be considered valid
+    threshold = 0.01
+
+    valid = np.isfinite(field)
+    orig_mask = valid
+    if ocean_mask is not None:
+        invalid_after_fill = np.logical_not(np.logical_or(valid, ocean_mask))
+    else:
+        invalid_after_fill = None
+
+    fields = dict(t_an=ds.t_an.values.copy(),
+                  s_an=ds.s_an.values.copy())
+
+    nlon = field.shape[1]
+
+    lon_with_halo = np.array([nlon - 2, nlon - 1] + list(range(nlon)) + [0, 1])
+    lon_no_halo = list(range(2, nlon + 2))
+
+    prev_fill_count = 0
+
+    while True:
+        valid_weight_sum = _extrap_with_halo(valid, kernel, valid,
+                                             lon_with_halo, lon_no_halo)
+        if invalid_after_fill is not None:
+            valid_weight_sum[invalid_after_fill] = 0.
+
+        new_valid = valid_weight_sum > threshold
+
+        # don't want to overwrite original data but do want ot smooth
+        # extrapolated data
+        fill_mask = np.logical_and(new_valid, np.logical_not(orig_mask))
+
+        fill_count = np.count_nonzero(fill_mask)
+        if fill_count == prev_fill_count:
+            # no change so we're done
+            break
+
+        for field_name, field in fields.items():
+            field_extrap = _extrap_with_halo(field, kernel, valid,
+                                             lon_with_halo, lon_no_halo)
+
+            field[fill_mask] = \
+                field_extrap[fill_mask] / valid_weight_sum[fill_mask]
+
+        valid = new_valid
+        prev_fill_count = fill_count
+
+    for field_name, field in fields.items():
+        if invalid_after_fill is not None:
+            field[invalid_after_fill] = np.nan
+        attrs = ds[field_name].attrs
+        dims = ds[field_name].dims
+        ds[field_name] = (dims, field)
+        ds[field_name].attrs = attrs
+
+    ds.to_netcdf(out_filename)
+    return out_filename
+
+
+def _extrap_with_halo(field, kernel, valid, lon_with_halo, lon_no_halo):
+    field = field.copy()
+    field[np.logical_not(valid)] = 0.
+    field_with_halo = field[:, lon_with_halo]
+    field_extrap = convolve2d(field_with_halo, kernel, mode='same')
+    field_extrap = field_extrap[:, lon_no_halo]
+    return field_extrap

--- a/compass/ocean/tests/utility/extrap_woa/extrap_woa.cfg
+++ b/compass/ocean/tests/utility/extrap_woa/extrap_woa.cfg
@@ -1,0 +1,13 @@
+# config options related to extrapolating WOA 2023 into ice-shelf cavities and
+# then grounded ice and land
+[extrap_woa]
+
+# the name of the topography file in the bathymetry database
+topo_filename = BedMachineAntarctica_v3_and_GEBCO_2022_0.0125_degree_20230315.nc
+
+# the target and minimum number of MPI tasks to use in remapping
+remap_ntasks = 1024
+remap_min_tasks = 360
+
+# remapping method {'bilinear', 'neareststod', 'conserve'}
+remap_method = conserve

--- a/compass/ocean/tests/utility/extrap_woa/remap_topography.py
+++ b/compass/ocean/tests/utility/extrap_woa/remap_topography.py
@@ -1,0 +1,91 @@
+from pyremap import LatLonGridDescriptor, Remapper
+
+from compass.step import Step
+
+
+class RemapTopography(Step):
+    """
+    A step for remapping bathymetry and ice-shelf topography from one
+    latitude-longitude grid to another
+    """
+
+    def __init__(self, test_case):
+        """
+        Create a new step
+
+        Parameters
+        ----------
+        test_case : compass.ocean.tests.utility.extrap_woa.ExtraWoa
+            The test case this step belongs to
+        """
+        super().__init__(test_case, name='remap_topography', ntasks=None,
+                         min_tasks=None)
+        self.add_input_file(filename='woa.nc',
+                            target='../combine/woa_combined.nc')
+        self.add_output_file(filename='topography_remapped.nc')
+
+    def setup(self):
+        """
+        Set up the step in the work directory, including downloading any
+        dependencies.
+        """
+        super().setup()
+        config = self.config
+        topo_filename = config.get('extrap_woa', 'topo_filename')
+
+        self.add_input_file(
+            filename='topography.nc',
+            target=topo_filename,
+            database='bathymetry_database')
+
+        self.ntasks = config.getint('extrap_woa', 'remap_ntasks')
+        self.min_tasks = config.getint('extrap_woa', 'remap_min_tasks')
+
+    def constrain_resources(self, available_resources):
+        """
+        Constrain ``cpus_per_task`` and ``ntasks`` based on the number of
+        cores available to this step
+
+        Parameters
+        ----------
+        available_resources : dict
+            The total number of cores available to the step
+        """
+        config = self.config
+        self.ntasks = config.getint('extrap_woa', 'remap_ntasks')
+        self.min_tasks = config.getint('extrap_woa', 'remap_min_tasks')
+        super().constrain_resources(available_resources)
+
+    def run(self):
+        """
+        Run this step of the test case
+        """
+        config = self.config
+        logger = self.logger
+        parallel_executable = config.get('parallel', 'parallel_executable')
+
+        method = config.get('extrap_woa', 'remap_method')
+
+        in_descriptor = LatLonGridDescriptor.read(fileName='topography.nc',
+                                                  lonVarName='lon',
+                                                  latVarName='lat')
+
+        in_mesh_name = in_descriptor.meshName
+
+        out_descriptor = LatLonGridDescriptor.read(fileName='woa.nc',
+                                                   lonVarName='lon',
+                                                   latVarName='lat')
+
+        out_mesh_name = out_descriptor.meshName
+
+        mapping_file_name = \
+            f'map_{in_mesh_name}_to_{out_mesh_name}_{method}.nc'
+        remapper = Remapper(in_descriptor, out_descriptor, mapping_file_name)
+
+        remapper.build_mapping_file(method=method, mpiTasks=self.ntasks,
+                                    tempdir='.', logger=logger,
+                                    esmf_parallel_exec=parallel_executable)
+
+        remapper.remap_file(inFileName='topography.nc',
+                            outFileName='topography_remapped.nc',
+                            logger=logger)

--- a/conda/compass_env/spec-file.template
+++ b/conda/compass_env/spec-file.template
@@ -10,6 +10,7 @@ esmf=*={{ mpi_prefix }}_*
 ffmpeg
 geometric_features=1.2.0
 git
+gsw
 ipython
 jigsaw=0.9.14
 jigsawpy=0.3.3

--- a/conda/recipe/meta.yaml
+++ b/conda/recipe/meta.yaml
@@ -47,6 +47,7 @@ requirements:
     - ffmpeg
     - geometric_features 1.2.0
     - git
+    - gsw
     - ipython
     - jigsaw 0.9.14
     - jigsawpy 0.3.3

--- a/docs/developers_guide/ocean/api.rst
+++ b/docs/developers_guide/ocean/api.rst
@@ -797,6 +797,28 @@ test cases and steps
    analysis.Analysis.plot
    analysis.Analysis.run
 
+utility
+~~~~~~~
+
+.. currentmodule:: compass.ocean.tests.utility
+
+.. autosummary::
+   :toctree: generated/
+
+   Utility
+
+   extrap_woa.ExtrapWoa
+   extrap_woa.Combine
+   extrap_woa.Combine.setup
+   extrap_woa.Combine.run
+   extrap_woa.ExtrapStep
+   extrap_woa.ExtrapStep.setup
+   extrap_woa.ExtrapStep.run
+   extrap_woa.RemapTopography
+   extrap_woa.RemapTopography.setup
+   extrap_woa.RemapTopography.constrain_resources
+   extrap_woa.RemapTopography.run
+
 ziso
 ~~~~
 

--- a/docs/developers_guide/ocean/framework.rst
+++ b/docs/developers_guide/ocean/framework.rst
@@ -45,7 +45,7 @@ Mesh
 The ``compass.ocean.mesh`` package includes modules for modifying spherical
 ocean meshes shared across test groups.
 
-.. _dev_ocean_framework_remap_topogrpahy:
+.. _dev_ocean_framework_remap_topography:
 
 Remapping Topography
 ~~~~~~~~~~~~~~~~~~~~

--- a/docs/developers_guide/ocean/test_groups/index.rst
+++ b/docs/developers_guide/ocean/test_groups/index.rst
@@ -25,4 +25,5 @@ Test groups
    sphere_transport
    spherical_harmonic_transform
    tides
+   utility
    ziso

--- a/docs/developers_guide/ocean/test_groups/utility.rst
+++ b/docs/developers_guide/ocean/test_groups/utility.rst
@@ -1,0 +1,85 @@
+.. _dev_ocean_utility:
+
+utility
+=======
+
+The ``utility`` test group is a general test group for ocean utilities that
+may create datasets for other test groups to use.  It is partly designed to
+provide provenance for data processing that may be more complex than a single,
+short script.
+
+extrap_woa
+----------
+The class :py:class:`compass.ocean.tests.utility.extrap_woa.ExtrapWoa`
+defines a test case for extrapolating
+`WOA 2023 <https://www.ncei.noaa.gov/products/world-ocean-atlas>`_ data into
+ice-shelf cavities and coastal regions, then into land, grounded ice and below
+bathymetry.
+
+combine
+~~~~~~~
+
+The class :py:class:`compass.ocean.tests.utility.extrap_woa.Combine` defines
+a step for combining the Annual and January temperature and salinity
+climatology data into a single file.  We use the 30-year objectively analyzed
+climatology (1991-2020) data sets on a 0.25 degree lon-lat grid.  The WOA data
+is provided only in the top 1500 m of the ocean in the monthly files, whereas
+it extends to 5500 m depth in the annual dataset.  The test case uses the
+January data where it is available and the annual data when monthly data is
+not provided. Finally, the step converts in situ temperature to potential
+temperature.
+
+remap_topography
+~~~~~~~~~~~~~~~~
+
+The class :py:class:`compass.ocean.tests.utility.extrap_woa.RemapTopography`
+defines a step for conservatively remapping a topography dataset (see
+:ref:`dev_ocean_framework_remap_topography`) from a very high resolution
+grid to the WOA 2023 0.25 degree grid.  The topography and masks are then used
+to aid in the extrapolation process.  Because of the very high resolution
+source grid, at least 360 cores are needed to make the mapping file in this
+step.
+
+extrap_step
+~~~~~~~~~~~
+
+The class :py:class:`compass.ocean.tests.utility.extrap_woa.ExtrapStep`
+defines a step for extrapolating the data into invalid regions.  Because we
+will use the dataset to interpolate potential temperature and salinity at the
+centers of MPAS grid cells, we want there to be valid data not just where WOA
+2023 has it defined but also in the cavities below Antarctic ice shelves, in a
+buffer region into land, and below the bathymetry.  This way, the interpolation
+will be sure never to be contaminated with NaNs or other invalid values.
+
+The ice-shelf cavities provide a particular challenge.  No temperature or
+salinity data is available for them in WOA 2023 but they cover vast areas so
+it is not safe to simply extrapolate from the nearest point available in
+the WOA dataset.  When we have done this in the past, properties deep in the
+Filchner-Ronne ice-shelf cavity come from the Bellinghshausen Sea, which is
+geographically close by but topographically disconnected from the cavity.  To
+avoid this problem, we perform extrapolation in 4 steps.
+
+1. Extrapolate horizontally from WOA 2023 data into regions that the topography
+   dataset indicates are ocean.  This includes anywhere where the top of a WOA
+   layer is above the bathymetry that is not covered the grounded antarctic ice
+   sheet.  This means that we extrapolate not only into ice-shelf cavities but
+   also into the ice-shelves above them.  Past experience has shown this to be
+   a helpful approach.
+
+2. Extrapolate vertically downward from the surface to the seafloor.  This
+   fills in regions that are horizontally blocked by topography from any valid
+   WOA data (e.g. the deep interiors of ice-shelf cavities) but which are still
+   either in the ocean or in floating ice shelves.
+
+3. Extrapolate horizontally from the results of step 2 to fill in land,
+   grounded ice sheet areas, and below the bathymetry.  here, we will likely
+   only ever use the data in a small halo around the "valid" ocean region when
+   we interpolate it to MPAS-Ocean meshes but we fill in everywhere "just in
+   case".
+
+4. Finally, we extrapolate vertically downward one last time all the way to the
+   bottom layer of the dataset.  This won't do anything unless there happen to
+   be layers with no valid WOA data at all (which is not presently the case).
+
+The resulting file is ready to be placed in compass' initial condition database
+(see :ref:`dev_step_input_download` for details on databases).

--- a/docs/users_guide/ocean/test_groups/index.rst
+++ b/docs/users_guide/ocean/test_groups/index.rst
@@ -29,4 +29,5 @@ coming months.
    sphere_transport
    spherical_harmonic_transform
    tides
+   utility
    ziso

--- a/docs/users_guide/ocean/test_groups/utility.rst
+++ b/docs/users_guide/ocean/test_groups/utility.rst
@@ -1,0 +1,18 @@
+.. _ocean_utility:
+
+utility
+=======
+
+The ``utility`` test group is a general test group for ocean utilities that
+may create datasets for other test groups to use.  It is partly designed to
+provide provenance for data processing that may be more complex than a single,
+short script.
+
+extrap_woa
+----------
+The ``ocean/utility/extrap_woa`` test case is used to extrapolate
+`WOA 2023 <https://www.ncei.noaa.gov/products/world-ocean-atlas>`_ data into
+ice-shelf cavities and coastal regions, then into land, grounded ice and below
+bathymetry.  It is provided mainly for developers to update for use on
+future datasets and is not intended for users, so we do not provide full
+documentation here.

--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,7 @@ def package_files(directory, prefixes, extensions):
 install_requires = \
     ['cartopy',
      'cmocean',
+     'gsw',
      'ipython',
      'jigsawpy==0.3.3',
      'jupyter',


### PR DESCRIPTION
This merge adds a new `utility` test group mostly for provenance and ease of updating data sets in the future.

For now, the only test case is `ExtrapWoa`, used to extrapolate WOA 2023 data into ice-shelf cavities and ice shelves, then into grounded ice, land and below bathymetry.

To convert from in situ to potential temperature, the `gsw` package has been added as a compass dependency.

<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->

<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [x] User's Guide has been updated
* [x] Developer's Guide has been updated
* [x] API documentation in the Developer's Guide (`api.rst`) has any new or modified class, method and/or functions listed
* [x] Documentation has been [built locally](https://mpas-dev.github.io/compass/latest/developers_guide/building_docs.html) and changes look as expected
* [x] Document (in a comment titled `Testing` in this PR) any testing that was used to verify the changes

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->
