### PR TITLE
Add decomp test case to the drying slope test group

### DIFF
--- a/compass/ocean/suites/wetdry.txt
+++ b/compass/ocean/suites/wetdry.txt
@@ -4,8 +4,10 @@ ocean/drying_slope/250m/single_layer/default
 ocean/drying_slope/250m/single_layer/ramp
 ocean/drying_slope/1km/sigma/default
 ocean/drying_slope/1km/sigma/ramp
+ocean/drying_slope/1km/sigma/decomp
 ocean/drying_slope/1km/single_layer/default
 ocean/drying_slope/1km/single_layer/ramp
+ocean/drying_slope/1km/single_layer/decomp
 ocean/dam_break/40cm/default
 ocean/dam_break/40cm/ramp
 ocean/dam_break/120cm/default

--- a/compass/ocean/tests/drying_slope/__init__.py
+++ b/compass/ocean/tests/drying_slope/__init__.py
@@ -1,3 +1,4 @@
+from compass.ocean.tests.drying_slope.decomp import Decomp
 from compass.ocean.tests.drying_slope.default import Default
 from compass.ocean.tests.drying_slope.loglaw import LogLaw
 from compass.ocean.tests.drying_slope.ramp import Ramp
@@ -21,6 +22,9 @@ class DryingSlope(TestGroup):
                 self.add_test_case(
                     Default(test_group=self, resolution=resolution,
                             coord_type=coord_type))
+                self.add_test_case(
+                    Decomp(test_group=self, resolution=resolution,
+                           coord_type=coord_type))
                 self.add_test_case(
                     Ramp(test_group=self, resolution=resolution,
                          coord_type=coord_type))

--- a/compass/ocean/tests/drying_slope/decomp/__init__.py
+++ b/compass/ocean/tests/drying_slope/decomp/__init__.py
@@ -1,0 +1,84 @@
+from compass.ocean.tests import drying_slope
+from compass.ocean.tests.drying_slope.forward import Forward
+from compass.ocean.tests.drying_slope.initial_state import InitialState
+from compass.testcase import TestCase
+from compass.validate import compare_variables
+
+
+class Decomp(TestCase):
+    """
+    A decomposition test case for the baroclinic channel test group, which
+    makes sure the model produces identical results on 1 and 12 cores.
+
+    Attributes
+    ----------
+    resolution : str
+        The resolution of the test case
+    """
+
+    def __init__(self, test_group, resolution, coord_type):
+        """
+        Create the test case
+
+        Parameters
+        ----------
+        test_group : compass.ocean.tests.baroclinic_channel.BaroclinicChannel
+            The test group that this test case belongs to
+
+        resolution : str
+            The resolution of the test case
+        """
+        name = 'decomp'
+        self.resolution = resolution
+        self.coord_type = coord_type
+        if resolution < 1.:
+            res_name = f'{int(resolution*1e3)}m'
+        else:
+            res_name = f'{int(resolution)}km'
+        subdir = f'{res_name}/{coord_type}/{name}'
+        super().__init__(test_group=test_group, name=name,
+                         subdir=subdir)
+
+        self.add_step(InitialState(test_case=self, coord_type=coord_type))
+        if coord_type == 'single_layer':
+            damping_coeff = None
+        else:
+            damping_coeff = 0.01
+        for procs in [1, 12]:
+            name = '{}proc'.format(procs)
+            forward_step = Forward(test_case=self, name=name, subdir=name,
+                                   resolution=resolution,
+                                   ntasks=procs, openmp_threads=1,
+                                   damping_coeff=damping_coeff,
+                                   coord_type=coord_type)
+            self.add_step(forward_step)
+
+    def configure(self):
+        """
+        Modify the configuration options for this test case.
+        """
+
+        resolution = self.resolution
+        config = self.config
+        ny = round(28 / resolution)
+        if resolution < 1.:
+            ny += 2
+        dc = 1e3 * resolution
+
+        config.set('drying_slope', 'ny', f'{ny}', comment='the number of '
+                   'mesh cells in the y direction')
+        config.set('drying_slope', 'dc', f'{dc}', comment='the distance '
+                   'between adjacent cell centers')
+
+    # no run() method is needed
+
+    def validate(self):
+        """
+        Test cases can override this method to perform validation of variables
+        and timers
+        """
+        variables = ['temperature', 'salinity', 'layerThickness',
+                     'normalVelocity']
+        compare_variables(test_case=self, variables=variables,
+                          filename1='1proc/output.nc',
+                          filename2='12proc/output.nc')

