### PR TITLE
Add general QU and Icos meshes

### DIFF
--- a/compass/ocean/tests/global_ocean/__init__.py
+++ b/compass/ocean/tests/global_ocean/__init__.py
@@ -16,6 +16,9 @@ from compass.ocean.tests.global_ocean.mesh.kuroshio.dynamic_adjustment import (
 from compass.ocean.tests.global_ocean.mesh.qu240.dynamic_adjustment import (
     QU240DynamicAdjustment,
 )
+from compass.ocean.tests.global_ocean.mesh.qu.dynamic_adjustment import (
+    QUDynamicAdjustment,
+)
 from compass.ocean.tests.global_ocean.mesh.so12to60.dynamic_adjustment import (
     SO12to60DynamicAdjustment,
 )
@@ -54,18 +57,18 @@ class GlobalOcean(TestGroup):
                         include_bgc=True)
 
         # for other meshes, we do fewer tests
+        self._add_tests(mesh_names=['QU', 'Icos', 'QUwISC', 'IcoswISC'],
+                        DynamicAdjustment=QUDynamicAdjustment)
+
         self._add_tests(mesh_names=['EC30to60', 'ECwISC30to60'],
                         DynamicAdjustment=EC30to60DynamicAdjustment)
 
-        # ARRM10to60: with and without cavities
         self._add_tests(mesh_names=['ARRM10to60', 'ARRMwISC10to60'],
                         DynamicAdjustment=ARRM10to60DynamicAdjustment)
 
-        # SO12to60: with and without cavities
         self._add_tests(mesh_names=['SO12to60', 'SOwISC12to60'],
                         DynamicAdjustment=SO12to60DynamicAdjustment)
 
-        # WC14: with and without cavities
         self._add_tests(mesh_names=['WC14', 'WCwISC14'],
                         DynamicAdjustment=WC14DynamicAdjustment)
 

--- a/compass/ocean/tests/global_ocean/forward.py
+++ b/compass/ocean/tests/global_ocean/forward.py
@@ -126,6 +126,11 @@ class ForwardStep(Step):
             if mesh_stream in mesh_package_contents:
                 self.add_streams_file(mesh_package, mesh_stream)
 
+        mesh_path = self.mesh.get_cull_mesh_path()
+        self.add_input_file(
+            filename='mesh.nc',
+            work_dir_target=f'{mesh_path}/culled_mesh.nc')
+
         if init is not None:
             if mesh.with_ice_shelf_cavities:
                 initial_state_target = \
