### PR TITLE
Add more graph partition sizes

### DIFF
--- a/compass/ocean/tests/global_ocean/files_for_e3sm/ocean_mesh.py
+++ b/compass/ocean/tests/global_ocean/files_for_e3sm/ocean_mesh.py
@@ -56,10 +56,16 @@ class OceanMesh(FilesForE3SMStep):
                 keep_vars.append('minLevelCell')
 
             if self.with_ice_shelf_cavities:
-                keep_vars = keep_vars + [
+                ice_shelf_keep_vars = [
                     'landIceMask', 'landIceDraft', 'landIceFraction',
                     'landIceFloatingMask', 'landIceFloatingFraction'
                 ]
+                for var in ice_shelf_keep_vars:
+                    if var in ds:
+                        keep_vars.append(var)
+                    else:
+                        self.logger.warn(f'Warning: {var} not present in '
+                                         f'ocean mesh file.')
 
             ds = ds[keep_vars]
             ds.load()


### PR DESCRIPTION
These include multiples of the node sizes up to 20 nodes for all node sizes supported by E3SM.  They also include any core count that is an exact multiple of a supported node size that is within 2 nodes of a set of desirable set of core counts for the ne30 atmosphere/land mesh (factors of 5400).

This merge also takes care of some issues exposed while generating new partition files:
* some existing ocean meshes with ice-shelf cavities don't have the `landIceDraft` variable, so we simply skip it when generating an ocean mesh if it is not present.
* some meshes *do* contain a `cullCell` variable, which causes trouble for the sea-ice partitioning tools, so we remove that variable before passing the mesh to the sea-ice partition tools.

<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->

<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [x] Document (in a comment titled `Testing` in this PR) any testing that was used to verify the changes

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->
closes #627 