--- a/compass/ocean/tests/drying_slope/streams.forward
+++ b/compass/ocean/tests/drying_slope/streams.forward
@@ -30,6 +30,7 @@
 
     <stream name="mesh"/>
     <var name="layerThickness"/>
+    <var_struct name="tracers"/>
     <var name="ssh"/>
     <var name="normalVelocity"/>
     <var name="xtime"/>

--- a/docs/developers_guide/ocean/api.rst
+++ b/docs/developers_guide/ocean/api.rst
@@ -87,6 +87,10 @@ drying_slope
 
    DryingSlope
 
+   decomp.Decomp
+   decomp.Decomp.configure
+   decomp.Decomp.validate
+
    default.Default
    default.Default.configure
    default.Default.validate

--- a/docs/developers_guide/ocean/test_groups/drying_slope.rst
+++ b/docs/developers_guide/ocean/test_groups/drying_slope.rst
@@ -82,6 +82,21 @@ two cases at different values of ``config_Rayleigh_damping_coeff``, 0.0025 and
 value of the implicit bottom drag coefficient. 
 
 
+.. _dev_ocean_drying_slope_decomp:
+
+decomp
+------
+
+The :py:class:`compass.ocean.tests.drying_slope.decomp.Decomp`
+test performs two 12-hour runs on 1 and 12 cores, respectively.
+:ref:`dev_validation` is performed by comparing the output of the two runs.
+This class accepts resolution and coordinate type ``coord_type`` as arguments.
+Both ``sigma`` and ``single_layer`` coordinate types are supported. For
+``sigma`` coordinates, this case is hard-coded to run with
+ ``config_Rayleigh_damping_coeff`` equal to 0.01. The ``single_layer`` case
+runs at one value of the implicit bottom drag coefficient. 
+
+
 .. _dev_ocean_drying_slope_ramp:
 
 ramp

--- a/docs/users_guide/ocean/test_groups/drying_slope.rst
+++ b/docs/users_guide/ocean/test_groups/drying_slope.rst
@@ -88,6 +88,16 @@ against analytic and ROMS solutions. ``RES`` is either 250m or 1km. ``COORD``
 is either ``single_layer`` or ``sigma``. Rayleigh drag is not compatible with
 ``single_layer`` so implicit drag with a constant coefficient is used.
 
+decomp
+------
+
+``ocean/drying_slope/${RES}/${COORD}/decomp`` is identical to the default version
+of the drying slope test case except it is run twice, on 1 processor and 12
+processors and the results of each are compared. ``RES`` is either 250m or 1km.
+``COORD`` is either ``single_layer`` or ``sigma``. The ``sigma`` case uses a
+Rayleigh drag coefficient of 0.01. Rayleigh drag is not compatible with
+``single_layer`` so implicit drag with a constant coefficient is used.
+
 ramp
 ----
 


### PR DESCRIPTION
This PR adds a decomp test case to the drying slope test group.

Checklist
* [X] User's Guide has been updated
* [X] Developer's Guide has been updated
* [X] API documentation in the Developer's Guide (`api.rst`) has any new or modified class, method and/or functions listed
* [X] Documentation has been [built locally](https://mpas-dev.github.io/compass/latest/developers_guide/building_docs.html) and changes look as expected
* [X] Document (in a comment titled `Testing` in this PR) any testing that was used to verify the changes
* [X] New tests have been added to a test suite

This test case helps evaluate https://github.com/MPAS-Dev/compass/issues/686.
