### PR TITLE
Two fixes to data ice shelf melt fluxes

### DIFF
--- a/compass/ocean/tests/global_ocean/data_ice_shelf_melt/remap_ice_shelf_melt.py
+++ b/compass/ocean/tests/global_ocean/data_ice_shelf_melt/remap_ice_shelf_melt.py
@@ -164,7 +164,6 @@ def remap_adusumilli(in_filename, mesh_filename, mesh_name,
     melt_rate = np.where(mask, melt_rate, 0.)
     ds['x'] = (('x',), x)
     ds['y'] = (('y',), y)
-    ds['landIceFluxMask'] = (('y', 'x'), mask.astype(float))
     ds['dataLandIceFreshwaterFlux'] = (('y', 'x'),
                                        melt_rate * rho_ice / s_per_yr)
     ds['dataLandIceHeatFlux'] = (latent_heat_of_fusion *
@@ -200,6 +199,10 @@ def remap_adusumilli(in_filename, mesh_filename, mesh_name,
         # regions with land ice
         ds_remap[field] = \
             mask * ds_remap[field].where(ds_remap[field].notnull(), 0.)
+
+        # add a time dimension
+        if 'Time' not in ds_remap[field].dims:
+            ds_remap[field] = ds_remap[field].expand_dims(dim='Time', axis=0)
 
     # deal with melting beyond the land-ice mask
 

--- a/compass/ocean/tests/global_ocean/files_for_e3sm/remap_ice_shelf_melt.py
+++ b/compass/ocean/tests/global_ocean/files_for_e3sm/remap_ice_shelf_melt.py
@@ -62,10 +62,10 @@ class RemapIceShelfMelt(FilesForE3SMStep):
         """
         Run this step of the test case
         """
+        super().run()
+
         if not self.with_ice_shelf_cavities:
             return
-
-        super().run()
 
         data_ice_shelf_melt = self.data_ice_shelf_melt
 


### PR DESCRIPTION
<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->
This merge:
* adds a missing `Time` dimension to the ice shelf melt flux variables if one is not already present.
* fixes as issue where the step for remapping data ice shelf melt fluxes was being skipped in `files_for_e3sm` for existing meshes

It also removes the `landIceFluxMask` variable from the DISMF output file because this variable is not used and could cause confusion.

<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [x] Document (in a comment titled `Testing` in this PR) any testing that was used to verify the changes

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->
