### PR TITLE
Remove unused namelist option

### DIFF
--- a/compass/ocean/tests/global_ocean/init/initial_state.py
+++ b/compass/ocean/tests/global_ocean/init/initial_state.py
@@ -82,8 +82,7 @@ class InitialState(Step):
 
         if 'remap_topography' in self.mesh.steps:
             options = {
-                'config_global_ocean_topography_source': "'mpas_variable'",
-                'config_global_ocean_land_ice_topo_source': "'mpas_variable'"
+                'config_global_ocean_topography_source': "'mpas_variable'"
             }
             self.add_namelist_options(options, mode='init')
             self.add_streams_file(package, 'streams.topo', mode='init')


### PR DESCRIPTION
The namelist option `config_global_ocean_land_ice_topo_source` doesn't exist.  Instead, `config_global_ocean_topography_source` is used both for bathymetry and land-ice topography.

This seems to have got missed in #566.

<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->

<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [ ] Document (in a comment titled `Testing` in this PR) any testing that was used to verify the changes

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->
