### PR TITLE
Fixup namelists for single layer RK4 ocean tests

### DIFF
--- a/compass/ocean/tests/dam_break/namelist.forward
+++ b/compass/ocean/tests/dam_break/namelist.forward
@@ -12,4 +12,5 @@ config_zero_drying_velocity=.true.
 config_drying_min_cell_height=1e-6
 config_thickness_flux_type='upwind'
 config_vert_coord_movement='impermeable_interfaces'
+config_use_debugTracers=.false.
 config_disable_tr_all_tend = .true.

--- a/compass/ocean/tests/drying_slope/namelist.forward
+++ b/compass/ocean/tests/drying_slope/namelist.forward
@@ -19,5 +19,5 @@ config_verify_not_dry=.true.
 config_thickness_flux_type='upwind'
 config_use_cvmix=.false.
 config_use_implicit_bottom_drag=.false.
-config_use_debugTracers=.true.
+config_use_debugTracers=.false.
 config_check_ssh_consistency=.true.


### PR DESCRIPTION
This PR sets `config_use_debugTracers=.false.` for all `dam_break` and `drying_slope` tests. This isn't strictly necessary for the multi-layer cases but there is no need to use `debugTracers` in any of these cases.