### PR TITLE
Update to MPAS-Tools v0.22.0

### DIFF
--- a/conda/compass_env/spec-file.template
+++ b/conda/compass_env/spec-file.template
@@ -22,7 +22,7 @@ mache=1.16.0
 {% endif %}
 matplotlib-base
 metis
-mpas_tools=0.19.0
+mpas_tools=0.22.0
 nco
 netcdf4=*=nompi_*
 numpy

--- a/conda/recipe/meta.yaml
+++ b/conda/recipe/meta.yaml
@@ -57,7 +57,7 @@ requirements:
     - mache 1.16.0
     - matplotlib-base
     - metis
-    - mpas_tools 0.19.0
+    - mpas_tools 0.22.0
     - nco
     - netcdf4 * nompi_*
     - numpy


### PR DESCRIPTION
This brings in the NetCDF-C version of the mesh conversion tools and the capability to sort mesh indices for better performance as well as bug fixes related to widening transects and computing the MOC southern transect.

<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->

<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [x] Document (in a comment titled `Testing` in this PR) any testing that was used to verify the changes

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->
