### PR TITLE
Add additional ice_shelf_2d test cases

### DIFF
--- a/compass/ocean/iceshelf.py
+++ b/compass/ocean/iceshelf.py
@@ -42,7 +42,7 @@ def compute_land_ice_pressure_and_draft(ssh, modify_mask, ref_density):
 
 
 def adjust_ssh(variable, iteration_count, step, update_pio=True,
-               convert_to_cdf5=False, deltaSSH_threshold=None):
+               convert_to_cdf5=False, delta_ssh_threshold=None):
     """
     Adjust the sea surface height or land-ice pressure to be dynamically
     consistent with one another.  A series of short model runs are performed,
@@ -187,8 +187,8 @@ def adjust_ssh(variable, iteration_count, step, update_pio=True,
                 logger.info(f'     {string}')
                 log_file.write(f'{string}\n')
 
-                if deltaSSH_threshold is not None:
-                    if abs(deltaSSHMax) < deltaSSH_threshold:
+                if delta_ssh_threshold is not None:
+                    if abs(deltaSSHMax) < delta_ssh_threshold:
                         break
 
         logger.info("   - Complete\n")

--- a/compass/ocean/iceshelf.py
+++ b/compass/ocean/iceshelf.py
@@ -42,7 +42,7 @@ def compute_land_ice_pressure_and_draft(ssh, modify_mask, ref_density):
 
 
 def adjust_ssh(variable, iteration_count, step, update_pio=True,
-               convert_to_cdf5=False):
+               convert_to_cdf5=False, deltaSSH_threshold=None):
     """
     Adjust the sea surface height or land-ice pressure to be dynamically
     consistent with one another.  A series of short model runs are performed,
@@ -168,6 +168,7 @@ def adjust_ssh(variable, iteration_count, step, update_pio=True,
                 iCell = numpy.abs(deltaSSH.where(mask)).argmax().values
 
                 ds_cell = ds.isel(nCells=iCell)
+                deltaSSHMax = deltaSSH.isel(nCells=iCell).values
 
                 if on_a_sphere:
                     coords = (f'lon/lat: '
@@ -177,7 +178,7 @@ def adjust_ssh(variable, iteration_count, step, update_pio=True,
                     coords = (f'x/y: {1e-3 * ds_cell.xCell.values:f} '
                               f'{1e-3 * ds_cell.yCell.values:f}')
                 string = (f'deltaSSHMax: '
-                          f'{deltaSSH.isel(nCells=iCell).values:g}, {coords}')
+                          f'{deltaSSHMax:g}, {coords}')
                 logger.info(f'     {string}')
                 log_file.write(f'{string}\n')
                 string = (f'ssh: {finalSSH.isel(nCells=iCell).values:g}, '
@@ -185,6 +186,10 @@ def adjust_ssh(variable, iteration_count, step, update_pio=True,
                           f'{landIcePressure.isel(nCells=iCell).values:g}')
                 logger.info(f'     {string}')
                 log_file.write(f'{string}\n')
+
+                if deltaSSH_threshold is not None:
+                    if abs(deltaSSHMax) < deltaSSH_threshold:
+                        break
 
         logger.info("   - Complete\n")
 

--- a/compass/ocean/tests/ice_shelf_2d/__init__.py
+++ b/compass/ocean/tests/ice_shelf_2d/__init__.py
@@ -20,6 +20,9 @@ class IceShelf2d(TestGroup):
                     Default(test_group=self, resolution=resolution,
                             coord_type=coord_type))
                 self.add_test_case(
+                    Default(test_group=self, resolution=resolution,
+                            coord_type=coord_type, tidal_forcing=True))
+                self.add_test_case(
                     RestartTest(test_group=self, resolution=resolution,
                                 coord_type=coord_type))
 

--- a/compass/ocean/tests/ice_shelf_2d/__init__.py
+++ b/compass/ocean/tests/ice_shelf_2d/__init__.py
@@ -15,7 +15,7 @@ class IceShelf2d(TestGroup):
         super().__init__(mpas_core=mpas_core, name='ice_shelf_2d')
 
         for resolution in ['5km']:
-            for coord_type in ['z-star', 'z-level']:
+            for coord_type in ['z-star', 'z-level', 'single_layer']:
                 self.add_test_case(
                     Default(test_group=self, resolution=resolution,
                             coord_type=coord_type))
@@ -52,3 +52,7 @@ def configure(resolution, coord_type, config):
     if coord_type == 'z-level':
         # we need more vertical resolution
         config.set('vertical_grid', 'vert_levels', '100')
+    elif coord_type == 'single_layer':
+        config.set('vertical_grid', 'vert_levels', '1')
+        config.set('vertical_grid', 'coord_type', 'z-level')
+        config.set('vertical_grid', 'partial_cell_type', 'None')

--- a/compass/ocean/tests/ice_shelf_2d/__init__.py
+++ b/compass/ocean/tests/ice_shelf_2d/__init__.py
@@ -14,7 +14,7 @@ class IceShelf2d(TestGroup):
         """
         super().__init__(mpas_core=mpas_core, name='ice_shelf_2d')
 
-        for resolution in ['5km']:
+        for resolution in [2e3, 5e3]:
             for coord_type in ['z-star', 'z-level', 'single_layer']:
                 self.add_test_case(
                     Default(test_group=self, resolution=resolution,
@@ -33,8 +33,8 @@ def configure(resolution, coord_type, config):
 
     Parameters
     ----------
-    resolution : str
-        The resolution of the test case
+    resolution : float
+        The resolution of the test case in meters
 
     coord_type : str
         The type of vertical coordinate (``z-star``, ``z-level``, etc.)
@@ -42,14 +42,16 @@ def configure(resolution, coord_type, config):
     config : compass.config.CompassConfigParser
         Configuration options for this test case
     """
-    res_params = {'5km': {'nx': 10, 'ny': 44, 'dc': 5e3}}
+    dx = 50e3  # width of domain in m
+    dy = 220e3  # length of domain in m
+    dc = resolution
+    nx = int(dx / resolution)
+    # ny needs to be even because it is nonperiodic
+    ny = 2 * int(dy / (2. * resolution))
 
-    if resolution not in res_params:
-        raise ValueError('Unsupported resolution {}. Supported values are: '
-                         '{}'.format(resolution, list(res_params)))
-    res_params = res_params[resolution]
-    for param in res_params:
-        config.set('ice_shelf_2d', param, '{}'.format(res_params[param]))
+    config.set('ice_shelf_2d', 'nx', f'{nx}')
+    config.set('ice_shelf_2d', 'ny', f'{ny}')
+    config.set('ice_shelf_2d', 'dc', f'{dc}')
 
     config.set('vertical_grid', 'coord_type', coord_type)
     if coord_type == 'z-level':

--- a/compass/ocean/tests/ice_shelf_2d/default/__init__.py
+++ b/compass/ocean/tests/ice_shelf_2d/default/__init__.py
@@ -15,8 +15,8 @@ class Default(TestCase):
 
     Attributes
     ----------
-    resolution : str
-        The horizontal resolution of the test case
+    resolution : float
+        The horizontal resolution of the test case in m
 
     coord_type : str
         The type of vertical coordinate (``z-star``, ``z-level``, etc.)
@@ -46,7 +46,11 @@ class Default(TestCase):
             with_frazil = True
         self.resolution = resolution
         self.coord_type = coord_type
-        subdir = f'{resolution}/{coord_type}/{name}'
+        if resolution >= 1e3:
+            res_name = f'{int(resolution / 1e3)}km'
+        else:
+            res_name = f'{int(resolution)}m'
+        subdir = f'{res_name}/{coord_type}/{name}'
         super().__init__(test_group=test_group, name=name,
                          subdir=subdir)
 

--- a/compass/ocean/tests/ice_shelf_2d/default/__init__.py
+++ b/compass/ocean/tests/ice_shelf_2d/default/__init__.py
@@ -47,10 +47,12 @@ class Default(TestCase):
         self.add_step(
             InitialState(test_case=self, resolution=resolution))
         self.add_step(
-            SshAdjustment(test_case=self, ntasks=4, openmp_threads=1))
+            SshAdjustment(test_case=self, coord_type=coord_type, ntasks=4,
+                          openmp_threads=1))
         self.add_step(
             Forward(test_case=self, ntasks=4, openmp_threads=1,
-                    resolution=resolution, with_frazil=True))
+                    coord_type=coord_type, resolution=resolution,
+                    with_frazil=True))
         self.add_step(Viz(test_case=self), run_by_default=False)
 
     def configure(self):

