### PR TITLE
Add monthly output tests for all meshes

### DIFF
--- a/compass/ocean/tests/global_ocean/__init__.py
+++ b/compass/ocean/tests/global_ocean/__init__.py
@@ -50,6 +50,7 @@ class GlobalOcean(TestGroup):
         self._add_tests(mesh_names=['QU240', 'Icos240', 'QUwISC240'],
                         DynamicAdjustment=QU240DynamicAdjustment,
                         remap_topography=False,
+                        include_monthly=True,
                         include_rk4=True,
                         include_regression=True,
                         include_phc=True,
@@ -80,9 +81,9 @@ class GlobalOcean(TestGroup):
         self.add_test_case(FilesForE3SM(test_group=self))
 
     def _add_tests(self, mesh_names, DynamicAdjustment, remap_topography=True,
-                   include_rk4=False, include_regression=False,
-                   include_phc=False, include_en4_1900=False,
-                   include_bgc=False):
+                   include_monthly=True, include_rk4=False,
+                   include_regression=False, include_phc=False,
+                   include_en4_1900=False, include_bgc=False):
         """ Add test cases for the given mesh(es) """
 
         default_ic = 'WOA23'
@@ -124,6 +125,7 @@ class GlobalOcean(TestGroup):
                     DailyOutputTest(
                         test_group=self, mesh=mesh_test, init=init_test,
                         time_integrator=time_integrator))
+            if include_monthly:
                 self.add_test_case(
                     MonthlyOutputTest(
                         test_group=self, mesh=mesh_test, init=init_test,

--- a/compass/ocean/tests/global_ocean/monthly_output_test/__init__.py
+++ b/compass/ocean/tests/global_ocean/monthly_output_test/__init__.py
@@ -1,6 +1,8 @@
+from compass.ocean.tests.global_ocean.forward import (
+    ForwardStep,
+    ForwardTestCase,
+)
 from compass.validate import compare_variables
-from compass.ocean.tests.global_ocean.forward import ForwardTestCase, \
-    ForwardStep
 
 
 class MonthlyOutputTest(ForwardTestCase):
@@ -32,8 +34,7 @@ class MonthlyOutputTest(ForwardTestCase):
                          name='monthly_output_test')
 
         step = ForwardStep(test_case=self, mesh=mesh, init=init,
-                           time_integrator=time_integrator, ntasks=4,
-                           openmp_threads=1)
+                           time_integrator=time_integrator)
 
         module = self.__module__
         step.add_output_file(filename='output.nc')

--- a/compass/ocean/tests/global_ocean/monthly_output_test/namelist.forward
+++ b/compass/ocean/tests/global_ocean/monthly_output_test/namelist.forward
@@ -1,3 +1,7 @@
 config_run_duration = '0000-01-00_00:00:00'
 config_AM_timeSeriesStatsMonthly_enable = .true.
 config_AM_timeSeriesStatsMonthly_restart_stream = 'none'
+config_AM_globalStats_enable = .true.
+config_AM_globalStats_compute_on_startup = .true.
+config_AM_globalStats_write_on_startup = .true.
+config_use_activeTracers_surface_restoring = .true.

--- a/compass/ocean/tests/global_ocean/monthly_output_test/streams.forward
+++ b/compass/ocean/tests/global_ocean/monthly_output_test/streams.forward
@@ -8,4 +8,7 @@
         clobber_mode="truncate">
 </stream>
 
+<stream name="globalStatsOutput"
+        output_interval="0000_01:00:00"/>
+
 </streams>


### PR DESCRIPTION
<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->

We would like to run some test simulations with `timeSeriesStatsMonthlyOutput` to see how the AMOC behaves in MPAS standalone.  For this purpose, it seems useful to define a monthly output test for each mesh.  Other changes include:
* setting the number of cores based on the mesh size
* turning on surface restoring
* turning on global stats


<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [x] Document (in a comment titled `Testing` in this PR) any testing that was used to verify the changes

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->
