### PR TITLE
Add double quotes to flag

### DIFF
--- a/compass/ocean/tests/global_ocean/mesh/arrm10to60/dynamic_adjustment/__init__.py
+++ b/compass/ocean/tests/global_ocean/mesh/arrm10to60/dynamic_adjustment/__init__.py
@@ -67,7 +67,7 @@ class ARRM10to60DynamicAdjustment(DynamicAdjustment):
             'config_run_duration': "'00-00-00_06:00:00'",
             'config_dt': "'00:00:30'",
             'config_btr_dt': "'00:00:01.5'",
-            'config_implicit_bottom_drag_type': 'constant_and_rayleigh',
+            'config_implicit_bottom_drag_type': "'constant_and_rayleigh'",
             'config_Rayleigh_damping_coeff': '1.0e-3'}
         namelist_options.update(shared_options)
         step.add_namelist_options(namelist_options)
@@ -91,7 +91,7 @@ class ARRM10to60DynamicAdjustment(DynamicAdjustment):
             'config_run_duration': "'00-00-00_06:00:00'",
             'config_dt': "'00:01:00'",
             'config_btr_dt': "'00:00:03'",
-            'config_implicit_bottom_drag_type': 'constant_and_rayleigh',
+            'config_implicit_bottom_drag_type': "'constant_and_rayleigh'",
             'config_Rayleigh_damping_coeff': '4.0e-4',
             'config_do_restart': '.true.',
             'config_start_time': "'{}'".format(restart_times[0])}
@@ -118,7 +118,7 @@ class ARRM10to60DynamicAdjustment(DynamicAdjustment):
             'config_run_duration': "'00-00-00_12:00:00'",
             'config_dt': "'00:02:00'",
             'config_btr_dt': "'00:00:06'",
-            'config_implicit_bottom_drag_type': 'constant_and_rayleigh',
+            'config_implicit_bottom_drag_type': "'constant_and_rayleigh'",
             'config_Rayleigh_damping_coeff': '1.0e-4',
             'config_do_restart': '.true.',
             'config_start_time': "'{}'".format(restart_times[1])}
@@ -145,7 +145,7 @@ class ARRM10to60DynamicAdjustment(DynamicAdjustment):
             'config_run_duration': "'00-00-01_00:00:00'",
             'config_dt': "'00:03:00'",
             'config_btr_dt': "'00:00:09'",
-            'config_implicit_bottom_drag_type': 'constant_and_rayleigh',
+            'config_implicit_bottom_drag_type': "'constant_and_rayleigh'",
             'config_Rayleigh_damping_coeff': '4.0e-5',
             'config_do_restart': '.true.',
             'config_start_time': "'{}'".format(restart_times[2])}
@@ -172,7 +172,7 @@ class ARRM10to60DynamicAdjustment(DynamicAdjustment):
             'config_run_duration': "'00-00-01_00:00:00'",
             'config_dt': "'00:05:00'",
             'config_btr_dt': "'00:00:12'",
-            'config_implicit_bottom_drag_type': 'constant_and_rayleigh',
+            'config_implicit_bottom_drag_type': "'constant_and_rayleigh'",
             'config_Rayleigh_damping_coeff': '2.0e-5',
             'config_do_restart': '.true.',
             'config_start_time': "'{}'".format(restart_times[3])}

--- a/compass/ocean/tests/global_ocean/mesh/ec30to60/dynamic_adjustment/__init__.py
+++ b/compass/ocean/tests/global_ocean/mesh/ec30to60/dynamic_adjustment/__init__.py
@@ -65,7 +65,7 @@ class EC30to60DynamicAdjustment(DynamicAdjustment):
             'config_run_duration': "'00-00-10_00:00:00'",
             'config_dt': "'00:15:00'",
             'config_btr_dt': "'00:00:10'",
-            'config_implicit_bottom_drag_type': 'constant_and_rayleigh',
+            'config_implicit_bottom_drag_type': "'constant_and_rayleigh'",
             'config_Rayleigh_damping_coeff': '1.0e-4'}
         namelist_options.update(shared_options)
         step.add_namelist_options(namelist_options)

