### PR TITLE
Fix substitution of `levels` at runtime in `global_ocean`

### DIFF
--- a/compass/ocean/tests/global_ocean/mesh/arrm10to60/arrm10to60.cfg
+++ b/compass/ocean/tests/global_ocean/mesh/arrm10to60/arrm10to60.cfg
@@ -42,7 +42,7 @@ prefix = ARRM
 # a description of the mesh and initial condition
 mesh_description = MPAS Arctic Regionally Refined Mesh (ARRM) for E3SM version
                    ${e3sm_version}, with ${min_res}-km resolution in the Arctic
-                    and ${levels} vertical levels
+                    and <<<levels>>> vertical levels
 
 # E3SM version that the mesh is intended for
 e3sm_version = 3

--- a/compass/ocean/tests/global_ocean/mesh/ec30to60/ec30to60.cfg
+++ b/compass/ocean/tests/global_ocean/mesh/ec30to60/ec30to60.cfg
@@ -47,7 +47,7 @@ prefix = EC
 mesh_description = MPAS Eddy Closure mesh for E3SM version ${e3sm_version} with
                    enhanced resolution around the equator (30 km), South pole
                    (35 km), Greenland (${min_res} km), ${max_res}-km resolution
-                   at mid latitudes, and ${levels} vertical levels
+                   at mid latitudes, and <<<levels>>> vertical levels
 # E3SM version that the mesh is intended for
 e3sm_version = 3
 # The revision number of the mesh, which should be incremented each time the

--- a/compass/ocean/tests/global_ocean/mesh/kuroshio/kuroshio.cfg
+++ b/compass/ocean/tests/global_ocean/mesh/kuroshio/kuroshio.cfg
@@ -32,7 +32,7 @@ mesh_description = MPAS Kuroshio regionally refined mesh for E3SM version
                    Kuroshio-Oyashio Extension, 45-km resolution in the mid latitudes,
                    30-km resolution in a 15-degree band around the equator, 60-km
                    resolution in northern mid latitudes, 30 km in the north
-                   Atlantic and 35 km in the Arctic.  This mesh has ${levels}
+                   Atlantic and 35 km in the Arctic.  This mesh has <<<levels>>>
                    vertical levels.
 # E3SM version that the mesh is intended for
 e3sm_version = 3

--- a/compass/ocean/tests/global_ocean/mesh/qu240/qu240.cfg
+++ b/compass/ocean/tests/global_ocean/mesh/qu240/qu240.cfg
@@ -53,7 +53,7 @@ forward_max_memory = 1000
 prefix = QU
 # a description of the mesh
 mesh_description = MPAS quasi-uniform mesh for E3SM version ${e3sm_version} at
-                   ${min_res}-km global resolution with ${levels} vertical
+                   ${min_res}-km global resolution with <<<levels>>> vertical
                    level
 
 # E3SM version that the mesh is intended for

--- a/compass/ocean/tests/global_ocean/mesh/so12to60/so12to60.cfg
+++ b/compass/ocean/tests/global_ocean/mesh/so12to60/so12to60.cfg
@@ -49,7 +49,7 @@ mesh_description = MPAS Southern Ocean regionally refined mesh for E3SM version
                    Antarctica, 45-km resolution in the mid southern latitudes,
                    30-km resolution in a 15-degree band around the equator, 60-km
                    resolution in northern mid latitudes, 30 km in the north
-                   Atlantic and 35 km in the Arctic.  This mesh has ${levels}
+                   Atlantic and 35 km in the Arctic.  This mesh has <<<levels>>>
                    vertical levels and includes cavities under the ice shelves
                    around Antarctica.
 # E3SM version that the mesh is intended for

--- a/compass/ocean/tests/global_ocean/mesh/wc14/wc14.cfg
+++ b/compass/ocean/tests/global_ocean/mesh/wc14/wc14.cfg
@@ -46,7 +46,7 @@ prefix = WC
 # a description of the mesh and initial condition
 mesh_description = MPAS North America and Arctic Focused Water Cycle mesh for E3SM version
                    ${e3sm_version}, with a focused ${min_res}-km resolution
