### PR TITLE
Get global ocean resources and time steps based on mesh size

### DIFF
--- a/compass/ocean/tests/global_ocean/global_ocean.cfg
+++ b/compass/ocean/tests/global_ocean/global_ocean.cfg
@@ -15,25 +15,31 @@ cull_mesh_max_memory = 1000
 
 ## each mesh should replace these with appropriate values in its config file
 
+# the number of cells per core to aim for
+goal_cells_per_core = 200
+# the approximate maximum number of cells per core (the test will fail if too
+# few cores are available)
+max_cells_per_core = 2000
+
+# the approximate number of cells in the mesh, to be estimated for each mesh
+approx_cell_count = <<<Missing>>>
+
+# time step per resolution (s/km), since dt is proportional to resolution
+dt_per_km = 30
+# barotropic time step per resolution (s/km)
+btr_dt_per_km = 1.5
+
 ## config options related to the initial_state step
 # number of cores to use
-init_ntasks = 4
+init_ntasks = 36
 # minimum of cores, below which the step fails
-init_min_tasks = 1
-# maximum memory usage allowed (in MB)
-init_max_memory = 1000
+init_min_tasks = 8
 # number of threads
 init_threads = 1
 
 ## config options related to the forward steps
-# number of cores to use
-forward_ntasks = 4
-# minimum of cores, below which the step fails
-forward_min_tasks = 1
 # number of threads
 forward_threads = 1
-# maximum memory usage allowed (in MB)
-forward_max_memory = 1000
 
 ## metadata related to the mesh
 # whether to add metadata to output files

--- a/compass/ocean/tests/global_ocean/mesh/arrm10to60/arrm10to60.cfg
+++ b/compass/ocean/tests/global_ocean/mesh/arrm10to60/arrm10to60.cfg
@@ -25,16 +25,9 @@ max_layer_thickness = 150.0
 init_ntasks = 256
 # minimum of cores, below which the step fails
 init_min_tasks = 64
-# maximum memory usage allowed (in MB)
-init_max_memory = 1000
 
-## config options related to the forward steps
-# number of cores to use
-forward_ntasks = 2000
-# minimum of cores, below which the step fails
-forward_min_tasks = 200
-# maximum memory usage allowed (in MB)
-forward_max_memory = 1000
+# the approximate number of cells in the mesh
+approx_cell_count = 600000
 
 ## metadata related to the mesh
 # the prefix (e.g. QU, EC, WC, SO)

