### PR TITLE
Adjust #cells in baroclinic channel to define 160x500km domain

### DIFF
--- a/compass/ocean/tests/baroclinic_channel/__init__.py
+++ b/compass/ocean/tests/baroclinic_channel/__init__.py
@@ -44,13 +44,13 @@ def configure(resolution, config):
         Configuration options for this test case
     """
     res_params = {'10km': {'nx': 16,
-                           'ny': 50,
+                           'ny': 58,  # NB. 2/sqrt(3) due to hexagons
                            'dc': 10e3},
                   '4km': {'nx': 40,
-                          'ny': 126,
+                          'ny': 144,
                           'dc': 4e3},
                   '1km': {'nx': 160,
-                          'ny': 500,
+                          'ny': 578,
                           'dc': 1e3}}
 
     comment = {'nx': 'the number of mesh cells in the x direction',

--- a/compass/ocean/tests/baroclinic_channel/__init__.py
+++ b/compass/ocean/tests/baroclinic_channel/__init__.py
@@ -1,9 +1,9 @@
-from compass.testgroup import TestGroup
 from compass.ocean.tests.baroclinic_channel.decomp_test import DecompTest
 from compass.ocean.tests.baroclinic_channel.default import Default
 from compass.ocean.tests.baroclinic_channel.restart_test import RestartTest
 from compass.ocean.tests.baroclinic_channel.rpe_test import RpeTest
 from compass.ocean.tests.baroclinic_channel.threads_test import ThreadsTest
+from compass.testgroup import TestGroup
 
 
 class BaroclinicChannel(TestGroup):


### PR DESCRIPTION
This PR adjusts the number of cells used in meshes for the baroclinic channel test case to ensure the 'standard' 160x500km domain is defined. Previously, the channel has had a shorter y-length of sqrt(3)/2 * 500 => 433km.

- When using the `make_planar_hex_mesh` routine, the number of cells along the y-axis should be scaled by `2/sqrt(3)` to account for hexagonal geometry.

The channel is a standard community test case, and use of the 160x500km domain enables model intercomparison, e.g.:

- Ilıcak, M., Adcroft, A.J., Griffies, S.M. and Hallberg, R.W., 2012. Spurious dianeutral mixing and the role of momentum closure. Ocean Modelling, 45, pp.37-58.

- Petersen, M.R., Jacobsen, D.W., Ringler, T.D., Hecht, M.W. and Maltrud, M.E., 2015. Evaluation of the arbitrary Lagrangian–Eulerian vertical coordinate method in the MPAS-Ocean model. Ocean Modelling, 86, pp.93-113.