### PR TITLE
Fix wISC in mesh prefix

### DIFF
--- a/compass/ocean/tests/global_ocean/mesh/__init__.py
+++ b/compass/ocean/tests/global_ocean/mesh/__init__.py
@@ -109,8 +109,6 @@ class Mesh(TestCase):
         """
         if config is None:
             config = self.config
-        config.set('spherical_mesh', 'add_mesh_density', 'True')
-        config.set('spherical_mesh', 'plot_cell_width', 'True')
         config.add_from_package('compass.mesh', 'mesh.cfg', exception=True)
         # a description of the bathymetry
         if 'remap_topography' in self.steps:
@@ -125,6 +123,8 @@ class Mesh(TestCase):
         config.add_from_package(self.package, self.mesh_config_filename,
                                 exception=True)
 
+        config.set('spherical_mesh', 'add_mesh_density', 'True')
+        config.set('spherical_mesh', 'plot_cell_width', 'True')
         if self.with_ice_shelf_cavities:
             prefix = config.get('global_ocean', 'prefix')
             config.set('global_ocean', 'prefix', f'{prefix}wISC')


### PR DESCRIPTION
The config parser can behave strangely when config options are set, then config files are loaded from other files, then more config options are set.  We now set all config options in the mesh test case only after loading config files that we want overwrite.

<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->

<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [x] Document (in a comment titled `Testing` in this PR) any testing that was used to verify the changes

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->
closes #612 