--- a/compass/ocean/tests/global_ocean/mesh/arrm10to60/dynamic_adjustment/__init__.py
+++ b/compass/ocean/tests/global_ocean/mesh/arrm10to60/dynamic_adjustment/__init__.py
@@ -61,7 +61,7 @@ class ARRM10to60DynamicAdjustment(DynamicAdjustment):
         step_name = 'damped_adjustment_1'
         step = ForwardStep(test_case=self, mesh=mesh, init=init,
                            time_integrator=time_integrator, name=step_name,
-                           subdir=step_name)
+                           subdir=step_name, get_dt_from_min_res=False)
 
         namelist_options = {
             'config_run_duration': "'00-00-00_06:00:00'",
@@ -85,7 +85,7 @@ class ARRM10to60DynamicAdjustment(DynamicAdjustment):
         step_name = 'damped_adjustment_2'
         step = ForwardStep(test_case=self, mesh=mesh, init=init,
                            time_integrator=time_integrator, name=step_name,
-                           subdir=step_name)
+                           subdir=step_name, get_dt_from_min_res=False)
 
         namelist_options = {
             'config_run_duration': "'00-00-00_06:00:00'",
@@ -112,7 +112,7 @@ class ARRM10to60DynamicAdjustment(DynamicAdjustment):
         step_name = 'damped_adjustment_3'
         step = ForwardStep(test_case=self, mesh=mesh, init=init,
                            time_integrator=time_integrator, name=step_name,
-                           subdir=step_name)
+                           subdir=step_name, get_dt_from_min_res=False)
 
         namelist_options = {
             'config_run_duration': "'00-00-00_12:00:00'",
@@ -139,7 +139,7 @@ class ARRM10to60DynamicAdjustment(DynamicAdjustment):
         step_name = 'damped_adjustment_4'
         step = ForwardStep(test_case=self, mesh=mesh, init=init,
                            time_integrator=time_integrator, name=step_name,
-                           subdir=step_name)
+                           subdir=step_name, get_dt_from_min_res=False)
 
         namelist_options = {
             'config_run_duration': "'00-00-01_00:00:00'",
@@ -166,7 +166,7 @@ class ARRM10to60DynamicAdjustment(DynamicAdjustment):
         step_name = 'damped_adjustment_5'
         step = ForwardStep(test_case=self, mesh=mesh, init=init,
                            time_integrator=time_integrator, name=step_name,
-                           subdir=step_name)
+                           subdir=step_name, get_dt_from_min_res=False)
 
         namelist_options = {
             'config_run_duration': "'00-00-01_00:00:00'",
@@ -193,7 +193,7 @@ class ARRM10to60DynamicAdjustment(DynamicAdjustment):
         step_name = 'damped_adjustment_6'
         step = ForwardStep(test_case=self, mesh=mesh, init=init,
                            time_integrator=time_integrator, name=step_name,
-                           subdir=step_name)
+                           subdir=step_name, get_dt_from_min_res=False)
 
         namelist_options = {
             'config_run_duration': "'00-00-03_00:00:00'",
@@ -218,7 +218,7 @@ class ARRM10to60DynamicAdjustment(DynamicAdjustment):
         step_name = 'simulation'
         step = ForwardStep(test_case=self, mesh=mesh, init=init,
                            time_integrator=time_integrator, name=step_name,
-                           subdir=step_name)
+                           subdir=step_name, get_dt_from_min_res=False)
 
         namelist_options = {
             'config_run_duration': "'00-00-24_00:00:00'",

--- a/compass/ocean/tests/global_ocean/mesh/ec30to60/dynamic_adjustment/__init__.py
+++ b/compass/ocean/tests/global_ocean/mesh/ec30to60/dynamic_adjustment/__init__.py
@@ -59,7 +59,7 @@ class EC30to60DynamicAdjustment(DynamicAdjustment):
         step_name = 'damped_adjustment_1'
         step = ForwardStep(test_case=self, mesh=mesh, init=init,
                            time_integrator=time_integrator, name=step_name,
-                           subdir=step_name)
+                           subdir=step_name, get_dt_from_min_res=False)
 
         namelist_options = {
             'config_run_duration': "'00-00-10_00:00:00'",
@@ -83,7 +83,7 @@ class EC30to60DynamicAdjustment(DynamicAdjustment):
         step_name = 'damped_adjustment_2'
         step = ForwardStep(test_case=self, mesh=mesh, init=init,
                            time_integrator=time_integrator, name=step_name,
-                           subdir=step_name)
+                           subdir=step_name, get_dt_from_min_res=False)
 
         namelist_options = {
             'config_run_duration': "'00-00-20_00:00:00'",
@@ -108,7 +108,7 @@ class EC30to60DynamicAdjustment(DynamicAdjustment):
         step_name = 'simulation'
         step = ForwardStep(test_case=self, mesh=mesh, init=init,
                            time_integrator=time_integrator, name=step_name,
-                           subdir=step_name)
+                           subdir=step_name, get_dt_from_min_res=False)
 
         namelist_options = {
             'config_run_duration': "'00-00-10_00:00:00'",

--- a/compass/ocean/tests/global_ocean/mesh/ec30to60/ec30to60.cfg
+++ b/compass/ocean/tests/global_ocean/mesh/ec30to60/ec30to60.cfg
@@ -24,21 +24,8 @@ transition_levels = 28
 # options for global ocean testcases
 [global_ocean]
 
-## config options related to the initial_state step
-# number of cores to use
-init_ntasks = 36
-# minimum of cores, below which the step fails
-init_min_tasks = 8
-# maximum memory usage allowed (in MB)
-init_max_memory = 1000
-
-## config options related to the forward steps
-# number of cores to use
-forward_ntasks = 128
-# minimum of cores, below which the step fails
-forward_min_tasks = 36
-# maximum memory usage allowed (in MB)
-forward_max_memory = 1000
+# the approximate number of cells in the mesh
+approx_cell_count = 240000
 
 ## metadata related to the mesh
 # the prefix (e.g. QU, EC, WC, SO)

--- a/compass/ocean/tests/global_ocean/mesh/kuroshio/dynamic_adjustment/__init__.py
+++ b/compass/ocean/tests/global_ocean/mesh/kuroshio/dynamic_adjustment/__init__.py
@@ -69,7 +69,7 @@ class KuroshioDynamicAdjustment(DynamicAdjustment):
         step_name = 'damped_adjustment_1'
         step = ForwardStep(test_case=self, mesh=mesh, init=init,
                            time_integrator=time_integrator, name=step_name,
-                           subdir=step_name)
+                           subdir=step_name, get_dt_from_min_res=False)
 
         namelist_options = {
             'config_run_duration': "'00-00-02_00:00:00'",
@@ -93,7 +93,7 @@ class KuroshioDynamicAdjustment(DynamicAdjustment):
         step_name = 'damped_adjustment_2'
         step = ForwardStep(test_case=self, mesh=mesh, init=init,
                            time_integrator=time_integrator, name=step_name,
-                           subdir=step_name)
+                           subdir=step_name, get_dt_from_min_res=False)
 
         namelist_options = {
             'config_run_duration': "'00-00-08_00:00:00'",
@@ -119,7 +119,7 @@ class KuroshioDynamicAdjustment(DynamicAdjustment):
         step_name = 'damped_adjustment_3'
         step = ForwardStep(test_case=self, mesh=mesh, init=init,
                            time_integrator=time_integrator, name=step_name,
-                           subdir=step_name)
+                           subdir=step_name, get_dt_from_min_res=False)
 
         namelist_options = {
             'config_run_duration': "'00-00-10_00:00:00'",
@@ -145,7 +145,7 @@ class KuroshioDynamicAdjustment(DynamicAdjustment):
         step_name = 'damped_adjustment_4'
         step = ForwardStep(test_case=self, mesh=mesh, init=init,
                            time_integrator=time_integrator, name=step_name,
-                           subdir=step_name)
+                           subdir=step_name, get_dt_from_min_res=False)
 
         namelist_options = {
             'config_run_duration': "'00-00-20_00:00:00'",
@@ -169,7 +169,7 @@ class KuroshioDynamicAdjustment(DynamicAdjustment):
         step_name = 'simulation'
         step = ForwardStep(test_case=self, mesh=mesh, init=init,
                            time_integrator=time_integrator, name=step_name,
-                           subdir=step_name)
+                           subdir=step_name, get_dt_from_min_res=False)
 
         namelist_options = {
             'config_run_duration': "'00-00-10_00:00:00'",

--- a/compass/ocean/tests/global_ocean/mesh/kuroshio/kuroshio.cfg
+++ b/compass/ocean/tests/global_ocean/mesh/kuroshio/kuroshio.cfg
@@ -7,22 +7,6 @@ grid_type = 60layerPHC
 # options for global ocean testcases
 [global_ocean]
 
-## config options related to the initial_state step
-# number of cores to use
-init_ntasks = 36
-# minimum of cores, below which the step fails
-init_min_tasks = 8
-# maximum memory usage allowed (in MB)
-init_max_memory = 1000
-
-## config options related to the forward steps
-# number of cores to use
-forward_ntasks = 1296
-# minimum of cores, below which the step fails
-forward_min_tasks = 128
-# maximum memory usage allowed (in MB)
-forward_max_memory = 1000
-
 ## metadata related to the mesh
 # the prefix (e.g. QU, EC, WC, SO, Kuroshio)
 prefix = Kuroshio

--- a/compass/ocean/tests/global_ocean/mesh/kuroshio12to60/kuroshio12to60.cfg
+++ b/compass/ocean/tests/global_ocean/mesh/kuroshio12to60/kuroshio12to60.cfg
@@ -1,5 +1,8 @@
 # options for global ocean testcases
 [global_ocean]
 
+# the approximate number of cells in the mesh
+approx_cell_count = 320000
+
 # the minimum (finest) resolution in the mesh
 min_res = 12

--- a/compass/ocean/tests/global_ocean/mesh/kuroshio8to60/kuroshio8to60.cfg
+++ b/compass/ocean/tests/global_ocean/mesh/kuroshio8to60/kuroshio8to60.cfg
@@ -1,5 +1,8 @@
 # options for global ocean testcases
 [global_ocean]
 
+# the approximate number of cells in the mesh
+approx_cell_count = 460000
+
 # the minimum (finest) resolution in the mesh
 min_res = 8

--- a/compass/ocean/tests/global_ocean/mesh/qu240/dynamic_adjustment/__init__.py
+++ b/compass/ocean/tests/global_ocean/mesh/qu240/dynamic_adjustment/__init__.py
@@ -49,7 +49,7 @@ class QU240DynamicAdjustment(DynamicAdjustment):
         step_name = 'damped_adjustment_1'
         step = ForwardStep(test_case=self, mesh=mesh, init=init,
                            time_integrator=time_integrator, name=step_name,
-                           subdir=step_name)
+                           subdir=step_name, get_dt_from_min_res=False)
 
         namelist_options = {
             'config_run_duration': "'00-00-01_00:00:00'",
@@ -71,7 +71,7 @@ class QU240DynamicAdjustment(DynamicAdjustment):
         step_name = 'simulation'
         step = ForwardStep(test_case=self, mesh=mesh, init=init,
                            time_integrator=time_integrator, name=step_name,
-                           subdir=step_name)
+                           subdir=step_name, get_dt_from_min_res=False)
 
         namelist_options = {
             'config_run_duration': "'00-00-01_00:00:00'",

--- a/compass/ocean/tests/global_ocean/mesh/qu240/qu240.cfg
+++ b/compass/ocean/tests/global_ocean/mesh/qu240/qu240.cfg
@@ -37,16 +37,9 @@ cull_mesh_max_memory = 1000
 init_ntasks = 4
 # minimum of cores, below which the step fails
 init_min_tasks = 1
-# maximum memory usage allowed (in MB)
-init_max_memory = 1000
 
-## config options related to the forward steps
-# number of cores to use
-forward_ntasks = 4
-# minimum of cores, below which the step fails
-forward_min_tasks = 1
-# maximum memory usage allowed (in MB)
-forward_max_memory = 1000
+# the approximate number of cells in the mesh
+approx_cell_count = 7400
 
 ## metadata related to the mesh
 # the prefix (e.g. QU, EC, WC, SO)

--- a/compass/ocean/tests/global_ocean/mesh/so12to60/dynamic_adjustment/__init__.py
+++ b/compass/ocean/tests/global_ocean/mesh/so12to60/dynamic_adjustment/__init__.py
@@ -60,7 +60,7 @@ class SO12to60DynamicAdjustment(DynamicAdjustment):
         step_name = 'damped_adjustment_1'
         step = ForwardStep(test_case=self, mesh=mesh, init=init,
                            time_integrator=time_integrator, name=step_name,
-                           subdir=step_name)
+                           subdir=step_name, get_dt_from_min_res=False)
 
         namelist_options = {
             'config_run_duration': "'00-00-02_00:00:00'",
@@ -84,7 +84,7 @@ class SO12to60DynamicAdjustment(DynamicAdjustment):
         step_name = 'damped_adjustment_2'
         step = ForwardStep(test_case=self, mesh=mesh, init=init,
                            time_integrator=time_integrator, name=step_name,
-                           subdir=step_name)
+                           subdir=step_name, get_dt_from_min_res=False)
 
         namelist_options = {
             'config_run_duration': "'00-00-08_00:00:00'",
@@ -111,7 +111,7 @@ class SO12to60DynamicAdjustment(DynamicAdjustment):
         step_name = 'damped_adjustment_3'
         step = ForwardStep(test_case=self, mesh=mesh, init=init,
                            time_integrator=time_integrator, name=step_name,
-                           subdir=step_name)
+                           subdir=step_name, get_dt_from_min_res=False)
 
         namelist_options = {
             'config_run_duration': "'00-00-10_00:00:00'",
@@ -138,7 +138,7 @@ class SO12to60DynamicAdjustment(DynamicAdjustment):
         step_name = 'damped_adjustment_4'
         step = ForwardStep(test_case=self, mesh=mesh, init=init,
                            time_integrator=time_integrator, name=step_name,
-                           subdir=step_name)
+                           subdir=step_name, get_dt_from_min_res=False)
 
         namelist_options = {
             'config_run_duration': "'00-00-20_00:00:00'",
@@ -163,7 +163,7 @@ class SO12to60DynamicAdjustment(DynamicAdjustment):
         step_name = 'simulation'
         step = ForwardStep(test_case=self, mesh=mesh, init=init,
                            time_integrator=time_integrator, name=step_name,
-                           subdir=step_name)
+                           subdir=step_name, get_dt_from_min_res=False)
 
         namelist_options = {
             'config_run_duration': "'00-00-10_00:00:00'",

--- a/compass/ocean/tests/global_ocean/mesh/so12to60/so12to60.cfg
+++ b/compass/ocean/tests/global_ocean/mesh/so12to60/so12to60.cfg
@@ -24,21 +24,8 @@ transition_levels = 28
 # options for global ocean testcases
 [global_ocean]
 
-## config options related to the initial_state step
-# number of cores to use
-init_ntasks = 36
-# minimum of cores, below which the step fails
-init_min_tasks = 8
-# maximum memory usage allowed (in MB)
-init_max_memory = 1000
-
-## config options related to the forward steps
-# number of cores to use
-forward_ntasks = 1296
-# minimum of cores, below which the step fails
-forward_min_tasks = 128
-# maximum memory usage allowed (in MB)
-forward_max_memory = 1000
+# the approximate number of cells in the mesh
+approx_cell_count = 570000
 
 ## metadata related to the mesh
 # the prefix (e.g. QU, EC, WC, SO)

--- a/compass/ocean/tests/global_ocean/mesh/wc14/dynamic_adjustment/__init__.py
+++ b/compass/ocean/tests/global_ocean/mesh/wc14/dynamic_adjustment/__init__.py
@@ -61,7 +61,7 @@ class WC14DynamicAdjustment(DynamicAdjustment):
         step_name = 'damped_adjustment_1'
         step = ForwardStep(test_case=self, mesh=mesh, init=init,
                            time_integrator=time_integrator, name=step_name,
-                           subdir=step_name)
+                           subdir=step_name, get_dt_from_min_res=False)
 
         namelist_options = {
             'config_run_duration': "'00-00-00_06:00:00'",
@@ -85,7 +85,7 @@ class WC14DynamicAdjustment(DynamicAdjustment):
         step_name = 'damped_adjustment_2'
         step = ForwardStep(test_case=self, mesh=mesh, init=init,
                            time_integrator=time_integrator, name=step_name,
-                           subdir=step_name)
+                           subdir=step_name, get_dt_from_min_res=False)
 
         namelist_options = {
             'config_run_duration': "'00-00-00_06:00:00'",
@@ -112,7 +112,7 @@ class WC14DynamicAdjustment(DynamicAdjustment):
         step_name = 'damped_adjustment_3'
         step = ForwardStep(test_case=self, mesh=mesh, init=init,
                            time_integrator=time_integrator, name=step_name,
-                           subdir=step_name)
+                           subdir=step_name, get_dt_from_min_res=False)
 
         namelist_options = {
             'config_run_duration': "'00-00-00_12:00:00'",
@@ -139,7 +139,7 @@ class WC14DynamicAdjustment(DynamicAdjustment):
         step_name = 'damped_adjustment_4'
         step = ForwardStep(test_case=self, mesh=mesh, init=init,
                            time_integrator=time_integrator, name=step_name,
-                           subdir=step_name)
+                           subdir=step_name, get_dt_from_min_res=False)
 
         namelist_options = {
             'config_run_duration': "'00-00-01_00:00:00'",
@@ -166,7 +166,7 @@ class WC14DynamicAdjustment(DynamicAdjustment):
         step_name = 'damped_adjustment_5'
         step = ForwardStep(test_case=self, mesh=mesh, init=init,
                            time_integrator=time_integrator, name=step_name,
-                           subdir=step_name)
+                           subdir=step_name, get_dt_from_min_res=False)
 
         namelist_options = {
             'config_run_duration': "'00-00-01_00:00:00'",
@@ -193,7 +193,7 @@ class WC14DynamicAdjustment(DynamicAdjustment):
         step_name = 'damped_adjustment_6'
         step = ForwardStep(test_case=self, mesh=mesh, init=init,
                            time_integrator=time_integrator, name=step_name,
-                           subdir=step_name)
+                           subdir=step_name, get_dt_from_min_res=False)
 
         namelist_options = {
             'config_run_duration': "'00-00-03_00:00:00'",
@@ -218,7 +218,7 @@ class WC14DynamicAdjustment(DynamicAdjustment):
         step_name = 'simulation'
         step = ForwardStep(test_case=self, mesh=mesh, init=init,
                            time_integrator=time_integrator, name=step_name,
-                           subdir=step_name)
+                           subdir=step_name, get_dt_from_min_res=False)
 
         namelist_options = {
             'config_run_duration': "'00-00-24_00:00:00'",

--- a/compass/ocean/tests/global_ocean/mesh/wc14/wc14.cfg
+++ b/compass/ocean/tests/global_ocean/mesh/wc14/wc14.cfg
@@ -24,21 +24,8 @@ transition_levels = 28
 # options for global ocean testcases
 [global_ocean]
 
-## config options related to the initial_state step
-# number of cores to use
-init_ntasks = 36
-# minimum of cores, below which the step fails
-init_min_tasks = 8
-# maximum memory usage allowed (in MB)
-init_max_memory = 1000
-
-## config options related to the forward steps
-# number of cores to use
-forward_ntasks = 720
-# minimum of cores, below which the step fails
-forward_min_tasks = 144
-# maximum memory usage allowed (in MB)
-forward_max_memory = 1000
+# the approximate number of cells in the mesh
+approx_cell_count = 410000
 
 ## metadata related to the mesh
 # the prefix (e.g. QU, EC, WC, SO)

--- a/compass/ocean/tests/global_ocean/restart_test/__init__.py
+++ b/compass/ocean/tests/global_ocean/restart_test/__init__.py
@@ -1,6 +1,8 @@
+from compass.ocean.tests.global_ocean.forward import (
+    ForwardStep,
+    ForwardTestCase,
+)
 from compass.validate import compare_variables
-from compass.ocean.tests.global_ocean.forward import ForwardTestCase, \
-    ForwardStep
 
 
 class RestartTest(ForwardTestCase):
@@ -42,7 +44,8 @@ class RestartTest(ForwardTestCase):
             name = '{}_run'.format(part)
             step = ForwardStep(test_case=self, mesh=mesh, init=init,
                                time_integrator=time_integrator, name=name,
-                               subdir=name, ntasks=4, openmp_threads=1)
+                               subdir=name, ntasks=4, openmp_threads=1,
+                               get_dt_from_min_res=False)
 
             suffix = '{}.{}'.format(time_integrator.lower(), part)
             step.add_namelist_file(module, 'namelist.{}'.format(suffix))