-                   around North America and ${levels} vertical levels
+                   around North America and <<<levels>>> vertical levels
 
 # E3SM version that the mesh is intended for
 e3sm_version = 3

--- a/compass/ocean/tests/global_ocean/metadata.py
+++ b/compass/ocean/tests/global_ocean/metadata.py
@@ -65,7 +65,7 @@ def get_e3sm_mesh_names(config, levels):
         The long E3SM name of the ocean and sea-ice mesh
     """
 
-    config.set('global_ocean', 'levels', '{}'.format(levels))
+    config.set('global_ocean', 'levels', f'{levels}')
     mesh_prefix = config.get('global_ocean', 'prefix')
     min_res = config.get('global_ocean', 'min_res')
     max_res = config.get('global_ocean', 'max_res')
@@ -110,9 +110,9 @@ def add_mesh_and_init_metadata(output_filenames, config, init_filename):
             if filename.endswith('.nc'):
                 args = ['ncks']
                 for key, value in metadata.items():
-                    args.extend(['--glb_att_add', '{}={}'.format(key, value)])
+                    args.extend(['--glb_att_add', f'{key}={value}'])
                 name, ext = os.path.splitext(filename)
-                new_filename = '{}_with_metadata{}'.format(name, ext)
+                new_filename = f'{name}_with_metadata{ext}'
                 args.extend([filename, new_filename])
                 subprocess.check_call(args)
                 shutil.move(new_filename, filename)
@@ -132,13 +132,13 @@ def _get_metadata(dsInit, config):
     max_depth = dsInit.bottomDepth.max().values
     # round to the nearest 0.1 m
     max_depth = numpy.round(max_depth, 1)
-    config.set('global_ocean', 'max_depth', '{}'.format(max_depth))
+    config.set('global_ocean', 'max_depth', f'{max_depth}')
 
     mesh_prefix = config.get('global_ocean', 'prefix')
     min_res = config.get('global_ocean', 'min_res')
     max_res = config.get('global_ocean', 'max_res')
     levels = dsInit.sizes['nVertLevels']
-    config.set('global_ocean', 'levels', '{}'.format(levels))
+    config.set('global_ocean', 'levels', f'{levels}')
     e3sm_version = config.get('global_ocean', 'e3sm_version')
     mesh_revision = config.get('global_ocean', 'mesh_revision')
     pull_request = config.get('global_ocean', 'pull_request')
@@ -152,7 +152,7 @@ def _get_metadata(dsInit, config):
                     '<<<creation_date>>>': creation_date}
 
     for prefix in ['mesh', 'init', 'bathy', 'bgc', 'wisc']:
-        option = '{}_description'.format(prefix)
+        option = f'{prefix}_description'
         if config.has_option('global_ocean', option):
             description = config.get('global_ocean', option)
             description = ' '.join(
@@ -163,21 +163,21 @@ def _get_metadata(dsInit, config):
                                                       replacement)
             descriptions[prefix] = description
 
-    prefix = 'MPAS_Mesh_{}'.format(mesh_prefix)
+    prefix = f'MPAS_Mesh_{mesh_prefix}'
 
     metadata = {'MPAS_Mesh_Short_Name': short_name,
                 'MPAS_Mesh_Long_Name': long_name,
                 'MPAS_Mesh_Prefix': mesh_prefix,
                 'MPAS_Mesh_E3SM_Version': e3sm_version,
                 'MPAS_Mesh_Pull_Request': pull_request,
-                '{}_Revision'.format(prefix): mesh_revision,
-                '{}_Version_Author'.format(prefix): author,
-                '{}_Version_Author_Email'.format(prefix): email,
-                '{}_Version_Creation_Date'.format(prefix): creation_date,
-                '{}_Minimum_Resolution_km'.format(prefix): min_res,
-                '{}_Maximum_Resolution_km'.format(prefix): max_res,
-                '{}_Maximum_Depth_m'.format(prefix): '{}'.format(max_depth),
-                '{}_Number_of_Levels'.format(prefix): '{}'.format(levels),
+                f'{prefix}_Revision': mesh_revision,
+                f'{prefix}_Version_Author': author,
+                f'{prefix}_Version_Author_Email': email,
+                f'{prefix}_Version_Creation_Date': creation_date,
+                f'{prefix}_Minimum_Resolution_km': min_res,
+                f'{prefix}_Maximum_Resolution_km': max_res,
+                f'{prefix}_Maximum_Depth_m': f'{max_depth}',
+                f'{prefix}_Number_of_Levels': f'{levels}',
                 'MPAS_Mesh_Description': descriptions['mesh'],
                 'MPAS_Mesh_Bathymetry': descriptions['bathy'],
                 'MPAS_Initial_Condition': descriptions['init']}
@@ -196,7 +196,7 @@ def _get_metadata(dsInit, config):
 
     for name in packages:
         package = packages[name]
-        metadata['MPAS_Mesh_{}_Version'.format(name)] = \
+        metadata[f'MPAS_Mesh_{name}_Version'] = \
             _get_conda_package_version(package)
 
     return metadata

--- a/compass/ocean/tests/global_ocean/metadata.py
+++ b/compass/ocean/tests/global_ocean/metadata.py
@@ -147,12 +147,20 @@ def _get_metadata(dsInit, config):
 
     descriptions = dict()
 
+    replacements = {'<<<levels>>>': f'{levels}',
+                    '<<<max_depth>>>': f'{max_depth:g}',
+                    '<<<creation_date>>>': creation_date}
+
     for prefix in ['mesh', 'init', 'bathy', 'bgc', 'wisc']:
         option = '{}_description'.format(prefix)
         if config.has_option('global_ocean', option):
             description = config.get('global_ocean', option)
             description = ' '.join(
                 [line.strip() for line in description.split('\n')])
+            for placeholder, replacement in replacements.items():
+                if placeholder in description:
+                    description = description.replace(placeholder,
+                                                      replacement)
             descriptions[prefix] = description
 
     prefix = 'MPAS_Mesh_{}'.format(mesh_prefix)

--- a/docs/developers_guide/ocean/test_groups/global_ocean.rst
+++ b/docs/developers_guide/ocean/test_groups/global_ocean.rst
@@ -94,7 +94,7 @@ defines:
     mesh_description = MPAS Eddy Closure mesh for E3SM version ${e3sm_version} with
                        enhanced resolution around the equator (30 km), South pole
                        (35 km), Greenland (${min_res} km), ${max_res}-km resolution
-                       at mid latitudes, and ${levels} vertical levels
+                       at mid latitudes, and <<<levels>>> vertical levels
     # E3SM version that the mesh is intended for
     e3sm_version = 2
     # The revision number of the mesh, which should be incremented each time the
@@ -107,6 +107,10 @@ defines:
     # The URL of the pull request documenting the creation of the mesh
     pull_request = <<<Missing>>>
 
+Note that ``<<<levels>>>`` is a custom placeholder for the number of vertical
+levels, since this isn't known until runtime.  There are similar placeholders
+for ``<<<creation_date>>>`` and ``<<<bottom_depth>>>`` for similar reasons.
+
 In this particular case, the ``pull_request`` has not yet been defined.  Each
 time the mesh is revised, the ``mesh_revision`` should be updated and the
 associated pull request to https://github.com/MPAS-Dev/compass/ should be
@@ -118,10 +122,9 @@ standard naming convention for E3SM:
 
 .. code-block:: python
 
-    short_mesh_name = '{}{}E{}r{}'.format(mesh_prefix, res, e3sm_version,
-                                          mesh_revision)
-    long_mesh_name = '{}{}kmL{}E3SMv{}r{}'.format(mesh_prefix, res, levels,
-                                                  e3sm_version, mesh_revision)
+    short_mesh_name = f'{mesh_prefix}{res}E{e3sm_version}r{mesh_revision}'
+    long_mesh_name = \
+        f'{mesh_prefix}{res}kmL{levels}E3SMv{e3sm_version}r{mesh_revision}'
 
 For example, the ``QU240`` mesh has the E3SM short name ``QU240E2r1`` and
 long name ``QU240kmL16E3SMv2r1``.
@@ -336,7 +339,7 @@ The default config options for these meshes are:
     prefix = QU
     # a description of the mesh
     mesh_description = MPAS quasi-uniform mesh for E3SM version ${e3sm_version} at
-                       ${min_res}-km global resolution with ${levels} vertical
+                       ${min_res}-km global resolution with <<<levels>>> vertical
                        level
 
     # E3SM version that the mesh is intended for
@@ -436,7 +439,7 @@ The default config options for these meshes are:
     mesh_description = MPAS Eddy Closure mesh for E3SM version ${e3sm_version} with
                        enhanced resolution around the equator (30 km), South pole
                        (35 km), Greenland (${min_res} km), ${max_res}-km resolution
-                       at mid latitudes, and ${levels} vertical levels
+                       at mid latitudes, and <<<levels>>> vertical levels
     # E3SM version that the mesh is intended for
     e3sm_version = 2
     # The revision number of the mesh, which should be incremented each time the
@@ -514,7 +517,7 @@ module:
                        Kuroshio-Oyashio Extension, 45-km resolution in the mid latitudes,
                        30-km resolution in a 15-degree band around the equator, 60-km
                        resolution in northern mid latitudes, 30 km in the north
-                       Atlantic and 35 km in the Arctic.  This mesh has ${levels}
+                       Atlantic and 35 km in the Arctic.  This mesh has <<<levels>>>
                        vertical levels.
     # E3SM version that the mesh is intended for
     e3sm_version = 2
@@ -603,7 +606,7 @@ The default config options for these meshes are:
                        Antarctica, 45-km resolution in the mid southern latitudes,
                        30-km resolution in a 15-degree band around the equator, 60-km
                        resolution in northern mid latitudes, 30 km in the north
-                       Atlantic and 35 km in the Arctic.  This mesh has ${levels}
+                       Atlantic and 35 km in the Arctic.  This mesh has <<<levels>>>
                        vertical levels and includes cavities under the ice shelves
                        around Antarctica.
     # E3SM version that the mesh is intended for
@@ -700,7 +703,7 @@ The default config options for these meshes are:
     # a description of the mesh and initial condition
     mesh_description = MPAS North America and Arctic Focused Water Cycle mesh for E3SM version
                        ${e3sm_version}, with a focused ${min_res}-km resolution
-                       around North America and ${levels} vertical levels
+                       around North America and <<<levels>>> vertical levels
 
     # E3SM version that the mesh is intended for
     e3sm_version = 2

--- a/docs/users_guide/config_files.rst
+++ b/docs/users_guide/config_files.rst
@@ -354,7 +354,7 @@ looks like:
     # a description of the mesh
     # source: /home/xylar/code/compass/customize_config_parser/compass/ocean/tests/global_ocean/mesh/qu240/qu240.cfg
     mesh_description = MPAS quasi-uniform mesh for E3SM version 2 at
-        240-km global resolution with autodetect vertical
+        240-km global resolution with <<<levels>>> vertical
         level
 
     # source: /home/xylar/code/compass/customize_config_parser/compass/ocean/tests/global_ocean/configure.py

--- a/docs/users_guide/ocean/test_groups/global_ocean.rst
+++ b/docs/users_guide/ocean/test_groups/global_ocean.rst
@@ -824,7 +824,7 @@ correct.
     mesh_description = MPAS Eddy Closure mesh for E3SM version ${e3sm_version} with
                        enhanced resolution around the equator (30 km), South pole
                        (35 km), Greenland (${min_res} km), ${max_res}-km resolution
-                       at mid latitudes, and ${levels} vertical levels
+                       at mid latitudes, and <<<levels>>> vertical levels
 
     bathy_description = Bathymetry is from GEBCO 2022, combined with BedMachine
                         Antarctica v2 around Antarctica.


### PR DESCRIPTION
We need a different placeholder in config options for situations where we need to replace them (not using extended interpolation in the config file) at runtime.  Currently, this only applies to `levels`, the number of vertical levels but it could apply to `creation_date` and `bottom_depth` so we support these in the same way.

<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [x] User's Guide has been updated
* [x] Developer's Guide has been updated
* [x] Documentation has been [built locally](https://mpas-dev.github.io/compass/latest/developers_guide/building_docs.html) and changes look as expected
* [x] Document (in a comment titled `Testing` in this PR) any testing that was used to verify the changes

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->

closes #614 