--- a/compass/ocean/tests/ice_shelf_2d/default/__init__.py
+++ b/compass/ocean/tests/ice_shelf_2d/default/__init__.py
@@ -47,9 +47,9 @@ class Default(TestCase):
         self.resolution = resolution
         self.coord_type = coord_type
         if resolution >= 1e3:
-            res_name = f'{int(resolution / 1e3)}km'
+            res_name = f'{resolution / 1e3:g}km'
         else:
-            res_name = f'{int(resolution)}m'
+            res_name = f'{resolution:g}m'
         subdir = f'{res_name}/{coord_type}/{name}'
         super().__init__(test_group=test_group, name=name,
                          subdir=subdir)

--- a/compass/ocean/tests/ice_shelf_2d/default/__init__.py
+++ b/compass/ocean/tests/ice_shelf_2d/default/__init__.py
@@ -57,8 +57,9 @@ class Default(TestCase):
         self.add_step(
             InitialState(test_case=self, resolution=resolution))
         self.add_step(
-            SshAdjustment(test_case=self, coord_type=coord_type, ntasks=4,
-                          openmp_threads=1, tidal_forcing=tidal_forcing))
+            SshAdjustment(test_case=self, coord_type=coord_type,
+                          resolution=resolution, ntasks=4, openmp_threads=1,
+                          tidal_forcing=tidal_forcing))
         self.add_step(
             Forward(test_case=self, ntasks=4, openmp_threads=1,
                     coord_type=coord_type, resolution=resolution,

--- a/compass/ocean/tests/ice_shelf_2d/default/__init__.py
+++ b/compass/ocean/tests/ice_shelf_2d/default/__init__.py
@@ -22,7 +22,8 @@ class Default(TestCase):
         The type of vertical coordinate (``z-star``, ``z-level``, etc.)
     """
 
-    def __init__(self, test_group, resolution, coord_type):
+    def __init__(self, test_group, resolution, coord_type,
+                 tidal_forcing=False):
         """
         Create the test case
 
@@ -38,9 +39,14 @@ class Default(TestCase):
             The type of vertical coordinate (``z-star``, ``z-level``, etc.)
         """
         name = 'default'
+        if tidal_forcing:
+            name = 'tidal_forcing'
+            with_frazil = False
+        else:
+            with_frazil = True
         self.resolution = resolution
         self.coord_type = coord_type
-        subdir = '{}/{}/{}'.format(resolution, coord_type, name)
+        subdir = f'{resolution}/{coord_type}/{name}'
         super().__init__(test_group=test_group, name=name,
                          subdir=subdir)
 
@@ -48,11 +54,11 @@ class Default(TestCase):
             InitialState(test_case=self, resolution=resolution))
         self.add_step(
             SshAdjustment(test_case=self, coord_type=coord_type, ntasks=4,
-                          openmp_threads=1))
+                          openmp_threads=1, tidal_forcing=tidal_forcing))
         self.add_step(
             Forward(test_case=self, ntasks=4, openmp_threads=1,
                     coord_type=coord_type, resolution=resolution,
-                    with_frazil=True))
+                    with_frazil=with_frazil, tidal_forcing=tidal_forcing))
         self.add_step(Viz(test_case=self), run_by_default=False)
 
     def configure(self):

--- a/compass/ocean/tests/ice_shelf_2d/forward.py
+++ b/compass/ocean/tests/ice_shelf_2d/forward.py
@@ -14,7 +14,7 @@ class Forward(Step):
     """
     def __init__(self, test_case, resolution, coord_type, name='forward',
                  subdir=None, ntasks=1, min_tasks=None, openmp_threads=1,
-                 with_frazil=True):
+                 with_frazil=True, tidal_forcing=False):
         """
         Create a new test case
 
@@ -63,6 +63,9 @@ class Forward(Step):
             self.add_namelist_file(
                 'compass.ocean.tests.ice_shelf_2d',
                 'namelist.single_layer.forward_and_ssh_adjust')
+        if tidal_forcing:
+            self.add_namelist_file('compass.ocean.tests.ice_shelf_2d',
+                                   'namelist.tidal_forcing.forward')
         if with_frazil:
             options = {'config_use_frazil_ice_formation': '.true.',
                        'config_frazil_maximum_depth': '2000.0'}
@@ -76,6 +79,9 @@ class Forward(Step):
         self.add_streams_file('compass.ocean.tests.ice_shelf_2d',
                               'streams.forward')
 
+        self.add_input_file(filename='forcing_data.nc',
+                            target=('../initial_state/'
+                                    'init_mode_forcing_data.nc'))
         self.add_input_file(filename='init.nc',
                             target='../ssh_adjustment/adjusted_init.nc')
         self.add_input_file(filename='graph.info',

--- a/compass/ocean/tests/ice_shelf_2d/forward.py
+++ b/compass/ocean/tests/ice_shelf_2d/forward.py
@@ -12,8 +12,9 @@ class Forward(Step):
     resolution : str
         The resolution of the test case
     """
-    def __init__(self, test_case, resolution, name='forward', subdir=None,
-                 ntasks=1, min_tasks=None, openmp_threads=1, with_frazil=True):
+    def __init__(self, test_case, resolution, coord_type, name='forward',
+                 subdir=None, ntasks=1, min_tasks=None, openmp_threads=1,
+                 with_frazil=True):
         """
         Create a new test case
 
@@ -58,6 +59,10 @@ class Forward(Step):
 
         self.add_namelist_file('compass.ocean.tests.ice_shelf_2d',
                                'namelist.forward')
+        if coord_type == 'single_layer':
+            self.add_namelist_file(
+                'compass.ocean.tests.ice_shelf_2d',
+                'namelist.single_layer.forward_and_ssh_adjust')
         if with_frazil:
             options = {'config_use_frazil_ice_formation': '.true.',
                        'config_frazil_maximum_depth': '2000.0'}

--- a/compass/ocean/tests/ice_shelf_2d/forward.py
+++ b/compass/ocean/tests/ice_shelf_2d/forward.py
@@ -57,7 +57,6 @@ class Forward(Step):
             whether the simulation includes frazil ice formation
         """
         self.resolution = resolution
-        self.tidal_forcing = tidal_forcing
         if min_tasks is None:
             min_tasks = ntasks
         super().__init__(test_case=test_case, name=name, subdir=subdir,
@@ -110,10 +109,6 @@ class Forward(Step):
         """
         config = self.config
         dt_per_km = config.getfloat('ice_shelf_2d', 'dt_per_km')
-        if self.tidal_forcing == 'tidal_forcing':
-            dt_per_km = min(dt_per_km,
-                            config.getfloat('ice_shelf_2d',
-                                            'dt_per_km_tidal_forcing'))
         dt = dt_per_km * self.resolution / 1.e3
         dt_str = time.strftime('%H:%M:%S', time.gmtime(dt))
         self.update_namelist_at_runtime({'config_dt': dt_str})

--- a/compass/ocean/tests/ice_shelf_2d/ice_shelf_2d.cfg
+++ b/compass/ocean/tests/ice_shelf_2d/ice_shelf_2d.cfg
@@ -8,7 +8,7 @@ grid_type = uniform
 vert_levels = 20
 
 # Depth of the bottom of the ocean
-bottom_depth = 2000.0
+bottom_depth = 1050.0
 
 # The type of vertical coordinate (e.g. z-level, z-star)
 coord_type = z-star
@@ -27,22 +27,22 @@ min_pc_fraction = 0.1
 dt_per_km = 60
 
 # Max time step in seconds as a function of resolution when forced by tides
-dt_per_km_tidal_forcing = 10
+dt_per_km_tidal_forcing = 5
 
 # Vertical thickness of ocean sub-ice cavity at GL
 y1_water_column_thickness = 50.0
 
 # Vertical thickness of water column thickness at y2
-y2_water_column_thickness = 500.0
+y2_water_column_thickness = 1050.0
 
 # GL location in y
 y1 = 30.0e3
 
 # ice shelf inflection point in y
-y2 = 60.0e3
+y2 = 90.0e3
 
 # ice shelf front location in y
-y3 = 75.0e3
+y3 = 90.0e3
 
 # Temperature of the surface in the northern half of the domain
 temperature = 1.0

--- a/compass/ocean/tests/ice_shelf_2d/ice_shelf_2d.cfg
+++ b/compass/ocean/tests/ice_shelf_2d/ice_shelf_2d.cfg
@@ -24,10 +24,7 @@ min_pc_fraction = 0.1
 [ice_shelf_2d]
 
 # Time step in seconds as a function of resolution
-dt_per_km = 60
-
-# Max time step in seconds as a function of resolution when forced by tides
-dt_per_km_tidal_forcing = 5
+dt_per_km = 5
 
 # Vertical thickness of ocean sub-ice cavity at GL
 y1_water_column_thickness = 50.0

--- a/compass/ocean/tests/ice_shelf_2d/ice_shelf_2d.cfg
+++ b/compass/ocean/tests/ice_shelf_2d/ice_shelf_2d.cfg
@@ -23,6 +23,12 @@ min_pc_fraction = 0.1
 # config options for 2D ice-shelf testcases
 [ice_shelf_2d]
 
+# Time step in seconds as a function of resolution
+dt_per_km = 60
+
+# Max time step in seconds as a function of resolution when forced by tides
+dt_per_km_tidal_forcing = 10
+
 # Vertical thickness of ocean sub-ice cavity
 cavity_thickness = 50.0
 

--- a/compass/ocean/tests/ice_shelf_2d/ice_shelf_2d.cfg
+++ b/compass/ocean/tests/ice_shelf_2d/ice_shelf_2d.cfg
@@ -29,20 +29,20 @@ dt_per_km = 60
 # Max time step in seconds as a function of resolution when forced by tides
 dt_per_km_tidal_forcing = 10
 
-# Vertical thickness of ocean sub-ice cavity
-cavity_thickness = 50.0
+# Vertical thickness of ocean sub-ice cavity at GL
+y1_water_column_thickness = 50.0
 
-# Vertical thickness of fixed slope
-slope_height = 500.0
+# Vertical thickness of water column thickness at y2
+y2_water_column_thickness = 500.0
 
-# Horizontal width of angled part of the ice
-edge_width = 15.0e3
-
-# cavity edge in y
+# GL location in y
 y1 = 30.0e3
 
-# shelf edge in y
+# ice shelf inflection point in y
 y2 = 60.0e3
+
+# ice shelf front location in y
+y3 = 75.0e3
 
 # Temperature of the surface in the northern half of the domain
 temperature = 1.0

--- a/compass/ocean/tests/ice_shelf_2d/initial_state.py
+++ b/compass/ocean/tests/ice_shelf_2d/initial_state.py
@@ -72,9 +72,9 @@ class InitialState(Step):
         # d variables are total water-column thickness below ice shelf
         y1 = section.getfloat('y1')
         y2 = section.getfloat('y2')
-        y3 = y2 + section.getfloat('edge_width')
-        d1 = section.getfloat('cavity_thickness')
-        d2 = d1 + section.getfloat('slope_height')
+        y3 = section.getfloat('y3')
+        d1 = section.getfloat('y1_water_column_thickness')
+        d2 = section.getfloat('y2_water_column_thickness')
         d3 = bottom_depth
 
         ds = dsMesh.copy()

--- a/compass/ocean/tests/ice_shelf_2d/initial_state.py
+++ b/compass/ocean/tests/ice_shelf_2d/initial_state.py
@@ -1,3 +1,4 @@
+import numpy as np
 import xarray
 from mpas_tools.cime.constants import constants
 from mpas_tools.io import write_netcdf
@@ -130,3 +131,10 @@ class InitialState(Step):
         ds['landIceDraft'] = landIceDraft
 
         write_netcdf(ds, 'initial_state.nc')
+
+        # Generate the tidal forcing dataset whether it is used or not
+        ds_forcing = xarray.Dataset()
+        y_max = np.max(ds.yCell.values)
+        ds_forcing['tidalInputMask'] = xarray.where(
+            ds.yCell > (y_max - 0.6 * 5.0e3), 1.0, 0.0)
+        write_netcdf(ds_forcing, 'init_mode_forcing_data.nc')

--- a/compass/ocean/tests/ice_shelf_2d/namelist.forward
+++ b/compass/ocean/tests/ice_shelf_2d/namelist.forward
@@ -1,4 +1,3 @@
-config_dt = '00:05:00'
 config_btr_dt = '00:00:15'
 config_run_duration = '0000_00:10:00'
 config_use_mom_del2 = .true.

--- a/compass/ocean/tests/ice_shelf_2d/namelist.single_layer.forward_and_ssh_adjust
+++ b/compass/ocean/tests/ice_shelf_2d/namelist.single_layer.forward_and_ssh_adjust
@@ -1,5 +1,4 @@
 config_time_integrator='RK4'
-config_dt='00:00:10'
 config_run_duration = '0002_00:00:00'
 config_bottom_drag_mode = 'explicit'
 config_explicit_bottom_drag_coeff = 3.0e-3

--- a/compass/ocean/tests/ice_shelf_2d/namelist.single_layer.forward_and_ssh_adjust
+++ b/compass/ocean/tests/ice_shelf_2d/namelist.single_layer.forward_and_ssh_adjust
@@ -1,5 +1,4 @@
 config_time_integrator='RK4'
-config_run_duration = '0002_00:00:00'
 config_bottom_drag_mode = 'explicit'
 config_explicit_bottom_drag_coeff = 3.0e-3
 config_AM_globalStats_enable = .false.

--- a/compass/ocean/tests/ice_shelf_2d/namelist.single_layer.forward_and_ssh_adjust
+++ b/compass/ocean/tests/ice_shelf_2d/namelist.single_layer.forward_and_ssh_adjust
@@ -1,0 +1,16 @@
+config_time_integrator='RK4'
+config_dt='00:00:10'
+config_run_duration = '0002_00:00:00'
+config_bottom_drag_mode = 'explicit'
+config_explicit_bottom_drag_coeff = 3.0e-3
+config_AM_globalStats_enable = .false.
+config_AM_globalStats_compute_on_startup = .false.
+config_AM_globalStats_write_on_startup = .false.
+config_compute_active_tracer_budgets = .false.
+config_disable_thick_vadv = .true.
+config_disable_thick_sflux = .true.
+config_disable_vel_hmix = .true.
+config_disable_vel_vmix = .true.
+config_disable_vel_vadv = .true.
+config_disable_tr_all_tend = .true.
+config_disable_redi_k33 = .true.

--- a/compass/ocean/tests/ice_shelf_2d/namelist.tidal_forcing.forward
+++ b/compass/ocean/tests/ice_shelf_2d/namelist.tidal_forcing.forward
@@ -1,0 +1,8 @@
+config_use_tidal_forcing = .true.
+config_use_tidal_forcing_tau = 10000
+config_tidal_forcing_model = 'monochromatic'
+config_tidal_forcing_type = 'thickness_source'
+config_tidal_forcing_monochromatic_amp = 1.0
+config_tidal_forcing_monochromatic_period = 10.0
+config_eos_type = 'linear'
+config_land_ice_flux_mode = 'pressure_only'

--- a/compass/ocean/tests/ice_shelf_2d/restart_test/__init__.py
+++ b/compass/ocean/tests/ice_shelf_2d/restart_test/__init__.py
@@ -40,7 +40,7 @@ class RestartTest(TestCase):
         name = 'restart_test'
         self.resolution = resolution
         self.coord_type = coord_type
-        subdir = '{}/{}/{}'.format(resolution, coord_type, name)
+        subdir = f'{resolution}/{coord_type}/{name}'
         super().__init__(test_group=test_group, name=name,
                          subdir=subdir)
 

--- a/compass/ocean/tests/ice_shelf_2d/restart_test/__init__.py
+++ b/compass/ocean/tests/ice_shelf_2d/restart_test/__init__.py
@@ -40,14 +40,19 @@ class RestartTest(TestCase):
         name = 'restart_test'
         self.resolution = resolution
         self.coord_type = coord_type
-        subdir = f'{resolution}/{coord_type}/{name}'
+        if resolution >= 1e3:
+            res_name = f'{int(resolution / 1e3)}km'
+        else:
+            res_name = f'{int(resolution)}m'
+        subdir = f'{res_name}/{coord_type}/{name}'
         super().__init__(test_group=test_group, name=name,
                          subdir=subdir)
 
         self.add_step(
             InitialState(test_case=self, resolution=resolution))
         self.add_step(
-            SshAdjustment(test_case=self, coord_type=coord_type, ntasks=4,
+            SshAdjustment(test_case=self, resolution=resolution,
+                          coord_type=coord_type, ntasks=4,
                           openmp_threads=1))
 
         for part in ['full', 'restart']:

--- a/compass/ocean/tests/ice_shelf_2d/restart_test/__init__.py
+++ b/compass/ocean/tests/ice_shelf_2d/restart_test/__init__.py
@@ -41,9 +41,9 @@ class RestartTest(TestCase):
         self.resolution = resolution
         self.coord_type = coord_type
         if resolution >= 1e3:
-            res_name = f'{int(resolution / 1e3)}km'
+            res_name = f'{resolution / 1e3:g}km'
         else:
-            res_name = f'{int(resolution)}m'
+            res_name = f'{resolution:g}m'
         subdir = f'{res_name}/{coord_type}/{name}'
         super().__init__(test_group=test_group, name=name,
                          subdir=subdir)

--- a/compass/ocean/tests/ice_shelf_2d/restart_test/__init__.py
+++ b/compass/ocean/tests/ice_shelf_2d/restart_test/__init__.py
@@ -47,13 +47,14 @@ class RestartTest(TestCase):
         self.add_step(
             InitialState(test_case=self, resolution=resolution))
         self.add_step(
-            SshAdjustment(test_case=self, ntasks=4, openmp_threads=1))
+            SshAdjustment(test_case=self, coord_type=coord_type, ntasks=4,
+                          openmp_threads=1))
 
         for part in ['full', 'restart']:
             name = '{}_run'.format(part)
-            step = Forward(test_case=self, name=name, subdir=name, ntasks=4,
-                           openmp_threads=1, resolution=resolution,
-                           with_frazil=True)
+            step = Forward(test_case=self, name=name, subdir=name,
+                           coord_type=coord_type, ntasks=4, openmp_threads=1,
+                           resolution=resolution, with_frazil=True)
 
             step.add_namelist_file(
                 'compass.ocean.tests.ice_shelf_2d.restart_test',

--- a/compass/ocean/tests/ice_shelf_2d/ssh_adjustment.py
+++ b/compass/ocean/tests/ice_shelf_2d/ssh_adjustment.py
@@ -8,7 +8,7 @@ class SshAdjustment(Step):
     shelf to match the sea-surface height as part of ice-shelf 2D test cases
     """
     def __init__(self, test_case, coord_type, ntasks=1, min_tasks=None,
-                 openmp_threads=1):
+                 openmp_threads=1, tidal_forcing=False):
         """
         Create the step
 

--- a/compass/ocean/tests/ice_shelf_2d/ssh_adjustment.py
+++ b/compass/ocean/tests/ice_shelf_2d/ssh_adjustment.py
@@ -92,4 +92,4 @@ class SshAdjustment(Step):
         self.update_namelist_at_runtime({'config_dt': dt_str})
         iteration_count = config.getint('ssh_adjustment', 'iterations')
         adjust_ssh(variable='landIcePressure', iteration_count=iteration_count,
-                   step=self)
+                   step=self, deltaSSH_threshold=1.e-10)

--- a/compass/ocean/tests/ice_shelf_2d/ssh_adjustment.py
+++ b/compass/ocean/tests/ice_shelf_2d/ssh_adjustment.py
@@ -39,7 +39,6 @@ class SshAdjustment(Step):
 
         """
         self.resolution = resolution
-        self.tidal_forcing = tidal_forcing
         if min_tasks is None:
             min_tasks = ntasks
         super().__init__(test_case=test_case, name='ssh_adjustment',
@@ -83,10 +82,6 @@ class SshAdjustment(Step):
         """
         config = self.config
         dt_per_km = config.getfloat('ice_shelf_2d', 'dt_per_km')
-        if self.tidal_forcing == 'tidal_forcing':
-            dt_per_km = min(dt_per_km,
-                            config.getfloat('ice_shelf_2d',
-                                            'dt_per_km_tidal_forcing'))
         dt = dt_per_km * self.resolution / 1.e3
         dt_str = time.strftime('%H:%M:%S', time.gmtime(dt))
         self.update_namelist_at_runtime({'config_dt': dt_str})

--- a/compass/ocean/tests/ice_shelf_2d/ssh_adjustment.py
+++ b/compass/ocean/tests/ice_shelf_2d/ssh_adjustment.py
@@ -87,4 +87,4 @@ class SshAdjustment(Step):
         self.update_namelist_at_runtime({'config_dt': dt_str})
         iteration_count = config.getint('ssh_adjustment', 'iterations')
         adjust_ssh(variable='landIcePressure', iteration_count=iteration_count,
-                   step=self, deltaSSH_threshold=1.e-10)
+                   step=self, delta_ssh_threshold=1.e-10)

--- a/compass/ocean/tests/ice_shelf_2d/ssh_adjustment.py
+++ b/compass/ocean/tests/ice_shelf_2d/ssh_adjustment.py
@@ -7,7 +7,8 @@ class SshAdjustment(Step):
     A step for iteratively adjusting the pressure from the weight of the ice
     shelf to match the sea-surface height as part of ice-shelf 2D test cases
     """
-    def __init__(self, test_case, ntasks=1, min_tasks=None, openmp_threads=1):
+    def __init__(self, test_case, coord_type, ntasks=1, min_tasks=None,
+                 openmp_threads=1):
         """
         Create the step
 
@@ -15,6 +16,9 @@ class SshAdjustment(Step):
         ----------
         test_case : compass.TestCase
             The test case this step belongs to
+
+        coord_type: str
+            The coordinate type (e.g., 'z-star', 'single_layer', etc.)
 
         ntasks : int, optional
             the number of tasks the step would ideally use.  If fewer tasks
@@ -39,6 +43,10 @@ class SshAdjustment(Step):
         # start with the same namelist settings as the forward run
         self.add_namelist_file('compass.ocean.tests.ice_shelf_2d',
                                'namelist.forward')
+        if coord_type == 'single_layer':
+            self.add_namelist_file(
+                'compass.ocean.tests.ice_shelf_2d',
+                'namelist.single_layer.forward_and_ssh_adjust')
 
         # we don't want the global stats AM for this run
         self.add_namelist_options({'config_AM_globalStats_enable': '.false.'})

--- a/compass/ocean/tests/ice_shelf_2d/streams.forward
+++ b/compass/ocean/tests/ice_shelf_2d/streams.forward
@@ -8,6 +8,14 @@
 
 <immutable_stream name="restart"/>
 
+<stream name="forcing_data"
+        filename_template="forcing_data.nc"
+        input_interval="initial_only"
+        type="input">
+
+    <var name="tidalInputMask"/>
+</stream>
+
 <stream name="output"
         type="output"
         filename_template="output.nc"
@@ -17,9 +25,13 @@
     <var_struct name="tracers"/>
     <stream name="mesh"/>
     <var name="xtime"/>
+    <var name="daysSinceStartOfSim"/>
     <var name="normalVelocity"/>
     <var name="layerThickness"/>
     <var name="ssh"/>
+    <var name="velocityX"/>
+    <var name="velocityY"/>
+    <var name="tidalInputMask"/>
     <var name="atmosphericPressure"/>
     <var name="landIcePressure"/>
     <var name="landIceDraft"/>
@@ -33,7 +45,7 @@
 </stream>
 
 <stream name="globalStatsOutput"
-        output_interval="0000_00:00:01" >
+        output_interval="0000_00:10:00" >
 </stream>
 
 

--- a/compass/ocean/tests/ice_shelf_2d/viz.py
+++ b/compass/ocean/tests/ice_shelf_2d/viz.py
@@ -113,38 +113,44 @@ class Viz(Step):
         min_column_thickness = self.config.getfloat(
             'ice_shelf_2d', 'y1_water_column_thickness')
 
+        figsize = (4, 8)
         delssh = dsOut.ssh - dsOut.ssh[0, :]
         s_vmin = np.nanmin(delssh.values)
         s_vmax = np.nanmax(delssh.values)
         plotter.plot_horiz_series(delssh, 'delssh', 'delssh', True,
                                   cmap='cmo.curl',
                                   vmin=-1. * max(abs(s_vmin), abs(s_vmax)),
-                                  vmax=max(abs(s_vmin), abs(s_vmax)))
+                                  vmax=max(abs(s_vmin), abs(s_vmax)),
+                                  figsize=figsize)
 
         u_vmin = np.nanmin(dsOut.velocityX[:, :, 0].values)
         u_vmax = np.nanmax(dsOut.velocityX[:, :, 0].values)
         plotter.plot_horiz_series(dsOut.velocityX[:, :, 0], 'u', 'u', True,
                                   cmap='cmo.balance',
                                   vmin=-1. * max(abs(u_vmin), abs(u_vmax)),
-                                  vmax=max(abs(u_vmin), abs(u_vmax)))
+                                  vmax=max(abs(u_vmin), abs(u_vmax)),
+                                  figsize=figsize)
 
         v_vmin = np.nanmin(dsOut.velocityY[:, :, 0].values)
         v_vmax = np.nanmax(dsOut.velocityY[:, :, 0].values)
         plotter.plot_horiz_series(dsOut.velocityY[:, :, 0], 'v', 'v', True,
                                   cmap='cmo.balance',
                                   vmin=-1. * max(abs(v_vmin), abs(v_vmax)),
-                                  vmax=max(abs(v_vmin), abs(v_vmax)))
+                                  vmax=max(abs(v_vmin), abs(v_vmax)),
+                                  figsize=figsize)
 
         plotter.plot_horiz_series(dsOut.landIcePressure, 'landIcePressure',
                                   'landIcePressure',
                                   True, vmin=1e3,
                                   vmax=1e7, cmap_set_under='r',
-                                  cmap_scale='log')
+                                  cmap_scale='log',
+                                  figsize=figsize)
 
         plotter.plot_horiz_series(dsOut.ssh + ds.bottomDepth, 'H', 'H',
                                   True, vmin=min_column_thickness + 1e-10,
                                   vmax=2000, cmap_set_under='r',
-                                  cmap_scale='log')
+                                  cmap_scale='log',
+                                  figsize=figsize)
 
         delssh = dsAdj.ssh - ds.ssh
         s_vmin = np.nanmin(delssh.values)
@@ -152,4 +158,5 @@ class Viz(Step):
         plotter.plot_horiz_series(delssh, 'delssh_adjust', 'delssh_adjust',
                                   True, cmap='cmo.curl', time_indices=[0],
                                   vmin=-1. * max(abs(s_vmin), abs(s_vmax)),
-                                  vmax=max(abs(s_vmin), abs(s_vmax)))
+                                  vmax=max(abs(s_vmin), abs(s_vmax)),
+                                  figsize=figsize)

--- a/compass/ocean/tests/ice_shelf_2d/viz.py
+++ b/compass/ocean/tests/ice_shelf_2d/viz.py
@@ -1,8 +1,9 @@
 import matplotlib.pyplot as plt
-import numpy
+import numpy as np
 import pandas as pd
 import xarray
 
+from compass.ocean.tests.isomip_plus.viz.plot import MoviePlotter
 from compass.step import Step
 
 
@@ -25,6 +26,8 @@ class Viz(Step):
                             target='../initial_state/initial_state.nc')
         self.add_input_file(filename='output.nc',
                             target='../forward/output.nc')
+        self.add_input_file(filename='output_ssh.nc',
+                            target='../ssh_adjustment/output_ssh.nc')
         self.add_output_file('vert_grid.png')
         self.add_output_file('velocity_max_t.png')
 
@@ -34,6 +37,14 @@ class Viz(Step):
         """
 
         ds = xarray.open_dataset('initial_state.nc')
+        dsOut = xarray.open_dataset('output.nc')
+        dsAdj = xarray.open_dataset('output_ssh.nc')
+        plotter = MoviePlotter(inFolder='../forward',
+                               streamfunctionFolder='',
+                               outFolder='./plots',
+                               expt='', sectionY=20. * 5.0e3,
+                               dsMesh=ds, ds=dsOut,
+                               showProgress=False)
 
         if 'Time' in ds.dims:
             ds = ds.isel(Time=0)
@@ -43,24 +54,24 @@ class Viz(Step):
         nCells = ds.sizes['yCell']
         nVertLevels = ds.sizes['nVertLevels']
 
-        zIndex = xarray.DataArray(data=numpy.arange(nVertLevels),
+        zIndex = xarray.DataArray(data=np.arange(nVertLevels),
                                   dims='nVertLevels')
 
         minLevelCell = ds.minLevelCell - 1
         maxLevelCell = ds.maxLevelCell - 1
 
-        cellMask = numpy.logical_and(zIndex >= minLevelCell,
-                                     zIndex <= maxLevelCell)
+        cellMask = np.logical_and(zIndex >= minLevelCell,
+                                  zIndex <= maxLevelCell)
 
-        zIndex = xarray.DataArray(data=numpy.arange(nVertLevels + 1),
+        zIndex = xarray.DataArray(data=np.arange(nVertLevels + 1),
                                   dims='nVertLevelsP1')
 
-        interfaceMask = numpy.logical_and(zIndex >= minLevelCell,
-                                          zIndex <= maxLevelCell + 1)
+        interfaceMask = np.logical_and(zIndex >= minLevelCell,
+                                       zIndex <= maxLevelCell + 1)
 
         zMid = ds.zMid.where(cellMask)
 
-        zInterface = numpy.zeros((nCells, nVertLevels + 1))
+        zInterface = np.zeros((nCells, nVertLevels + 1))
         zInterface[:, 0] = ds.ssh.values
         for zIndex in range(nVertLevels):
             thickness = ds.layerThickness.isel(nVertLevels=zIndex)
@@ -83,14 +94,14 @@ class Viz(Step):
         plt.legend()
         plt.savefig('vert_grid.png', dpi=200)
         plt.close()
-        ds.close()
 
-        ds = xarray.open_dataset('output.nc')
+        ds = xarray.open_dataset('initial_state.nc')
+
         # Plot the time series of max velocity
         plt.figure(figsize=[12, 6], dpi=100)
-        umax = numpy.amax(ds.velocityX[:, :, 0].values, axis=1)
-        vmax = numpy.amax(ds.velocityY[:, :, 0].values, axis=1)
-        t = ds.daysSinceStartOfSim.values
+        umax = np.amax(dsOut.velocityX[:, :, 0].values, axis=1)
+        vmax = np.amax(dsOut.velocityY[:, :, 0].values, axis=1)
+        t = dsOut.daysSinceStartOfSim.values
         time = pd.to_timedelta(t) / 1.e9
         plt.plot(time, umax, 'k', label='u')
         plt.plot(time, vmax, 'b', label='v')
@@ -99,3 +110,46 @@ class Viz(Step):
         plt.legend()
         plt.savefig('velocity_max_t.png', dpi=200)
         plt.close()
+        min_column_thickness = self.config.getfloat(
+            'ice_shelf_2d', 'y1_water_column_thickness')
+
+        delssh = dsOut.ssh - dsOut.ssh[0, :]
+        s_vmin = np.nanmin(delssh.values)
+        s_vmax = np.nanmax(delssh.values)
+        plotter.plot_horiz_series(delssh, 'delssh', 'delssh', True,
+                                  cmap='cmo.curl',
+                                  vmin=-1. * max(abs(s_vmin), abs(s_vmax)),
+                                  vmax=max(abs(s_vmin), abs(s_vmax)))
+
+        u_vmin = np.nanmin(dsOut.velocityX[:, :, 0].values)
+        u_vmax = np.nanmax(dsOut.velocityX[:, :, 0].values)
+        plotter.plot_horiz_series(dsOut.velocityX[:, :, 0], 'u', 'u', True,
+                                  cmap='cmo.balance',
+                                  vmin=-1. * max(abs(u_vmin), abs(u_vmax)),
+                                  vmax=max(abs(u_vmin), abs(u_vmax)))
+
+        v_vmin = np.nanmin(dsOut.velocityY[:, :, 0].values)
+        v_vmax = np.nanmax(dsOut.velocityY[:, :, 0].values)
+        plotter.plot_horiz_series(dsOut.velocityY[:, :, 0], 'v', 'v', True,
+                                  cmap='cmo.balance',
+                                  vmin=-1. * max(abs(v_vmin), abs(v_vmax)),
+                                  vmax=max(abs(v_vmin), abs(v_vmax)))
+
+        plotter.plot_horiz_series(dsOut.landIcePressure, 'landIcePressure',
+                                  'landIcePressure',
+                                  True, vmin=1e3,
+                                  vmax=1e7, cmap_set_under='r',
+                                  cmap_scale='log')
+
+        plotter.plot_horiz_series(dsOut.ssh + ds.bottomDepth, 'H', 'H',
+                                  True, vmin=min_column_thickness + 1e-10,
+                                  vmax=2000, cmap_set_under='r',
+                                  cmap_scale='log')
+
+        delssh = dsAdj.ssh - ds.ssh
+        s_vmin = np.nanmin(delssh.values)
+        s_vmax = np.nanmax(delssh.values)
+        plotter.plot_horiz_series(delssh, 'delssh_adjust', 'delssh_adjust',
+                                  True, cmap='cmo.curl', time_indices=[0],
+                                  vmin=-1. * max(abs(s_vmin), abs(s_vmax)),
+                                  vmax=max(abs(s_vmin), abs(s_vmax)))

--- a/compass/ocean/tests/isomip_plus/viz/plot.py
+++ b/compass/ocean/tests/isomip_plus/viz/plot.py
@@ -469,7 +469,8 @@ class MoviePlotter(object):
     def plot_horiz_series(self, da, nameInTitle, prefix, oceanDomain,
                           units=None, vmin=None, vmax=None, cmap=None,
                           cmap_set_under=None, cmap_set_over=None,
-                          cmap_scale='linear', time_indices=None):
+                          cmap_scale='linear', time_indices=None,
+                          figsize=(9, 3)):
         """
         Plot a series of image of a given variable
 
@@ -533,7 +534,7 @@ class MoviePlotter(object):
                                    vmax=vmax, cmap=cmap,
                                    cmap_set_under=cmap_set_under,
                                    cmap_set_over=cmap_set_over,
-                                   cmap_scale=cmap_scale)
+                                   cmap_scale=cmap_scale, figsize=figsize)
             if self.showProgress:
                 bar.update(tIndex + 1)
         if self.showProgress:


### PR DESCRIPTION
This PR adds new `ice_shelf_2d` test cases which are combinations of:
* `2km` resolution
* `single_layer` vertical coordinate
* `tidal_forcing` version of the default test case
 
There are also changes made to the cfg options related to the cavity geometry which I think are more intuitive for users looking to modify the cavity geometry. In addition, the `isomip_plus` plotter class was imported to generate new plots.

Checklist
* [X] User's Guide has been updated
* [X] Developer's Guide has been updated
* [X] N/A API documentation in the Developer's Guide (`api.rst`) has any new or modified class, method and/or functions listed
* [X] Documentation has been [built locally](https://mpas-dev.github.io/compass/latest/developers_guide/building_docs.html) and changes look as expected
* [X] Document (in a comment titled `Testing` in this PR) any testing that was used to verify the changes