### PR TITLE
Always remap topogrpahy, even for low res meshes

### DIFF
--- a/compass/ocean/tests/global_ocean/__init__.py
+++ b/compass/ocean/tests/global_ocean/__init__.py
@@ -49,7 +49,7 @@ class GlobalOcean(TestGroup):
         # we do a lot of tests for QU240/QUwISC240
         self._add_tests(mesh_names=['QU240', 'Icos240', 'QUwISC240'],
                         DynamicAdjustment=QU240DynamicAdjustment,
-                        remap_topography=False,
+                        high_res_topography=False,
                         include_rk4=True,
                         include_regression=True,
                         include_phc=True,
@@ -78,9 +78,10 @@ class GlobalOcean(TestGroup):
         # A test case for making E3SM support files from an existing mesh
         self.add_test_case(FilesForE3SM(test_group=self))
 
-    def _add_tests(self, mesh_names, DynamicAdjustment, remap_topography=True,
-                   include_rk4=False, include_regression=False,
-                   include_phc=False, include_en4_1900=False):
+    def _add_tests(self, mesh_names, DynamicAdjustment,
+                   high_res_topography=True, include_rk4=False,
+                   include_regression=False, include_phc=False,
+                   include_en4_1900=False):
         """ Add test cases for the given mesh(es) """
 
         default_ic = 'WOA23'
@@ -88,7 +89,7 @@ class GlobalOcean(TestGroup):
 
         for mesh_name in mesh_names:
             mesh_test = Mesh(test_group=self, mesh_name=mesh_name,
-                             remap_topography=remap_topography)
+                             high_res_topography=high_res_topography)
             self.add_test_case(mesh_test)
 
             init_test = Init(test_group=self, mesh=mesh_test,

--- a/compass/ocean/tests/global_ocean/init/initial_state.py
+++ b/compass/ocean/tests/global_ocean/init/initial_state.py
@@ -71,24 +71,16 @@ class InitialState(Step):
         if mesh_streams in mesh_package_contents:
             self.add_streams_file(mesh_package, mesh_streams, mode='init')
 
-        if 'remap_topography' in self.mesh.steps:
-            options = {
-                'config_global_ocean_topography_source': "'mpas_variable'"
-            }
-            self.add_namelist_options(options, mode='init')
-            self.add_streams_file(package, 'streams.topo', mode='init')
+        options = {
+            'config_global_ocean_topography_source': "'mpas_variable'"
+        }
+        self.add_namelist_options(options, mode='init')
+        self.add_streams_file(package, 'streams.topo', mode='init')
 
-            cull_step = self.mesh.steps['cull_mesh']
-            target = os.path.join(cull_step.path, 'topography_culled.nc')
-            self.add_input_file(filename='topography.nc',
-                                work_dir_target=target)
-
-        else:
-            target = 'BedMachineAntarctica_v2_and_GEBCO_2022_0.05_degree_20220729.nc'  # noqa: E501
-            self.add_input_file(
-                filename='topography.nc',
-                target=target,
-                database='bathymetry_database')
+        cull_step = self.mesh.steps['cull_mesh']
+        target = os.path.join(cull_step.path, 'topography_culled.nc')
+        self.add_input_file(filename='topography.nc',
+                            work_dir_target=target)
 
         self.add_input_file(
             filename='wind_stress.nc',


### PR DESCRIPTION
We use an older, lower resolution data set for the QU240 meshes.

This work is a preliminary step that will allow us to move toward initializing the global ocean in python, rather than Fortran.  

<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->

<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [x] Document (in a comment titled `Testing` in this PR) any testing that was used to verify the changes

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->
