### PR TITLE
Renormalize topography after remapping in `global_ocean`

### DIFF
--- a/compass/ocean/mesh/remap_topography.cfg
+++ b/compass/ocean/mesh/remap_topography.cfg
@@ -24,3 +24,7 @@ min_tasks = 360
 
 # remapping method {'bilinear', 'neareststod', 'conserve'}
 method = conserve
+
+# threshold of what fraction of an MPAS cell must contain ocean in order to
+# perform renormalization of elevation variables
+renorm_threshold = 0.01

--- a/compass/ocean/tests/global_ocean/init/namelist.init
+++ b/compass/ocean/tests/global_ocean/init/namelist.init
@@ -53,5 +53,4 @@ config_global_ocean_depth_conversion_factor = 1.0
 config_global_ocean_minimum_depth = 10
 config_global_ocean_deepen_critical_passages = .false.
 config_block_decomp_file_prefix = 'graph.info.part.'
-config_global_ocean_topography_smooth_iterations = 6
-config_global_ocean_topography_smooth_weight = 0.9
+config_global_ocean_topography_smooth_iterations = 0


### PR DESCRIPTION
<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->
A bug in #566 left the remapped topography multiplied by the remapped ocean mask.  This means that the topography falls back to zero at coastlines and grounding lines under ice shelves.  This merge fixes that issue by renormalizing topography as long as the remapped ocean mask is over a given threshold (0.01 by default).

This merge also turns off smoothing of topography in `global_ocean` init mode because it should no longer be needed with the conservative remapping approach.
<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [x] Document (in a comment titled `Testing` in this PR) any testing that was used to verify the changes

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->
