### PR TITLE
New Mesh: IcoswISC30E3r1

### DIFF
--- a/compass/ocean/tests/global_ocean/mesh/qu/qu.cfg
+++ b/compass/ocean/tests/global_ocean/mesh/qu/qu.cfg
@@ -24,6 +24,9 @@ transition_levels = 28
 # options for global ocean testcases
 [global_ocean]
 
+# Maximum allowed Haney number for configurations with ice-shelf cavities
+rx1_max = 10
+
 ## metadata related to the mesh
 # the prefix (e.g. QU, EC, WC, SO)
 prefix = QU

--- a/compass/ocean/tests/global_ocean/mesh/qu/qu.cfg
+++ b/compass/ocean/tests/global_ocean/mesh/qu/qu.cfg
@@ -37,13 +37,13 @@ mesh_description = MPAS quasi-uniform mesh for E3SM version ${e3sm_version} at
 e3sm_version = 3
 # The revision number of the mesh, which should be incremented each time the
 # mesh is revised
-mesh_revision = <<<Missing>>>
+mesh_revision = 1
 # the minimum (finest) resolution in the mesh
 min_res = ${qu_resolution}
 # the maximum (coarsest) resolution in the mesh, can be the same as min_res
 max_res = ${qu_resolution}
 # The URL of the pull request documenting the creation of the mesh
-pull_request = <<<Missing>>>
+pull_request = https://github.com/MPAS-Dev/compass/pull/667
 
 # the resolution of the QU or Icos mesh in km
 qu_resolution = 120


### PR DESCRIPTION
<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->

Long name: IcoswISC30L64E3SMv3r1

This Icosahedral (Icos) mesh is made by subdividing an icosahedron and has nearly uniform 30 km resolution.

Mesh, initial condition, dynamic adjustment and files for E3SM are on Chrysalis at:
```
/lcrc/group/e3sm/ac.xylar/compass_1.2/chrysalis/e3smv3-meshes/icoswisc30e3r1
```

<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [x] Document (in a comment titled `Testing` in this PR) any testing that was used to verify the changes

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->
