### PR TITLE
Bound graph partition sizes

### DIFF
--- a/compass/ocean/tests/global_ocean/files_for_e3sm/graph_partition.py
+++ b/compass/ocean/tests/global_ocean/files_for_e3sm/graph_partition.py
@@ -53,7 +53,8 @@ def get_core_list(ncells, max_cells_per_core=30000, min_cells_per_core=2):
     for node_size in node_sizes:
         for node_count in range(1, max_nodes + 1):
             core_count = node_size * node_count
-            cores.add(core_count)
+            if min_graph_size <= core_count <= max_graph_size:
+                cores.add(core_count)
 
     # add even node counts if they are close to some especially desirable
     # core counts for the ne30 atmosphere mesh (also used for MPAS-Seaice)
@@ -61,8 +62,8 @@ def get_core_list(ncells, max_cells_per_core=30000, min_cells_per_core=2):
         for node_count in range(1, max_nodes_approx + 1):
             core_count = node_size * node_count
             for approx in special_approx_cores:
-                lower = approx - 2 * node_size
-                upper = approx + 2 * node_size
+                lower = max(approx - 2 * node_size, min_graph_size)
+                upper = min(approx + 2 * node_size, max_graph_size)
                 if lower <= core_count <= upper:
                     cores.add(core_count)
 


### PR DESCRIPTION
The algorithm for computing graph partition sizes was previously producing partitions that were larger than the number of cells in the mesh.  With this fix, there will not be fewer than about 2 cells per task.

<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->

<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [x] Document (in a comment titled `Testing` in this PR) any testing that was used to verify the changes

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->
