### PR TITLE
Update conda packages for unsupported machines

### DIFF
--- a/conda/bootstrap.py
+++ b/conda/bootstrap.py
@@ -355,6 +355,12 @@ def get_env_vars(machine, compiler, mpilib):
                    f'export I_MPI_F77=ifort\n' \
                    f'export I_MPI_F90=ifort\n'
 
+    if machine.startswith('conda'):
+        # we're using parallelio so we don't have ADIOS support
+        env_vars = \
+            f'{env_vars}' \
+            f'export HAVE_ADIOS=false\n'
+
     if platform.system() == 'Linux' and machine.startswith('conda'):
         env_vars = \
             f'{env_vars}' \

--- a/conda/compass_env/spec-file.template
+++ b/conda/compass_env/spec-file.template
@@ -47,9 +47,9 @@ c-compiler
 cmake
 cxx-compiler
 fortran-compiler
-libnetcdf=4.8.1={{ mpi_prefix }}_*
+libnetcdf=4.9.2={{ mpi_prefix }}_*
 libpnetcdf=1.12.3={{ mpi_prefix }}_*
-scorpio=1.4.1={{ mpi_prefix }}_*
+parallelio=2.6.0={{ mpi_prefix }}_*
 m4
 make
 {{ mpi }}

--- a/conda/shared.py
+++ b/conda/shared.py
@@ -181,13 +181,6 @@ def install_miniconda(conda_base, activate_base, logger):
     check_call(commands, logger=logger)
 
     commands = f'{activate_base} && ' \
-               f'conda remove -y boa'
-    try:
-        check_call(commands, logger=logger)
-    except subprocess.CalledProcessError:
-        pass
-
-    commands = f'{activate_base} && ' \
                f'mamba update -y --all && ' \
                f'mamba init'
 


### PR DESCRIPTION
<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->
This merge also sets a flag to indicate that we don't have ADIOS on unsupported machines.

This merge also stops removing the `boa` conda package, which is no longer causing the issues reported in #544 

<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [x] Document (in a comment titled `Testing` in this PR) any testing that was used to verify the changes

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->

closes #664 
