### PR TITLE
Update tests to support start year of 0001

### DIFF
--- a/compass/landice/tests/enthalpy_benchmark/A/namelist.landice1
+++ b/compass/landice/tests/enthalpy_benchmark/A/namelist.landice1
@@ -1,1 +1,3 @@
+config_start_time = '0001-01-01_00:00:00'
+config_run_duration = '100000-00-00_00:00:00'
 config_dt = '25-00-00_00:00:00'

--- a/compass/landice/tests/enthalpy_benchmark/A/namelist.landice2
+++ b/compass/landice/tests/enthalpy_benchmark/A/namelist.landice2
@@ -1,5 +1,5 @@
 config_surface_air_temperature_value = 268.15
 config_do_restart = .true.
-config_start_time = '100000-01-01_00:00:00'
+config_start_time = '100001-01-01_00:00:00'
 config_run_duration = '050000-00-00_00:00:00'
 config_dt = '25-00-00_00:00:00'

--- a/compass/landice/tests/enthalpy_benchmark/A/namelist.landice3
+++ b/compass/landice/tests/enthalpy_benchmark/A/namelist.landice3
@@ -1,4 +1,4 @@
 config_do_restart = .true.
-config_start_time = '150000-01-01_00:00:00'
+config_start_time = '150001-01-01_00:00:00'
 config_run_duration = '150000-00-00_00:00:00'
 config_dt = '25-00-00_00:00:00'

--- a/compass/landice/tests/enthalpy_benchmark/namelist.landice
+++ b/compass/landice/tests/enthalpy_benchmark/namelist.landice
@@ -4,7 +4,6 @@ config_thermal_solver = 'enthalpy'
 config_max_water_fraction = 0.05
 config_surface_air_temperature_value = 243.15
 config_dt = '0010-00-00_00:00:00'
-config_run_duration = '100000-00-00_00:00:00'
 config_block_decomp_file_prefix = 'graph.info.part.'
 config_AM_globalStats_enable = .false.
 config_year_digits = 6

--- a/compass/landice/tests/hydro_radial/namelist.landice
+++ b/compass/landice/tests/hydro_radial/namelist.landice
@@ -1,5 +1,5 @@
 config_dt = '0001-00-00_00:00:00'
-config_stop_time = '0000-02-01_00:00:00'
+config_stop_time = '0001-02-01_00:00:00'
 config_block_decomp_file_prefix = 'graph.info.part.'
 config_velocity_solver = 'none'
 config_thickness_advection = 'none'

--- a/compass/landice/tests/hydro_radial/restart_test/namelist.full
+++ b/compass/landice/tests/hydro_radial/restart_test/namelist.full
@@ -1,4 +1,5 @@
-config_stop_time = '0002-01-01_00:00:00'
+config_start_time = '0001-01-01_00:00:00'
+config_stop_time = '0003-01-01_00:00:00'
 config_run_duration = 'none'
 config_write_output_on_startup = .true.
 config_do_restart = .false.

--- a/compass/landice/tests/hydro_radial/restart_test/namelist.restart
+++ b/compass/landice/tests/hydro_radial/restart_test/namelist.restart
@@ -1,4 +1,5 @@
-config_stop_time = '0001-01-01_00:00:00'
+config_start_time = '0001-01-01_00:00:00'
+config_stop_time = '0003-01-01_00:00:00'
 config_run_duration = 'none'
 config_write_output_on_startup = .true.
 config_do_restart = .false.

--- a/compass/landice/tests/hydro_radial/restart_test/namelist.restart.rst
+++ b/compass/landice/tests/hydro_radial/restart_test/namelist.restart.rst
@@ -1,4 +1,4 @@
-config_start_time = '0001-01-01_00:00:00'
-config_stop_time = '0002-01-01_00:00:00'
+config_start_time = '0002-01-01_00:00:00'
+config_stop_time = '0003-01-01_00:00:00'
 config_write_output_on_startup = .true.
 config_do_restart = .true.

--- a/compass/landice/tests/hydro_radial/spinup_test/namelist.landice
+++ b/compass/landice/tests/hydro_radial/spinup_test/namelist.landice
@@ -1,3 +1,3 @@
-config_stop_time = '10000-01-01_00:00:00'
+config_stop_time = '10001-01-01_00:00:00'
 config_year_digits = 6
 config_SGH_englacial_porosity = 0.1


### PR DESCRIPTION
<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->
MALI's Registry has been using a default `config_start_time` of '0000-01-01_00:00:00', which is not CF-compliant.  The MALI-Dev PR https://github.com/MALI-Dev/E3SM/pull/85 updates Registry to make the default `config_start_time` '0001-01-01_00:00:00'.  This PR updates the few compass tests that were assuming a start year of 0000.

<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [x] The `MALI-Dev` submodule has been updated with relevant MALI changes
* [x] Document (in a comment titled `Testing` in this PR) any testing that was used to verify the changes

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->
