### PR TITLE
Minor changes to lts forward nmlist and streams

### DIFF
--- a/compass/ocean/tests/hurricane/lts/forward/namelist.ocean
+++ b/compass/ocean/tests/hurricane/lts/forward/namelist.ocean
@@ -1,5 +1,5 @@
 config_start_time = '2012-10-10_00:00:00'
-config_stop_time = '2012-11-10_00:00:00'
+config_stop_time = '2012-11-03_00:00:00'
 config_run_duration = 'none'
 config_dt = '72'
 config_time_integrator = 'LTS'

--- a/compass/ocean/tests/hurricane/lts/forward/streams.ocean
+++ b/compass/ocean/tests/hurricane/lts/forward/streams.ocean
@@ -57,7 +57,7 @@
 <stream name="output"
         type="output"
         filename_template="output.nc"
-        output_interval="24:00:00"
+        output_interval="12:00:00"
         precision="double"
         clobber_mode="truncate">
 
@@ -74,7 +74,7 @@
         filename_template="pointwiseStats.nc"
         type="output"
         mode="forward;analysis"
-        output_interval="24:00:00"
+        output_interval="00:30:00"
         packages="pointwiseStatsAMPKG"
         clobber_mode="truncate"
         io_type="netcdf"


### PR DESCRIPTION
Made minor changes to the streams and namelist of the hurricane lts test case.
The change to the streams is to print pointwise stats and output with the same frequency as the standard hurricane test. The change to namelist is to run for the same duration as the standard hurricane test.

<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->

<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [ ] Document (in a comment titled `Testing` in this PR) any testing that was used to verify the changes

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->