--- a/compass/ocean/tests/global_ocean/tasks.py
+++ b/compass/ocean/tests/global_ocean/tasks.py
@@ -1,0 +1,54 @@
+import xarray as xr
+
+
+def get_ntasks_from_cell_count(config, at_setup, mesh_filename):
+    """
+    Computes ``ntasks`` and ``min_tasks`` for a step based on the estimated
+    (at setup) or exact (at runtime) mesh size
+
+    Parameters
+    ----------
+    config : compass.config.CompassConfigParser
+        Configuration options for the test case the step belongs to
+
+    at_setup : bool
+        Whether this method is being run during setup of the step, as
+        opposed to at runtime
+
+    mesh_filename : str
+        A file containing the MPAS mesh (specifically ``nCells``) if
+        ``at_setup == False``
+
+    Returns
+    -------
+    ntasks : int
+        The target number of MPI tasks for the step
+
+    min_tasks : int
+        The minimum number of tasks for the step
+    """
+    if at_setup:
+        cell_count = config.getint('global_ocean', 'approx_cell_count')
+    else:
+        with xr.open_dataset(mesh_filename) as ds:
+            cell_count = ds.sizes['nCells']
+
+    if cell_count is None:
+        raise ValueError('ntasks and min_tasks were not set explicitly '
+                         'but they also cannot be computed because '
+                         'compute_cell_count() does not appear to have '
+                         'been overridden.')
+
+    goal_cells_per_core = config.getfloat('global_ocean',
+                                          'goal_cells_per_core')
+    max_cells_per_core = config.getfloat('global_ocean',
+                                         'max_cells_per_core')
+
+    # machines (e.g. Perlmutter) seem to be happier with ntasks that
+    # are multiples of 4
+    # ideally, about 200 cells per core
+    ntasks = max(1, 4 * round(cell_count / (4 * goal_cells_per_core)))
+    # In a pinch, about 2000 cells per core
+    min_tasks = max(1, 4 * round(cell_count / (4 * max_cells_per_core)))
+
+    return ntasks, min_tasks