@@ -174,7 +179,7 @@ class ForwardStep(Step):
         """
         config = self.config
         if self.dynamic_ntasks:
-            mesh_filename = os.path.join(self.work_dir, 'init.nc')
+            mesh_filename = os.path.join(self.work_dir, 'mesh.nc')
             self.ntasks, self.min_tasks = get_ntasks_from_cell_count(
                 config=config, at_setup=False, mesh_filename=mesh_filename)
             self.openmp_threads = config.getint('global_ocean',

--- a/compass/ocean/tests/global_ocean/mesh/__init__.py
+++ b/compass/ocean/tests/global_ocean/mesh/__init__.py
@@ -7,6 +7,10 @@ from compass.ocean.mesh.remap_topography import RemapTopography
 from compass.ocean.tests.global_ocean.mesh.arrm10to60 import ARRM10to60BaseMesh
 from compass.ocean.tests.global_ocean.mesh.ec30to60 import EC30to60BaseMesh
 from compass.ocean.tests.global_ocean.mesh.kuroshio import KuroshioBaseMesh
+from compass.ocean.tests.global_ocean.mesh.qu import (
+    IcosMeshFromConfigStep,
+    QUMeshFromConfigStep,
+)
 from compass.ocean.tests.global_ocean.mesh.so12to60 import SO12to60BaseMesh
 from compass.ocean.tests.global_ocean.mesh.wc14 import WC14BaseMesh
 from compass.ocean.tests.global_ocean.metadata import (
@@ -72,6 +76,12 @@ class Mesh(TestCase):
         elif mesh_name in ['QU240', 'QUwISC240']:
             base_mesh_step = QuasiUniformSphericalMeshStep(
                 self, name=name, subdir=subdir, cell_width=240)
+        elif mesh_name in ['Icos', 'IcoswISC']:
+            base_mesh_step = IcosMeshFromConfigStep(
+                self, name=name, subdir=subdir)
+        elif mesh_name in ['QU', 'QUwISC']:
+            base_mesh_step = QUMeshFromConfigStep(
+                self, name=name, subdir=subdir)
         elif mesh_name in ['EC30to60', 'ECwISC30to60']:
             base_mesh_step = EC30to60BaseMesh(self, name=name, subdir=subdir)
         elif mesh_name in ['ARRM10to60', 'ARRMwISC10to60']:
@@ -122,6 +132,18 @@ class Mesh(TestCase):
                 'kuroshio.cfg', exception=True)
         config.add_from_package(self.package, self.mesh_config_filename,
                                 exception=True)
+        if self.mesh_name in ['Icos', 'IcoswISC']:
+            # add the config options for all kuroshio meshes
+            config.add_from_package(
+                'compass.ocean.tests.global_ocean.mesh.qu',
+                'icos.cfg', exception=True)
+
+        if self.mesh_name in ['QU', 'QUwISC', 'Icos', 'IcoswISC']:
+            res = config.getfloat('global_ocean', 'qu_resolution')
+            # roughly area of the ocean divided by the area of a cell
+            approx_cell_count = int(4e8 / res**2)
+            config.set('global_ocean', 'approx_cell_count',
+                       f'{approx_cell_count}')
 
         config.set('spherical_mesh', 'add_mesh_density', 'True')
         config.set('spherical_mesh', 'plot_cell_width', 'True')

--- a/compass/ocean/tests/global_ocean/mesh/qu/__init__.py
+++ b/compass/ocean/tests/global_ocean/mesh/qu/__init__.py
@@ -1,0 +1,36 @@
+from compass.mesh.spherical import (
+    IcosahedralMeshStep,
+    QuasiUniformSphericalMeshStep,
+)
+
+
+class IcosMeshFromConfigStep(IcosahedralMeshStep):
+    """
+    A step for creating quasi-uniform meshes at a resolution given by a config
+    option
+    """
+    def setup(self):
+        """
+        Set up the test case in the work directory, including downloading any
+        dependencies.
+        """
+        # get the these properties from the config options
+        super().setup()
+        config = self.config
+        self.cell_width = config.getfloat('global_ocean', 'qu_resolution')
+
+
+class QUMeshFromConfigStep(QuasiUniformSphericalMeshStep):
+    """
+    A step for creating quasi-uniform meshes at a resolution given by a config
+    option
+    """
+    def setup(self):
+        """
+        Set up the test case in the work directory, including downloading any
+        dependencies.
+        """
+        # get the these properties from the config options
+        super().setup()
+        config = self.config
+        self.cell_width = config.getfloat('global_ocean', 'qu_resolution')

--- a/compass/ocean/tests/global_ocean/mesh/qu/dynamic_adjustment/__init__.py
+++ b/compass/ocean/tests/global_ocean/mesh/qu/dynamic_adjustment/__init__.py
@@ -1,0 +1,92 @@
+from compass.ocean.tests.global_ocean.dynamic_adjustment import (
+    DynamicAdjustment,
+)
+from compass.ocean.tests.global_ocean.forward import ForwardStep
+
+
+class QUDynamicAdjustment(DynamicAdjustment):
+    """
+    A test case performing dynamic adjustment (dissipating fast-moving waves)
+    from an initial condition on the QU240 MPAS-Ocean mesh
+    """
+
+    def __init__(self, test_group, mesh, init, time_integrator):
+        """
+        Create the test case
+
+        Parameters
+        ----------
+        test_group : compass.ocean.tests.global_ocean.GlobalOcean
+            The global ocean test group that this test case belongs to
+
+        mesh : compass.ocean.tests.global_ocean.mesh.Mesh
+            The test case that produces the mesh for this run
+
+        init : compass.ocean.tests.global_ocean.init.Init
+            The test case that produces the initial condition for this run
+
+        time_integrator : {'split_explicit', 'RK4'}
+            The time integrator to use for the forward run
+        """
+        restart_times = ['0001-01-02_00:00:00', '0001-01-03_00:00:00']
+        restart_filenames = [
+            'restarts/rst.{}.nc'.format(restart_time.replace(':', '.'))
+            for restart_time in restart_times]
+
+        super().__init__(test_group=test_group, mesh=mesh, init=init,
+                         time_integrator=time_integrator,
+                         restart_filenames=restart_filenames)
+
+        module = self.__module__
+
+        shared_options = \
+            {'config_AM_globalStats_enable': '.true.',
+             'config_AM_globalStats_compute_on_startup': '.true.',
+             'config_AM_globalStats_write_on_startup': '.true.',
+             'config_use_activeTracers_surface_restoring': '.true.'}
+
+        # first step
+        step_name = 'damped_adjustment_1'
+        step = ForwardStep(test_case=self, mesh=mesh, init=init,
+                           time_integrator=time_integrator, name=step_name,
+                           subdir=step_name, get_dt_from_min_res=True)
+
+        namelist_options = {
+            'config_run_duration': "'00-00-01_00:00:00'",
+            'config_implicit_bottom_drag_type': "'constant_and_rayleigh'",
+            'config_Rayleigh_damping_coeff': '1.0e-4'}
+        namelist_options.update(shared_options)
+        step.add_namelist_options(namelist_options)
+
+        stream_replacements = {
+            'output_interval': '00-00-01_00:00:00',
+            'restart_interval': '00-00-01_00:00:00'}
+        step.add_streams_file(module, 'streams.template',
+                              template_replacements=stream_replacements)
+
+        step.add_output_file(filename='../{}'.format(restart_filenames[0]))
+        self.add_step(step)
+
+        # final step
+        step_name = 'simulation'
+        step = ForwardStep(test_case=self, mesh=mesh, init=init,
+                           time_integrator=time_integrator, name=step_name,
+                           subdir=step_name, get_dt_from_min_res=True)
+
+        namelist_options = {
+            'config_run_duration': "'00-00-01_00:00:00'",
+            'config_do_restart': '.true.',
+            'config_start_time': "'{}'".format(restart_times[0])}
+        namelist_options.update(shared_options)
+        step.add_namelist_options(namelist_options)
+
+        stream_replacements = {
+            'output_interval': '00-00-01_00:00:00',
+            'restart_interval': '00-00-01_00:00:00'}
+        step.add_streams_file(module, 'streams.template',
+                              template_replacements=stream_replacements)
+
+        step.add_input_file(filename='../{}'.format(restart_filenames[0]))
+        step.add_output_file(filename='../{}'.format(restart_filenames[1]))
+        step.add_output_file(filename='output.nc')
+        self.add_step(step)

--- a/compass/ocean/tests/global_ocean/mesh/qu/dynamic_adjustment/streams.template
+++ b/compass/ocean/tests/global_ocean/mesh/qu/dynamic_adjustment/streams.template
@@ -1,0 +1,12 @@
+<streams>
+
+<stream name="output"
+        output_interval="{{ output_interval }}"/>
+<immutable_stream name="restart"
+                  filename_template="../restarts/rst.$Y-$M-$D_$h.$m.$s.nc"
+                  output_interval="{{ restart_interval }}"/>
+
+<stream name="globalStatsOutput"
+        output_interval="0000_00:00:01"/>
+
+</streams>

--- a/compass/ocean/tests/global_ocean/mesh/qu/icos.cfg
+++ b/compass/ocean/tests/global_ocean/mesh/qu/icos.cfg
@@ -1,0 +1,11 @@
+# options for global ocean testcases
+[global_ocean]
+
+## metadata related to the mesh
+# the prefix (e.g. QU, EC, WC, SO)
+prefix = Icos
+
+# a description of the mesh
+mesh_description = MPAS subdivided icosahedral mesh for E3SM version
+                   ${e3sm_version} at ${min_res}-km global resolution with
+                   <<<levels>>> vertical level

--- a/compass/ocean/tests/global_ocean/mesh/qu/namelist.split_explicit
+++ b/compass/ocean/tests/global_ocean/mesh/qu/namelist.split_explicit
@@ -1,0 +1,5 @@
+config_time_integrator = 'split_explicit'
+config_run_duration = '0000_06:00:00'
+config_hmix_use_ref_cell_width = .true.
+config_write_output_on_startup = .false.
+config_use_debugTracers = .true.

--- a/compass/ocean/tests/global_ocean/mesh/qu/qu.cfg
+++ b/compass/ocean/tests/global_ocean/mesh/qu/qu.cfg
@@ -1,0 +1,49 @@
+# Options related to the vertical grid
+[vertical_grid]
+
+# the type of vertical grid
+grid_type = index_tanh_dz
+
+# Number of vertical levels
+vert_levels = 64
+
+# Depth of the bottom of the ocean
+bottom_depth = 5500.0
+
+# The minimum layer thickness
+min_layer_thickness = 10.0
+
+# The maximum layer thickness
+max_layer_thickness = 250.0
+
+# The characteristic number of levels over which the transition between
+# the min and max occurs
+transition_levels = 28
+
+
+# options for global ocean testcases
+[global_ocean]
+
+## metadata related to the mesh
+# the prefix (e.g. QU, EC, WC, SO)
+prefix = QU
+
+# a description of the mesh
+mesh_description = MPAS quasi-uniform mesh for E3SM version ${e3sm_version} at
+                   ${min_res}-km global resolution with <<<levels>>> vertical
+                   level
+
+# E3SM version that the mesh is intended for
+e3sm_version = 3
+# The revision number of the mesh, which should be incremented each time the
+# mesh is revised
+mesh_revision = <<<Missing>>>
+# the minimum (finest) resolution in the mesh
+min_res = ${qu_resolution}
+# the maximum (coarsest) resolution in the mesh, can be the same as min_res
+max_res = ${qu_resolution}
+# The URL of the pull request documenting the creation of the mesh
+pull_request = <<<Missing>>>
+
+# the resolution of the QU or Icos mesh in km
+qu_resolution = 120

--- a/docs/developers_guide/ocean/api.rst
+++ b/docs/developers_guide/ocean/api.rst
@@ -202,24 +202,22 @@ test cases and steps
    mesh.ec30to60.EC30to60BaseMesh
    mesh.ec30to60.EC30to60BaseMesh.build_cell_width_lat_lon
    mesh.ec30to60.dynamic_adjustment.EC30to60DynamicAdjustment
-   mesh.ec30to60.dynamic_adjustment.EC30to60DynamicAdjustment.configure
-   mesh.ec30to60.dynamic_adjustment.EC30to60DynamicAdjustment.run
+
+   mesh.qu.IcosMeshFromConfigStep
+   mesh.qu.IcosMeshFromConfigStep.setup
+   mesh.qu.QUMeshFromConfigStep
+   mesh.qu.QUMeshFromConfigStep.setup
+   mesh.qu.dynamic_adjustment.QUDynamicAdjustment
 
    mesh.qu240.dynamic_adjustment.QU240DynamicAdjustment
-   mesh.qu240.dynamic_adjustment.QU240DynamicAdjustment.configure
-   mesh.qu240.dynamic_adjustment.QU240DynamicAdjustment.run
 
    mesh.so12to60.SO12to60BaseMesh
    mesh.so12to60.SO12to60BaseMesh.build_cell_width_lat_lon
    mesh.so12to60.dynamic_adjustment.SO12to60DynamicAdjustment
-   mesh.so12to60.dynamic_adjustment.SO12to60DynamicAdjustment.configure
-   mesh.so12to60.dynamic_adjustment.SO12to60DynamicAdjustment.run
 
    mesh.wc14.WC14BaseMesh
    mesh.wc14.WC14BaseMesh.build_cell_width_lat_lon
    mesh.wc14.dynamic_adjustment.WC14DynamicAdjustment
-   mesh.wc14.dynamic_adjustment.WC14DynamicAdjustment.configure
-   mesh.wc14.dynamic_adjustment.WC14DynamicAdjustment.run
 
    performance_test.PerformanceTest
    performance_test.PerformanceTest.configure

--- a/docs/developers_guide/ocean/test_groups/global_ocean.rst
+++ b/docs/developers_guide/ocean/test_groups/global_ocean.rst
@@ -406,6 +406,102 @@ using the :py:class:`compass.mesh.IcosahedralMeshStep` class. The
 ice shelves in the ocean domain. Aside from the base mesh, these are identical
 to :ref:`dev_ocean_global_ocean_qu240`.
 
+.. _dev_ocean_global_ocean_qu_icos:
+
+QU, QUwISC, Icos and IcoswISC
++++++++++++++++++++++++++++++
+
+The generalized ``QU`` and ``Icos`` meshes are quasi-uniform meshes with
+user-defined resolutions (120 km by default). The ``QUwISC`` and ``IcoswISC``
+meshes are identical except that they include the cavities below ice shelves in
+the ocean domain. The classes
+:py:class:`compass.ocean.tests.global_ocean.mesh.qu.QUMeshFromConfigStep` and
+:py:class:`compass.ocean.tests.global_ocean.mesh.qu.IcosMeshFromConfigStep`
+create the ``QU`` and ``Icos`` base meshes, respectively (with or without
+ice-shelf cavities). The ``compass.ocean.tests.global_ocean.mesh.qu``
+module includes config and namelist options appropriate for initialization and
+forward simulations with split-explicit (but not RK4) time integration on these
+meshes.  The number of target and minimum number of MPI tasks, and also the
+baroclinic and barotropic time steps are set algorithmically based on the
+number of cells in the mesh and its resolution.
+
+The default config options for these meshes are:
+
+.. code-block:: cfg
+
+    # Options related to the vertical grid
+    [vertical_grid]
+
+    # the type of vertical grid
+    grid_type = index_tanh_dz
+
+    # Number of vertical levels
+    vert_levels = 64
+
+    # Depth of the bottom of the ocean
+    bottom_depth = 5500.0
+
+    # The minimum layer thickness
+    min_layer_thickness = 10.0
+
+    # The maximum layer thickness
+    max_layer_thickness = 250.0
+
+    # The characteristic number of levels over which the transition between
+    # the min and max occurs
+    transition_levels = 28
+
+
+    # options for global ocean testcases
+    [global_ocean]
+
+    ## metadata related to the mesh
+    # the prefix (e.g. QU, EC, WC, SO)
+    prefix = QU
+
+    # a description of the mesh
+    mesh_description = MPAS quasi-uniform mesh for E3SM version ${e3sm_version} at
+                       ${min_res}-km global resolution with <<<levels>>> vertical
+                       level
+
+    # E3SM version that the mesh is intended for
+    e3sm_version = 3
+    # The revision number of the mesh, which should be incremented each time the
+    # mesh is revised
+    mesh_revision = <<<Missing>>>
+    # the minimum (finest) resolution in the mesh
+    min_res = ${qu_resolution}
+    # the maximum (coarsest) resolution in the mesh, can be the same as min_res
+    max_res = ${qu_resolution}
+    # The URL of the pull request documenting the creation of the mesh
+    pull_request = <<<Missing>>>
+
+    # the resolution of the QU or Icos mesh in km
+    qu_resolution = 120
+
+The Icos and IcoswISC meshes have these config options that replace the
+corresponding QU config options above:
+
+.. code-block:: cfg
+
+    # options for global ocean testcases
+    [global_ocean]
+
+    ## metadata related to the mesh
+    # the prefix (e.g. QU, EC, WC, SO)
+    prefix = Icos
+
+    # a description of the mesh
+    mesh_description = MPAS subdivided icosahedral mesh for E3SM version
+                       ${e3sm_version} at ${min_res}-km global resolution with
+                       <<<levels>>> vertical level
+
+The vertical grid is an ``index_tanh_dz`` profile (see
+:ref:`dev_ocean_framework_vertical`) with 64 vertical levels ranging in
+thickness from 10 to 250 m.
+
+The resolution of the mesh is controlled by ``qu_resolution``.
+
 .. _dev_ocean_global_ocean_ec30to60:
 
 EC30to60 and ECwISC30to60

--- a/docs/users_guide/ocean/test_groups/global_ocean.rst
+++ b/docs/users_guide/ocean/test_groups/global_ocean.rst
@@ -281,11 +281,13 @@ The final mesh has resolution focused in the Southern Ocean around Antarctica.
 
 .. _global_ocean_mesh_qu240:
 
-QU240
-^^^^^
+QU240 and Icos240
+^^^^^^^^^^^^^^^^^
 
 The quasi-uniform 240-km (QU240) mesh, is a global mesh with approximately
-240-km horizontal resolution everywhere (as the name implies).
+240-km horizontal resolution everywhere (as the name implies).  The
+Icos240 mesh is similar but based on a subdivided icosahedron, and thus has
+grid cells that are more regular in size and shape.
 :ref:`global_ocean_ice_shelf_cavities` around Antarctica are excluded from the
 mesh.  This mesh is used as part of the :ref:`ocean_suite_nightly` to perform
 regression and performance testing in a coarse but realistic model
@@ -294,11 +296,12 @@ configuration.  This mesh is also being used in studies of
 
 .. _global_ocean_mesh_quwisc240:
 
-QUwISC240
-^^^^^^^^^
+QUwISC240 and IcoswISC240
+^^^^^^^^^^^^^^^^^^^^^^^^^
 
-The quasi-uniform 240-km mesh with ice-shelf cavities (QUwISC240) is nearly
-identical to the :ref:`global_ocean_mesh_qu240` except that it includes the
+The quasi-uniform 240-km mesh with ice-shelf cavities (QUwISC240) and the
+corresponding icosahedral mesh (IcoswISC240) are nearly identical to the
+:ref:`global_ocean_mesh_qu240` meshes except that they include the
 :ref:`global_ocean_ice_shelf_cavities` around Antarctica in the ocean domain.
 
 MPAS-Ocean's treatment of ice-shelf cavities requires and iterative adjustment
@@ -309,6 +312,33 @@ less efficient for regression and performance testing than QU240.  However,
 it is useful for low-resolution testing that exercises compass and MPAS-Ocean
 functionality related to ice-shelf cavities and sub-ice-shelf freshwater
 fluxes.
+
+.. _global_ocean_mesh_qu_icos:
+
+QU, Icos, QUwISC and IcoswISC
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The quasi-uniform (QU) and icosahedral (Icos) general meshes are global meshes
+with approximately constant horizontal resolution everywhere.  As with all
+global ocean meshes, if ``wISC`` is in the mesh name,
+:ref:`global_ocean_ice_shelf_cavities` around Antarctica are included,
+otherwise they are excluded. The resolution of the mesh is determined by a user
+config file, with a default of 120 km (very low resolution).  In addition to
+config options related to the vertical grid and metadata, the only important
+config option for these meshes is:
+
+.. code-block:: cfg
+
+    # options for global ocean testcases
+    [global_ocean]
+
+    # the resolution of the QU or Icos mesh in km
+    qu_resolution = 120
+
+You can specify ``qu_resolution`` by placing it in a user config file and
+modify it before setting up test cases with the QU mesh.  You could also
+modify the config option in *each* test case after setting them up but this
+is typically too tedious to be practical.
 
 .. _global_ocean_mesh_ec30to60:
 


### PR DESCRIPTION
<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->
A user can set the resolution at setup or runtime with the `qu_resolution` config option in the `global_ocean` section.

<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [x] User's Guide has been updated
* [x] Developer's Guide has been updated
* [x] API documentation in the Developer's Guide (`api.rst`) has any new or modified class, method and/or functions listed
* [x] Documentation has been [built locally](https://mpas-dev.github.io/compass/latest/developers_guide/building_docs.html) and changes look as expected
* [x] Document (in a comment titled `Testing` in this PR) any testing that was used to verify the changes

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->