--- a/compass/ocean/tests/global_ocean/mesh/kuroshio/dynamic_adjustment/__init__.py
+++ b/compass/ocean/tests/global_ocean/mesh/kuroshio/dynamic_adjustment/__init__.py
@@ -75,7 +75,7 @@ class KuroshioDynamicAdjustment(DynamicAdjustment):
             'config_run_duration': "'00-00-02_00:00:00'",
             'config_dt': dt,
             'config_btr_dt': initial_btr_dt,
-            'config_implicit_bottom_drag_type': 'constant_and_rayleigh',
+            'config_implicit_bottom_drag_type': "'constant_and_rayleigh'",
             'config_Rayleigh_damping_coeff': '1.0e-4'}
         namelist_options.update(global_stats)
         step.add_namelist_options(namelist_options)
@@ -98,7 +98,7 @@ class KuroshioDynamicAdjustment(DynamicAdjustment):
         namelist_options = {
             'config_run_duration': "'00-00-08_00:00:00'",
             'config_dt': dt,
-            'config_implicit_bottom_drag_type': 'constant_and_rayleigh',
+            'config_implicit_bottom_drag_type': "'constant_and_rayleigh'",
             'config_Rayleigh_damping_coeff': '1.0e-5',
             'config_do_restart': '.true.',
             'config_start_time': "'{}'".format(restart_times[0])}
@@ -124,7 +124,7 @@ class KuroshioDynamicAdjustment(DynamicAdjustment):
         namelist_options = {
             'config_run_duration': "'00-00-10_00:00:00'",
             'config_dt': dt,
-            'config_implicit_bottom_drag_type': 'constant_and_rayleigh',
+            'config_implicit_bottom_drag_type': "'constant_and_rayleigh'",
             'config_Rayleigh_damping_coeff': '1.0e-6',
             'config_do_restart': '.true.',
             'config_start_time': "'{}'".format(restart_times[1])}

--- a/compass/ocean/tests/global_ocean/mesh/qu240/dynamic_adjustment/__init__.py
+++ b/compass/ocean/tests/global_ocean/mesh/qu240/dynamic_adjustment/__init__.py
@@ -53,7 +53,7 @@ class QU240DynamicAdjustment(DynamicAdjustment):
 
         namelist_options = {
             'config_run_duration': "'00-00-01_00:00:00'",
-            'config_implicit_bottom_drag_type': 'constant_and_rayleigh',
+            'config_implicit_bottom_drag_type': "'constant_and_rayleigh'",
             'config_Rayleigh_damping_coeff': '1.0e-4'}
         namelist_options.update(shared_options)
         step.add_namelist_options(namelist_options)

--- a/compass/ocean/tests/global_ocean/mesh/so12to60/dynamic_adjustment/__init__.py
+++ b/compass/ocean/tests/global_ocean/mesh/so12to60/dynamic_adjustment/__init__.py
@@ -66,7 +66,7 @@ class SO12to60DynamicAdjustment(DynamicAdjustment):
             'config_run_duration': "'00-00-02_00:00:00'",
             'config_dt': "'00:05:00'",
             'config_btr_dt': "'00:00:10'",
-            'config_implicit_bottom_drag_type': 'constant_and_rayleigh',
+            'config_implicit_bottom_drag_type': "'constant_and_rayleigh'",
             'config_Rayleigh_damping_coeff': '1.0e-4'}
         namelist_options.update(shared_options)
         step.add_namelist_options(namelist_options)
@@ -90,7 +90,7 @@ class SO12to60DynamicAdjustment(DynamicAdjustment):
             'config_run_duration': "'00-00-08_00:00:00'",
             'config_dt': "'00:05:00'",
             'config_btr_dt': "'00:00:10'",
-            'config_implicit_bottom_drag_type': 'constant_and_rayleigh',
+            'config_implicit_bottom_drag_type': "'constant_and_rayleigh'",
             'config_Rayleigh_damping_coeff': '1.0e-5',
             'config_do_restart': '.true.',
             'config_start_time': "'{}'".format(restart_times[0])}