--- a/compass/step.py
+++ b/compass/step.py
@@ -47,23 +47,23 @@ class Step:
         ``mpas_core``, ``test_group``, the test case's ``subdir`` and the
         step's ``subdir``
 
-    cpus_per_task : int, optional
+    cpus_per_task : int
         the number of cores per task the step would ideally use.  If
         fewer cores per node are available on the system, the step will
         run on all available cores as long as this is not below
         ``min_cpus_per_task``
 
-    min_cpus_per_task : int, optional
+    min_cpus_per_task : int
         the number of cores per task the step requires.  If the system
         has fewer than this number of cores per node, the step will fail
 
-    ntasks : int, optional
+    ntasks : int
         the number of tasks the step would ideally use.  If too few
         cores are available on the system to accommodate the number of
         tasks and the number of cores per task, the step will run on
         fewer tasks as long as as this is not below ``min_tasks``
 
-    min_tasks : int, optional
+    min_tasks : int
         the number of tasks the step requires.  If the system has too
         few cores to accommodate the number of tasks and cores per task,
         the step will fail

--- a/docs/developers_guide/ocean/api.rst
+++ b/docs/developers_guide/ocean/api.rst
@@ -256,6 +256,8 @@ global_ocean framework
    metadata.get_e3sm_mesh_names
    metadata.add_mesh_and_init_metadata
 
