### PR TITLE
Update tolerance on circ shelf decomp test

### DIFF
--- a/compass/landice/tests/circular_shelf/decomposition_test/__init__.py
+++ b/compass/landice/tests/circular_shelf/decomposition_test/__init__.py
@@ -1,8 +1,8 @@
-from compass.validate import compare_variables
-from compass.testcase import TestCase
-from compass.landice.tests.circular_shelf.setup_mesh import SetupMesh
 from compass.landice.tests.circular_shelf.run_model import RunModel
+from compass.landice.tests.circular_shelf.setup_mesh import SetupMesh
 from compass.landice.tests.circular_shelf.visualize import Visualize
+from compass.testcase import TestCase
+from compass.validate import compare_variables
 
 
 class DecompositionTest(TestCase):
@@ -60,15 +60,15 @@ class DecompositionTest(TestCase):
         compare_variables(test_case=self, variables=['normalVelocity', ],
                           filename1='1proc_run/output.nc',
                           filename2='4proc_run/output.nc',
-                          l1_norm=1.0e-12, l2_norm=1.0e-14,
+                          l1_norm=1.0e-11, l2_norm=1.0e-13,
                           linf_norm=1.0e-15, quiet=False)
         compare_variables(test_case=self, variables=['uReconstructX', ],
                           filename1='1proc_run/output.nc',
                           filename2='4proc_run/output.nc',
-                          l1_norm=1.0e-12, l2_norm=2.0e-14,
+                          l1_norm=1.0e-11, l2_norm=1.0e-13,
                           linf_norm=1.0e-15, quiet=False)
         compare_variables(test_case=self, variables=['uReconstructY', ],
                           filename1='1proc_run/output.nc',
                           filename2='4proc_run/output.nc',
-                          l1_norm=1.0e-12, l2_norm=2.0e-14,
+                          l1_norm=1.0e-11, l2_norm=1.0e-13,
                           linf_norm=1.0e-15, quiet=False)


### PR DESCRIPTION
This is required to allow circular shelf decomposition test to pass after updating version of Albany in #641.  The differences are expected.  Closes #654 .

<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->

<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [x] Document (in a comment titled `Testing` in this PR) any testing that was used to verify the changes

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->