@@ -117,7 +117,7 @@ class SO12to60DynamicAdjustment(DynamicAdjustment):
             'config_run_duration': "'00-00-10_00:00:00'",
             'config_dt': "'00:05:00'",
             'config_btr_dt': "'00:00:10'",
-            'config_implicit_bottom_drag_type': 'constant_and_rayleigh',
+            'config_implicit_bottom_drag_type': "'constant_and_rayleigh'",
             'config_Rayleigh_damping_coeff': '1.0e-6',
             'config_do_restart': '.true.',
             'config_start_time': "'{}'".format(restart_times[1])}

--- a/compass/ocean/tests/global_ocean/mesh/wc14/dynamic_adjustment/__init__.py
+++ b/compass/ocean/tests/global_ocean/mesh/wc14/dynamic_adjustment/__init__.py
@@ -67,7 +67,7 @@ class WC14DynamicAdjustment(DynamicAdjustment):
             'config_run_duration': "'00-00-00_06:00:00'",
             'config_dt': "'00:00:30'",
             'config_btr_dt': "'00:00:01.5'",
-            'config_implicit_bottom_drag_type': 'constant_and_rayleigh',
+            'config_implicit_bottom_drag_type': "'constant_and_rayleigh'",
             'config_Rayleigh_damping_coeff': '1.0e-3'}
         namelist_options.update(shared_options)
         step.add_namelist_options(namelist_options)
@@ -91,7 +91,7 @@ class WC14DynamicAdjustment(DynamicAdjustment):
             'config_run_duration': "'00-00-00_06:00:00'",
             'config_dt': "'00:01:00'",
             'config_btr_dt': "'00:00:03'",
-            'config_implicit_bottom_drag_type': 'constant_and_rayleigh',
+            'config_implicit_bottom_drag_type': "'constant_and_rayleigh'",
             'config_Rayleigh_damping_coeff': '4.0e-4',
             'config_do_restart': '.true.',
             'config_start_time': "'{}'".format(restart_times[0])}
@@ -118,7 +118,7 @@ class WC14DynamicAdjustment(DynamicAdjustment):
             'config_run_duration': "'00-00-00_12:00:00'",
             'config_dt': "'00:02:00'",
             'config_btr_dt': "'00:00:06'",
-            'config_implicit_bottom_drag_type': 'constant_and_rayleigh',
+            'config_implicit_bottom_drag_type': "'constant_and_rayleigh'",
             'config_Rayleigh_damping_coeff': '1.0e-4',
             'config_do_restart': '.true.',
             'config_start_time': "'{}'".format(restart_times[1])}
@@ -145,7 +145,7 @@ class WC14DynamicAdjustment(DynamicAdjustment):
             'config_run_duration': "'00-00-01_00:00:00'",
             'config_dt': "'00:03:00'",
             'config_btr_dt': "'00:00:09'",
-            'config_implicit_bottom_drag_type': 'constant_and_rayleigh',
+            'config_implicit_bottom_drag_type': "'constant_and_rayleigh'",
             'config_Rayleigh_damping_coeff': '4.0e-5',
             'config_do_restart': '.true.',
             'config_start_time': "'{}'".format(restart_times[2])}
@@ -172,7 +172,7 @@ class WC14DynamicAdjustment(DynamicAdjustment):
             'config_run_duration': "'00-00-01_00:00:00'",
             'config_dt': "'00:05:00'",
             'config_btr_dt': "'00:00:12'",
-            'config_implicit_bottom_drag_type': 'constant_and_rayleigh',
+            'config_implicit_bottom_drag_type': "'constant_and_rayleigh'",
             'config_Rayleigh_damping_coeff': '2.0e-5',
             'config_do_restart': '.true.',
             'config_start_time': "'{}'".format(restart_times[3])}


### PR DESCRIPTION
In python, string flag specifications require both single and double quotes. This fixes the recent `config_implicit_bottom_drag_type` addition. This broke all the `dynamic_adjustment` cases, and specifically `ocean/global_ocean/QU240/WOA23/dynamic_adjustment` in the `pr` suite. This works now. 