+   tasks.get_ntasks_from_cell_count
+
 
 gotm
 ~~~~

--- a/docs/users_guide/ocean/test_groups/global_ocean.rst
+++ b/docs/users_guide/ocean/test_groups/global_ocean.rst
@@ -38,7 +38,7 @@ Note that meshes and test cases may modify these options, as noted below.
 
     ## config options related to the step for culling land from the mesh
     # number of cores to use
-    cull_mesh_cpus_per_task = 18
+    cull_mesh_cpus_per_task = 128
     # minimum of cores, below which the step fails
     cull_mesh_min_cpus_per_task = 1
     # maximum memory usage allowed (in MB)
@@ -50,25 +50,31 @@ Note that meshes and test cases may modify these options, as noted below.
 
     ## each mesh should replace these with appropriate values in its config file
 
+    # the number of cells per core to aim for
+    goal_cells_per_core = 200
+    # the approximate maximum number of cells per core (the test will fail if too
+    # few cores are available)
+    max_cells_per_core = 2000
+
+    # the approximate number of cells in the mesh, to be estimated for each mesh
+    approx_cell_count = <<<Missing>>>
+
+    # time step per resolution (s/km), since dt is proportional to resolution
+    dt_per_km = 30
+    # barotropic time step per resolution (s/km)
+    btr_dt_per_km = 1.5
+
     ## config options related to the initial_state step
     # number of cores to use
