### PR TITLE
Fix bug in changing permissions on downloaded files

### DIFF
--- a/compass/step.py
+++ b/compass/step.py
@@ -748,7 +748,11 @@ class Step:
                 download_path = os.path.join(database_root, core_path,
                                              database, download_target)
                 if not os.path.exists(download_path):
-                    database_subdir = os.path.join(database_root, database)
+                    databases_with_downloads.add(database_root)
+                    core_root = os.path.join(database_root, core_path)
+                    databases_with_downloads.add(core_root)
+                    database_subdir = os.path.join(database_root, core_path,
+                                                   database)
                     databases_with_downloads.add(database_subdir)
             elif url is not None:
                 download_path = download_target
@@ -904,10 +908,7 @@ class Step:
         # first the base directories that don't seem to be included in
         # os.walk()
         for directory in databases:
-            try:
-                dir_stat = os.stat(directory)
-            except OSError:
-                continue
+            dir_stat = os.stat(directory)
 
             perm = dir_stat.st_mode & mask
 


### PR DESCRIPTION
The code for changing permissions was being given an incorrect directory and then was failing silently.  This merge fixes the path and also removes the silent failure (an error will be raised if the status of the download directory cannot be determined).

This merge also adds the database root and the root for each affected core to the list of directories to chmod/chown anytime any files get downloaded.

<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->

<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [x] Document (in a comment titled `Testing` in this PR) any testing that was used to verify the changes

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->
closes #586 
closes #608 