### PR TITLE
New Mesh: ECwISC30to60E3r2

### DIFF
--- a/compass/ocean/tests/global_ocean/mesh/ec30to60/ec30to60.cfg
+++ b/compass/ocean/tests/global_ocean/mesh/ec30to60/ec30to60.cfg
@@ -42,7 +42,7 @@ mesh_description = MPAS Eddy Closure mesh for E3SM version ${e3sm_version} with
 e3sm_version = 3
 # The revision number of the mesh, which should be incremented each time the
 # mesh is revised
-mesh_revision = 1
+mesh_revision = 2
 # the minimum (finest) resolution in the mesh
 min_res = 30
 # the maximum (coarsest) resolution in the mesh, can be the same as min_res

--- a/compass/ocean/tests/global_ocean/mesh/ec30to60/ec30to60.cfg
+++ b/compass/ocean/tests/global_ocean/mesh/ec30to60/ec30to60.cfg
@@ -48,4 +48,4 @@ min_res = 30
 # the maximum (coarsest) resolution in the mesh, can be the same as min_res
 max_res = 60
 # The URL of the pull request documenting the creation of the mesh
-pull_request = <<<Missing>>>
+pull_request = https://github.com/MPAS-Dev/compass/pull/689

--- a/compass/ocean/tests/global_ocean/mesh/ec30to60/ec30to60.cfg
+++ b/compass/ocean/tests/global_ocean/mesh/ec30to60/ec30to60.cfg
@@ -25,7 +25,7 @@ transition_levels = 28
 [global_ocean]
 
 # Maximum allowed Haney number for configurations with ice-shelf cavities
-rx1_max = 15
+rx1_max = 10
 
 # the approximate number of cells in the mesh
 approx_cell_count = 240000


### PR DESCRIPTION
<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->

Long name: ECwISC30to60L64E3SMv3r2

As with previous versions of the mesh, this Eddy Closure (EC) mesh has:
* 30 km resolution at the equator
* 60 km resolution at mid latitudes
* 35 km resolution near the poles

Mesh, initial condition, dynamic adjustment and files for E3SM are on Chrysalis at:
```
/lcrc/group/e3sm/ac.xylar/compass_1.2/chrysalis/e3smv3-meshes/ecwisc30to60e3r2
```

<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [x] Document (in a comment titled `Testing` in this PR) any testing that was used to verify the changes

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->

Replaces #666 
