### PR TITLE
New Mesh: ECwISC30to60E3r1

### DIFF
--- a/compass/ocean/mesh/remap_topography.cfg
+++ b/compass/ocean/mesh/remap_topography.cfg
@@ -2,7 +2,7 @@
 [remap_topography]
 
 # the name of the topography file in the bathymetry database
-topo_filename = BedMachineAntarctica_v3_and_GEBCO_2022_0.0125_degree_20230315.nc
+topo_filename = BedMachineAntarctica_v3_and_GEBCO_2023_0.0125_degree_20230831.nc
 
 # variable names in topo_filename
 lon_var = lon
@@ -15,7 +15,7 @@ grounded_ice_frac_var = grounded_mask
 ocean_frac_var = ocean_mask
 
 # the description to include in metadata
-description = Bathymetry is from GEBCO 2022, combined with BedMachine
+description = Bathymetry is from GEBCO 2023, combined with BedMachine
               Antarctica v3 around Antarctica.
 
 # the target and minimum number of MPI tasks to use in remapping

--- a/compass/ocean/tests/global_ocean/mesh/__init__.py
+++ b/compass/ocean/tests/global_ocean/mesh/__init__.py
@@ -172,7 +172,7 @@ class Mesh(TestCase):
         if 'remap_topography' in self.steps:
             description = config.get('remap_topography', 'description')
         else:
-            description = 'Bathymetry is from GEBCO 2022, combined with ' \
+            description = 'Bathymetry is from GEBCO 2023, combined with ' \
                           'BedMachine Antarctica v3 around Antarctica.'
 
         config.set('global_ocean', 'bathy_description', description)

--- a/compass/ocean/tests/global_ocean/mesh/ec30to60/ec30to60.cfg
+++ b/compass/ocean/tests/global_ocean/mesh/ec30to60/ec30to60.cfg
@@ -48,4 +48,4 @@ min_res = 30
 # the maximum (coarsest) resolution in the mesh, can be the same as min_res
 max_res = 60
 # The URL of the pull request documenting the creation of the mesh
-pull_request = <<<Missing>>>
+pull_request = https://github.com/MPAS-Dev/compass/pull/666

--- a/compass/ocean/tests/global_ocean/mesh/ec30to60/ec30to60.cfg
+++ b/compass/ocean/tests/global_ocean/mesh/ec30to60/ec30to60.cfg
@@ -25,7 +25,7 @@ transition_levels = 28
 [global_ocean]
 
 # Maximum allowed Haney number for configurations with ice-shelf cavities
-rx1_max = 15
+rx1_max = 10
 
 # the approximate number of cells in the mesh
 approx_cell_count = 240000

--- a/compass/ocean/tests/utility/extrap_woa/extrap_woa.cfg
+++ b/compass/ocean/tests/utility/extrap_woa/extrap_woa.cfg
@@ -3,7 +3,7 @@
 [extrap_woa]
 
 # the name of the topography file in the bathymetry database
-topo_filename = BedMachineAntarctica_v3_and_GEBCO_2022_0.0125_degree_20230315.nc
+topo_filename = BedMachineAntarctica_v3_and_GEBCO_2023_0.0125_degree_20230831.nc
 
 # the target and minimum number of MPI tasks to use in remapping
 remap_ntasks = 1024

--- a/docs/developers_guide/organization.rst
+++ b/docs/developers_guide/organization.rst
@@ -1542,12 +1542,12 @@ To add an input file from a database, call
 
     self.add_input_file(
         filename='topography.nc',
-        target='BedMachineAntarctica_v2_and_GEBCO_2022_0.05_degree_20220729.nc',
+        target='BedMachineAntarctica_v3_and_GEBCO_2023_0.0125_degree_20230831.nc',
         database='bathymetry_database')
 
 In this example from
 :py:class:`compass.ocean.tests.global_ocean.init.initial_state.InitialState()`,
-the file ``BedMachineAntarctica_v2_and_GEBCO_2022_0.05_degree_20220729.nc`` is
+the file ``BedMachineAntarctica_v3_and_GEBCO_2023_0.0125_degree_20230831.nc`` is
 slated for later downloaded from
 `MPAS-Ocean's bathymetry database <https://web.lcrc.anl.gov/public/e3sm/mpas_standalonedata/mpas-ocean/bathymetry_database/>`_.
 The file will be stored in the subdirectory ``mpas-ocean/bathymetry_database``

--- a/docs/users_guide/ocean/framework/mesh.rst
+++ b/docs/users_guide/ocean/framework/mesh.rst
@@ -24,7 +24,7 @@ controlled by the following config options:
     [remap_topography]
 
     # the name of the topography file in the bathymetry database
-    topo_filename = BedMachineAntarctica_v3_and_GEBCO_2022_0.0125_degree_20230315.nc
+    topo_filename = BedMachineAntarctica_v3_and_GEBCO_2023_0.0125_degree_20230831.nc
 
     # variable names in topo_filename
     lon_var = lon
@@ -37,7 +37,7 @@ controlled by the following config options:
     ocean_frac_var = ocean_mask
 
     # the description to include in metadata
-    description = Bathymetry is from GEBCO 2022, combined with BedMachine
+    description = Bathymetry is from GEBCO 2023, combined with BedMachine
                   Antarctica v3 around Antarctica.
 
     # the target and minimum number of MPI tasks to use in remapping


### PR DESCRIPTION
<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->

Long name: ECwISC30to60L64E3SMv3r1

As with previous versions of the mesh, this Eddy Closure (EC) mesh has:
* 30 km resolution at the equator
* 60 km resolution at mid latitudes
* 35 km resolution near the poles

Mesh, initial condition, dynamic adjustment and files for E3SM are on Chrysalis at:
```
/lcrc/group/e3sm/ac.xylar/compass_1.2/chrysalis/e3smv3-meshes/ecwisc30to60e3r1
```

<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [x] Document (in a comment titled `Testing` in this PR) any testing that was used to verify the changes

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->
