### PR TITLE
Update E3SM-Project submodule

### DIFF
--- a/utils/e3sm_update/example.cfg
+++ b/utils/e3sm_update/example.cfg
@@ -30,3 +30,5 @@ setup_command = compass suite -s -c ocean -t pr
 # the absolute or relative path to the load script use to activate the
 # compass environment
 load_script = load_compass_e3sm__update_chrysalis_intel_openmpi.sh
+# a list of pull request numbers to skip
+skip_prs =


### PR DESCRIPTION
This merge updates the E3SM-Project submodule from [c292bec000](https://github.com/E3SM-Project/E3SM/tree/c292bec000) to [4b3e611fee](https://github.com/E3SM-Project/E3SM/tree/4b3e611fee).

This update includes the following MPAS-Ocean and MPAS-Frameworks PRs (check mark indicates bit-for-bit with previous PR in the list):
- [x]  (ocn) https://github.com/E3SM-Project/E3SM/pull/5418
- [x]  (ocn) https://github.com/E3SM-Project/E3SM/pull/5447
- [x]  (ocn) https://github.com/E3SM-Project/E3SM/pull/5568
- [x]  (ocn) https://github.com/E3SM-Project/E3SM/pull/5583
       Had to cherry-pick [47f0bca04](https://github.com/E3SM-Project/E3SM/commit/47f0bca0454b66ff1c57151c2e687ba11d3cd249) for this to build
- [x]  (ocn) https://github.com/E3SM-Project/E3SM/pull/5575
       Had to cherry-pick [47f0bca04](https://github.com/E3SM-Project/E3SM/commit/47f0bca0454b66ff1c57151c2e687ba11d3cd249) for this to build
- [x]  (ocn) https://github.com/E3SM-Project/E3SM/pull/5600

It also adds the capability to skip certain PRs in the testing.  This capability works but was not ultimately useful in this update.

closes #500 