### PR TITLE
Add land-ice floating variables to `ocean_mesh` step

### DIFF
--- a/compass/ocean/tests/global_ocean/files_for_e3sm/ocean_mesh.py
+++ b/compass/ocean/tests/global_ocean/files_for_e3sm/ocean_mesh.py
@@ -57,7 +57,8 @@ class OceanMesh(FilesForE3SMStep):
 
             if self.with_ice_shelf_cavities:
                 keep_vars = keep_vars + [
-                    'landIceMask', 'landIceDraft', 'landIceFraction'
+                    'landIceMask', 'landIceDraft', 'landIceFraction',
+                    'landIceFloatingMask', 'landIceFloatingFraction'
                 ]
 
             ds = ds[keep_vars]


### PR DESCRIPTION
This likely got missed because `ocean_mesh` got added to `files_for_e3sm` since the floating variable branch was created (several months ago).

<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->

<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [x] Document (in a comment titled `Testing` in this PR) any testing that was used to verify the changes

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->
