### PR TITLE
Add a test for log-law ocean bottom drag

### DIFF
--- a/compass/ocean/tests/drying_slope/__init__.py
+++ b/compass/ocean/tests/drying_slope/__init__.py
@@ -1,4 +1,5 @@
 from compass.ocean.tests.drying_slope.default import Default
+from compass.ocean.tests.drying_slope.loglaw import LogLaw
 from compass.ocean.tests.drying_slope.ramp import Ramp
 from compass.testgroup import TestGroup
 
@@ -23,3 +24,6 @@ class DryingSlope(TestGroup):
                 self.add_test_case(
                     Ramp(test_group=self, resolution=resolution,
                          coord_type=coord_type))
+                self.add_test_case(
+                    LogLaw(test_group=self, resolution=resolution,
+                           coord_type=coord_type))

--- a/compass/ocean/tests/drying_slope/namelist.single_layer.forward
+++ b/compass/ocean/tests/drying_slope/namelist.single_layer.forward
@@ -1,9 +1,8 @@
-config_bottom_drag_mode = 'explicit'
-config_explicit_bottom_drag_coeff = 3.0e-3
+config_bottom_drag_mode = 'implicit'
+config_implicit_constant_bottom_drag_coeff = 3.0e-3
 config_disable_thick_vadv = .true.
 config_disable_thick_sflux = .true.
 config_disable_vel_hmix = .true.
-config_disable_vel_vmix = .true.
 config_disable_vel_vadv = .true.
 config_disable_tr_all_tend = .true.
 config_pressure_gradient_type = 'ssh_gradient'

--- a/docs/developers_guide/ocean/api.rst
+++ b/docs/developers_guide/ocean/api.rst
@@ -89,12 +89,21 @@ drying_slope
 
    default.Default
    default.Default.configure
+   default.Default.validate
 
    forward.Forward
    forward.Forward.run
 
    initial_state.InitialState
    initial_state.InitialState.run
+
+   loglaw.LogLaw
+   loglaw.LogLaw.configure
+   loglaw.LogLaw.validate
+
+   ramp.Ramp
+   ramp.Ramp.configure
+   ramp.Ramp.validate
 
    viz.Viz
    viz.Viz.run

--- a/docs/developers_guide/ocean/test_groups/drying_slope.rst
+++ b/docs/developers_guide/ocean/test_groups/drying_slope.rst
@@ -79,7 +79,7 @@ test performs two 12-hour runs on 4 cores. It doesn't contain any
 types are supported. For ``sigma`` coordinates, this case is hard-coded to run
 two cases at different values of ``config_Rayleigh_damping_coeff``, 0.0025 and
 0.01, for which there is comparison data. The ``single_layer`` case runs at one
-value of the explicit bottom drag coefficient. 
+value of the implicit bottom drag coefficient. 
 
 
 .. _dev_ocean_drying_slope_ramp:
@@ -90,3 +90,12 @@ ramp
 The :py:class:`compass.ocean.tests.drying_slope.ramp.Ramp` is identical to the
 default class except it sets ``ramp`` to ``True`` for the forward step to enable
 the ramp feature for wetting and drying.
+
+
+.. _dev_ocean_drying_slope_log_law:
+
+loglaw
+------
+
+The :py:class:`compass.ocean.tests.drying_slope.loglaw.LogLaw` is identical to the
+default class except it uses the log-law implicit drag option.

--- a/docs/users_guide/ocean/test_groups/drying_slope.rst
+++ b/docs/users_guide/ocean/test_groups/drying_slope.rst
@@ -84,7 +84,9 @@ default
 ``ocean/drying_slope/${RES}/${COORD}/default`` is the default version of the
 drying slope test case for two short (12h) test runs with two different drag
 coefficients and validation of sea surface height through visual inspection
-against analytic and ROMS solutions. ``RES`` is either 250m or 1km. ``COORD`` is either ``single_layer`` or ``sigma``.
+against analytic and ROMS solutions. ``RES`` is either 250m or 1km. ``COORD``
+is either ``single_layer`` or ``sigma``. Rayleigh drag is not compatible with
+``single_layer`` so implicit drag with a constant coefficient is used.
 
 ramp
 ----
@@ -94,3 +96,10 @@ test except the factor that scales velocities and velocity tendencies is
 ramped over a given layer thickness range rather than a binary switch at the
 minimum thickness. ``RES`` is either 250m or 1km. ``COORD`` is either
 ``single_layer`` or ``sigma``.
+
+loglaw
+------
+
+``ocean/drying_slope/${RES}/${COORD}/loglaw`` is identical to the ``default``
+test except that the log-law option for implicit bottom drag is used. ``RES``
+is either 250m or 1km. ``COORD`` is either ``single_layer`` or ``sigma``.


### PR DESCRIPTION
This PR adds 4 ocean `drying_slope` tests (2 resolutions and 2 vertical coordinates) which exercise the log-law version of implicit bottom drag. This bottom drag option is introduced by https://github.com/E3SM-Project/E3SM/pull/5734.

Checklist
* [X] User's Guide has been updated
* [X] Developer's Guide has been updated
* [X] Documentation has been [built locally](https://mpas-dev.github.io/compass/latest/developers_guide/building_docs.html) and changes look as expected
* [x] The `E3SM-Project` submodule has been updated with relevant E3SM changes
* [X] Document (in a comment titled `Testing` in this PR) any testing that was used to verify the changes
* [X] New tests have been added to a test suite