-    init_ntasks = 4
+    init_ntasks = 36
     # minimum of cores, below which the step fails
-    init_min_tasks = 1
-    # maximum memory usage allowed (in MB)
-    init_max_memory = 1000
+    init_min_tasks = 8
     # number of threads
     init_threads = 1
 
     ## config options related to the forward steps
-    # number of cores to use
-    forward_ntasks = 4
-    # minimum of cores, below which the step fails
-    forward_min_tasks = 1
     # number of threads
     forward_threads = 1
-    # maximum memory usage allowed (in MB)
-    forward_max_memory = 1000
 
     ## metadata related to the mesh
     # whether to add metadata to output files
@@ -82,7 +88,7 @@ Note that meshes and test cases may modify these options, as noted below.
     # a description of the mesh with ice-shelf cavities
     init_description = <<<Missing>>>
     # E3SM version that the mesh is intended for
-    e3sm_version = 2
+    e3sm_version = 3
     # The revision number of the mesh, which should be incremented each time the
     # mesh is revised
     mesh_revision = <<Missing>>
@@ -180,6 +186,9 @@ Note that meshes and test cases may modify these options, as noted below.
 
     # whether the mesh has ice-shelf cavities
     with_ice_shelf_cavities = autodetect
+
+    # whether to write out sea-ice partition info for plotting in paraview
+    plot_seaice_partitions = False
 
 The ``cull_mesh_*``, ``init_*`` and ``forward:*`` config options are used to
 specify the resources used in in the ``mesh`` step of the :ref:`global_ocean_mesh`,


### PR DESCRIPTION
<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->

This merge switches many global ocean steps to getting the core count from either an estimate or exact number of cells in the mesh.  Similarly, it switches to computing the time steps (both barotropic and baroclinic) from the minimum resolution of the mesh.

This work paves the way for generalized QU and icosahedral global ocean meshes.

<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [x] User's Guide has been updated
* [x] Developer's Guide has been updated
* [x] API documentation in the Developer's Guide (`api.rst`) has any new or modified class, method and/or functions listed
* [x] Documentation has been [built locally](https://mpas-dev.github.io/compass/latest/developers_guide/building_docs.html) and changes look as expected
* [x] Document (in a comment titled `Testing` in this PR) any testing that was used to verify the changes

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->
