### PR TITLE
Switch to python masking for culling landice meshes

### DIFF
--- a/compass/landice/mesh.py
+++ b/compass/landice/mesh.py
@@ -554,7 +554,8 @@ def build_cell_width(self, section_name, gridded_dataset,
 
 def build_mali_mesh(self, cell_width, x1, y1, geom_points,
                     geom_edges, mesh_name, section_name,
-                    gridded_dataset, projection, geojson_file=None):
+                    gridded_dataset, projection, geojson_file=None,
+                    cores=1):
     """
     Create the MALI mesh based on final cell widths determined by
     :py:func:`compass.landice.mesh.build_cell_width()`, using Jigsaw and
@@ -603,8 +604,11 @@ def build_mali_mesh(self, cell_width, x1, y1, geom_points,
         Projection to be used for setting lat-long fields.
         Likely ``'gis-gimp'`` or ``'ais-bedmap2'``
 
-    geojson_file : str
+    geojson_file : str, optional
         Name of geojson file that defines regional domain extent.
+
+    cores : int, optional
+        The number of cores to use for mask creation
     """
 
     logger = self.logger
@@ -653,8 +657,13 @@ def build_mali_mesh(self, cell_width, x1, y1, geom_points,
 
         check_call(args, logger=logger)
 
-        args = ['MpasMaskCreator.x', 'grid_preCull.nc',
-                'mask.nc', '-f', geojson_file]
+        args = ['compute_mpas_region_masks',
+                '-m', 'grid_preCull.nc',
+                '-o', 'mask.nc',
+                '-g', geojson_file,
+                '--process_count', f'{cores}',
+                '--format', mpas_tools.io.default_format,
+                '--engine', mpas_tools.io.default_engine]
 
         check_call(args, logger=logger)
 

--- a/compass/landice/tests/antarctica/mesh.py
+++ b/compass/landice/tests/antarctica/mesh.py
@@ -31,7 +31,7 @@ class Mesh(Step):
             The test case this step belongs to
 
         """
-        super().__init__(test_case=test_case, name='mesh', cpus_per_task=64,
+        super().__init__(test_case=test_case, name='mesh', cpus_per_task=128,
                          min_cpus_per_task=1)
 
         self.mesh_filename = 'Antarctica.nc'

--- a/compass/landice/tests/antarctica/mesh_gen/__init__.py
+++ b/compass/landice/tests/antarctica/mesh_gen/__init__.py
@@ -1,5 +1,6 @@
 from compass.landice.tests.antarctica.mesh import Mesh
 from compass.testcase import TestCase
+from compass.validate import compare_variables
 
 
 class MeshGen(TestCase):
@@ -24,3 +25,13 @@ class MeshGen(TestCase):
 
         self.add_step(
             Mesh(test_case=self))
+
+    def validate(self):
+        """
+        Compare ``thickness``, ``bedTopography``, ``iceMask`` and
+        ``beta`` with a baseline if one was provided.
+        """
+        variables = ['thickness', 'bedTopography', 'iceMask',
+                     'beta']
+        compare_variables(test_case=self, variables=variables,
+                          filename1='mesh/Antarctica.nc')

--- a/compass/landice/tests/antarctica/mesh_gen/__init__.py
+++ b/compass/landice/tests/antarctica/mesh_gen/__init__.py
@@ -1,12 +1,11 @@
-from compass.testcase import TestCase
 from compass.landice.tests.antarctica.mesh import Mesh
+from compass.testcase import TestCase
 
 
 class MeshGen(TestCase):
     """
     The default test case for the Antarctica test group simply creates the
     mesh and initial condition.
-
     """
 
     def __init__(self, test_group):
@@ -17,7 +16,6 @@ class MeshGen(TestCase):
         ----------
         test_group : compass.landice.tests.antarctica.Antarctica
             The test group that this test case belongs to
-
         """
         name = 'mesh_gen'
         subdir = name

--- a/compass/landice/tests/greenland/mesh.py
+++ b/compass/landice/tests/greenland/mesh.py
@@ -28,7 +28,8 @@ class Mesh(Step):
         mesh_type : str
             The resolution or mesh type of the test case
         """
-        super().__init__(test_case=test_case, name='mesh')
+        super().__init__(test_case=test_case, name='mesh', cpus_per_task=128,
+                         min_cpus_per_task=1)
 
         self.add_output_file(filename='graph.info')
         self.add_output_file(filename='GIS.nc')

--- a/compass/landice/tests/greenland/mesh_gen/__init__.py
+++ b/compass/landice/tests/greenland/mesh_gen/__init__.py
@@ -1,5 +1,6 @@
 from compass.landice.tests.greenland.mesh import Mesh
 from compass.testcase import TestCase
+from compass.validate import compare_variables
 
 
 class MeshGen(TestCase):
@@ -26,3 +27,13 @@ class MeshGen(TestCase):
 
         self.add_step(
             Mesh(test_case=self))
+
+    def validate(self):
+        """
+        Compare ``thickness``, ``bedTopography``, ``iceMask`` and
+        ``beta`` with a baseline if one was provided.
+        """
+        variables = ['thickness', 'bedTopography', 'iceMask',
+                     'beta']
+        compare_variables(test_case=self, variables=variables,
+                          filename1='mesh/GIS.nc')

--- a/compass/landice/tests/greenland/mesh_gen/__init__.py
+++ b/compass/landice/tests/greenland/mesh_gen/__init__.py
@@ -13,6 +13,7 @@ class MeshGen(TestCase):
     def __init__(self, test_group):
         """
         Create the test case
+
         Parameters
         ----------
         test_group : compass.landice.tests.greenland.Greenland

--- a/compass/landice/tests/humboldt/mesh.py
+++ b/compass/landice/tests/humboldt/mesh.py
@@ -24,7 +24,8 @@ class Mesh(Step):
         mesh_type : str
             The resolution or mesh type of the test case
         """
-        super().__init__(test_case=test_case, name='mesh')
+        super().__init__(test_case=test_case, name='mesh', cpus_per_task=128,
+                         min_cpus_per_task=1)
 
         self.add_output_file(filename='graph.info')
         self.add_output_file(filename='Humboldt.nc')
@@ -60,7 +61,8 @@ class Mesh(Step):
             self, cell_width, x1, y1, geom_points, geom_edges,
             mesh_name=mesh_name, section_name=section_name,
             gridded_dataset='humboldt_1km_2020_04_20.epsg3413.icesheetonly.nc',
-            projection='gis-gimp', geojson_file='Humboldt.geojson')
+            projection='gis-gimp', geojson_file='Humboldt.geojson',
+            cores=self.cpus_per_task)
 
         logger.info('creating graph.info')
         make_graph_file(mesh_filename=mesh_name,

--- a/compass/landice/tests/humboldt/mesh_gen/__init__.py
+++ b/compass/landice/tests/humboldt/mesh_gen/__init__.py
@@ -1,12 +1,11 @@
-from compass.testcase import TestCase
 from compass.landice.tests.humboldt.mesh import Mesh
+from compass.testcase import TestCase
 
 
 class MeshGen(TestCase):
     """
     The MeshGen test case for the humboldt test group simply creates the
     mesh and initial condition.
-
     """
 
     def __init__(self, test_group):
@@ -17,7 +16,6 @@ class MeshGen(TestCase):
         ----------
         test_group : compass.landice.tests.humboldt.Humboldt
             The test group that this test case belongs to
-
         """
         name = 'mesh_gen'
         subdir = name

--- a/compass/landice/tests/humboldt/mesh_gen/__init__.py
+++ b/compass/landice/tests/humboldt/mesh_gen/__init__.py
@@ -1,5 +1,6 @@
 from compass.landice.tests.humboldt.mesh import Mesh
 from compass.testcase import TestCase
+from compass.validate import compare_variables
 
 
 class MeshGen(TestCase):
@@ -24,3 +25,13 @@ class MeshGen(TestCase):
 
         self.add_step(
             Mesh(test_case=self))
+
+    def validate(self):
+        """
+        Compare ``thickness``, ``bedTopography``, ``iceMask`` and
+        ``beta`` with a baseline if one was provided.
+        """
+        variables = ['thickness', 'bedTopography', 'iceMask',
+                     'beta']
+        compare_variables(test_case=self, variables=variables,
+                          filename1='mesh/Humboldt.nc')

--- a/compass/landice/tests/kangerlussuaq/mesh.py
+++ b/compass/landice/tests/kangerlussuaq/mesh.py
@@ -25,7 +25,8 @@ class Mesh(Step):
         mesh_type : str
             The resolution or mesh type of the test case
         """
-        super().__init__(test_case=test_case, name='mesh')
+        super().__init__(test_case=test_case, name='mesh', cpus_per_task=128,
+                         min_cpus_per_task=1)
 
         self.add_output_file(filename='graph.info')
         self.add_output_file(filename='Kangerlussuaq.nc')
@@ -61,7 +62,8 @@ class Mesh(Step):
             self, cell_width, x1, y1, geom_points, geom_edges,
             mesh_name=mesh_name, section_name=section_name,
             gridded_dataset='greenland_1km_2020_04_20.epsg3413.icesheetonly.nc',  # noqa
-            projection='gis-gimp', geojson_file='Kangerlussuaq.geojson')
+            projection='gis-gimp', geojson_file='Kangerlussuaq.geojson',
+            cores=self.cpus_per_task)
 
         logger.info('creating graph.info')
         make_graph_file(mesh_filename=mesh_name,

--- a/compass/landice/tests/kangerlussuaq/mesh_gen/__init__.py
+++ b/compass/landice/tests/kangerlussuaq/mesh_gen/__init__.py
@@ -1,5 +1,6 @@
 from compass.landice.tests.kangerlussuaq.mesh import Mesh
 from compass.testcase import TestCase
+from compass.validate import compare_variables
 
 
 class MeshGen(TestCase):
@@ -24,3 +25,13 @@ class MeshGen(TestCase):
 
         self.add_step(
             Mesh(test_case=self))
+
+    def validate(self):
+        """
+        Compare ``thickness``, ``bedTopography``, ``iceMask`` and
+        ``beta`` with a baseline if one was provided.
+        """
+        variables = ['thickness', 'bedTopography', 'iceMask',
+                     'beta']
+        compare_variables(test_case=self, variables=variables,
+                          filename1='mesh/Kangerlussuaq.nc')

--- a/compass/landice/tests/kangerlussuaq/mesh_gen/__init__.py
+++ b/compass/landice/tests/kangerlussuaq/mesh_gen/__init__.py
@@ -1,12 +1,11 @@
-from compass.testcase import TestCase
 from compass.landice.tests.kangerlussuaq.mesh import Mesh
+from compass.testcase import TestCase
 
 
 class MeshGen(TestCase):
     """
     The default test case for the Kangerlussuaq test group simply creates the
     mesh and initial condition.
-
     """
 
     def __init__(self, test_group):
@@ -17,7 +16,6 @@ class MeshGen(TestCase):
         ----------
         test_group : compass.landice.tests.kangerlussuaq.Kangerlussuaq
             The test group that this test case belongs to
-
         """
         name = 'mesh_gen'
         subdir = name

--- a/compass/landice/tests/koge_bugt_s/mesh.py
+++ b/compass/landice/tests/koge_bugt_s/mesh.py
@@ -25,7 +25,8 @@ class Mesh(Step):
         mesh_type : str
             The resolution or mesh type of the test case
         """
-        super().__init__(test_case=test_case, name='mesh')
+        super().__init__(test_case=test_case, name='mesh', cpus_per_task=128,
+                         min_cpus_per_task=1)
 
         self.add_output_file(filename='graph.info')
         self.add_output_file(filename='Koge_Bugt_S.nc')
@@ -61,7 +62,8 @@ class Mesh(Step):
             self, cell_width, x1, y1, geom_points, geom_edges,
             mesh_name=mesh_name, section_name=section_name,
             gridded_dataset='greenland_1km_2020_04_20.epsg3413.icesheetonly.nc',  # noqa
-            projection='gis-gimp', geojson_file='Koge_Bugt_S.geojson')
+            projection='gis-gimp', geojson_file='Koge_Bugt_S.geojson',
+            cores=self.cpus_per_task)
 
         logger.info('creating graph.info')
         make_graph_file(mesh_filename=mesh_name,

--- a/compass/landice/tests/koge_bugt_s/mesh_gen/__init__.py
+++ b/compass/landice/tests/koge_bugt_s/mesh_gen/__init__.py
@@ -1,5 +1,6 @@
 from compass.landice.tests.koge_bugt_s.mesh import Mesh
 from compass.testcase import TestCase
+from compass.validate import compare_variables
 
 
 class MeshGen(TestCase):
@@ -24,3 +25,13 @@ class MeshGen(TestCase):
 
         self.add_step(
             Mesh(test_case=self))
+
+    def validate(self):
+        """
+        Compare ``thickness``, ``bedTopography``, ``iceMask`` and
+        ``beta`` with a baseline if one was provided.
+        """
+        variables = ['thickness', 'bedTopography', 'iceMask',
+                     'beta']
+        compare_variables(test_case=self, variables=variables,
+                          filename1='mesh/Koge_Bugt_S.nc')

--- a/compass/landice/tests/koge_bugt_s/mesh_gen/__init__.py
+++ b/compass/landice/tests/koge_bugt_s/mesh_gen/__init__.py
@@ -1,12 +1,11 @@
-from compass.testcase import TestCase
 from compass.landice.tests.koge_bugt_s.mesh import Mesh
+from compass.testcase import TestCase
 
 
 class MeshGen(TestCase):
     """
     The default test case for the Koge_Bugt_S test group simply creates the
     mesh and initial condition.
-
     """
 
     def __init__(self, test_group):
@@ -17,7 +16,6 @@ class MeshGen(TestCase):
         ----------
         test_group : compass.landice.tests.koge_bugt_s.KogeBugtS
             The test group that this test case belongs to
-
         """
         name = 'mesh_gen'
         subdir = name

--- a/compass/landice/tests/thwaites/mesh.py
+++ b/compass/landice/tests/thwaites/mesh.py
@@ -15,7 +15,8 @@ class Mesh(Step):
         test_case : compass.TestCase
             The test case this step belongs to
         """
-        super().__init__(test_case=test_case, name='mesh')
+        super().__init__(test_case=test_case, name='mesh', cpus_per_task=128,
+                         min_cpus_per_task=1)
 
         self.add_output_file(filename='graph.info')
         self.add_output_file(filename='Thwaites.nc')
@@ -50,7 +51,8 @@ class Mesh(Step):
             self, cell_width, x1, y1, geom_points, geom_edges,
             mesh_name=mesh_name, section_name=section_name,
             gridded_dataset='antarctica_1km_2020_10_20_ASE.nc',
-            projection='ais-bedmap2', geojson_file='thwaites_minimal.geojson')
+            projection='ais-bedmap2', geojson_file='thwaites_minimal.geojson',
+            cores=self.cpus_per_task)
 
         logger.info('creating graph.info')
         make_graph_file(mesh_filename=mesh_name,

--- a/compass/landice/tests/thwaites/mesh_gen/__init__.py
+++ b/compass/landice/tests/thwaites/mesh_gen/__init__.py
@@ -13,6 +13,7 @@ class MeshGen(TestCase):
     def __init__(self, test_group):
         """
         Create the test case
+
         Parameters
         ----------
         test_group : compass.landice.tests.thwaites.Thwaites

--- a/compass/landice/tests/thwaites/mesh_gen/__init__.py
+++ b/compass/landice/tests/thwaites/mesh_gen/__init__.py
@@ -1,5 +1,6 @@
 from compass.landice.tests.thwaites.mesh import Mesh
 from compass.testcase import TestCase
+from compass.validate import compare_variables
 
 
 class MeshGen(TestCase):
@@ -26,3 +27,13 @@ class MeshGen(TestCase):
 
         self.add_step(
             Mesh(test_case=self))
+
+    def validate(self):
+        """
+        Compare ``thickness``, ``bedTopography``, ``iceMask`` and
+        ``beta`` with a baseline if one was provided.
+        """
+        variables = ['thickness', 'bedTopography', 'iceMask',
+                     'beta']
+        compare_variables(test_case=self, variables=variables,
+                          filename1='mesh/Thwaites.nc')


### PR DESCRIPTION
<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->

Instead of using `MpasMaskCreator.x`, use the python command-line tool `compute_mpas_region_masks`.

This merge also updates several mesh creation steps to use up to 128 cores for making masks.

Finally, this merge adds validation of 4 mesh variables against a baseline for each `MeshGen` test case.  This is used to show that the results are BFB with the main branch.

<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [x] Document (in a comment titled `Testing` in this PR) any testing that was used to verify the changes

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->
