### PR TITLE
Update to geometric_features 1.3.0

### DIFF
--- a/conda/compass_env/spec-file.template
+++ b/conda/compass_env/spec-file.template
@@ -8,7 +8,7 @@ cartopy_offlinedata
 cmocean
 esmf=*={{ mpi_prefix }}_*
 ffmpeg
-geometric_features=1.2.0
+geometric_features=1.3.0
 git
 gsw
 h5py

--- a/conda/recipe/meta.yaml
+++ b/conda/recipe/meta.yaml
@@ -45,7 +45,7 @@ requirements:
     - cmocean
     - esmf * {{ mpi_prefix }}_*
     - ffmpeg
-    - geometric_features 1.2.0
+    - geometric_features 1.3.0
     - git
     - gsw
     - h5py


### PR DESCRIPTION
This brings in 2 new critical land blockages to make sure the interior of Greenland does not become part of the ocean (because of the GEBCO topography that we use).

<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->

<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [x] Document (in a comment titled `Testing` in this PR) any testing that was used to verify the changes

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->
