### PR TITLE
For smaller meshes, create partitions for a single task

### DIFF
--- a/compass/ocean/tests/global_ocean/files_for_e3sm/graph_partition.py
+++ b/compass/ocean/tests/global_ocean/files_for_e3sm/graph_partition.py
@@ -36,6 +36,9 @@ def get_core_list(ncells, max_cells_per_core=30000, min_cells_per_core=2):
     special_approx_cores = [675, 1350, 2700, 5400]
 
     cores = set()
+    if ncells < max_cells_per_core:
+        cores.add(1)
+
     for candidate in range(min_graph_size, max_graph_size):
         factors = _prime_factors(candidate)
         twos = np.count_nonzero(factors == 2)

--- a/compass/ocean/tests/global_ocean/files_for_e3sm/ocean_graph_partition.py
+++ b/compass/ocean/tests/global_ocean/files_for_e3sm/ocean_graph_partition.py
@@ -73,8 +73,14 @@ class OceanGraphPartition(FilesForE3SMStep):
         logger.info(f'Creating graph files between {np.amin(cores)} and '
                     f'{np.amax(cores)}')
         for ncores in cores:
-            args = ['gpmetis', f'mpas-o.graph.info.{creation_date}',
-                    f'{ncores}']
+            if ncores > ncells:
+                raise ValueError('Can\t have more tasks than cells in a '
+                                 'partition file.')
+            if ncores == 1:
+                args = ['touch', f'mpas-o.graph.info.{creation_date}.part.1']
+            else:
+                args = ['gpmetis', f'mpas-o.graph.info.{creation_date}',
+                        f'{ncores}']
             check_call(args, logger)
 
         # create link in assembled files directory

--- a/compass/ocean/tests/global_ocean/files_for_e3sm/seaice_graph_partition.py
+++ b/compass/ocean/tests/global_ocean/files_for_e3sm/seaice_graph_partition.py
@@ -80,6 +80,10 @@ class SeaiceGraphPartition(FilesForE3SMStep):
         logger.info(f'Creating graph files between {np.amin(cores)} and '
                     f'{np.amax(cores)}')
 
+        if 1 in cores:
+            args = ['touch', f'mpas-seaice.graph.info.{creation_date}.part.1']
+            check_call(args, logger)
+
         mapping_filename = _make_mapping_file(
             in_mesh_filename='seaice_QU60km_polar.nc',
             in_mesh_name='QU60km',
@@ -107,7 +111,14 @@ class SeaiceGraphPartition(FilesForE3SMStep):
 
         if plotting:
             args.append('--plotting')
-        args = args + [f'{ncores}' for ncores in cores]
+
+        for ncores in cores:
+            if ncores > ncells:
+                raise ValueError('Can\t have more tasks than cells in a '
+                                 'partition file.')
+            if ncores > 1:
+                args.append(f'{ncores}')
+
         check_call(args, logger)
 
         # create link in assembled files directory


### PR DESCRIPTION
This applies to meshes with fewer than 30,000 cells.  Although MPAS components run in standalone don't require partition files for a single core, E3SM does need them.

<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->

<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [x] Document (in a comment titled `Testing` in this PR) any testing that was used to verify the changes

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->
