### PR TITLE
Add a few isomip_plus configurations for wetting and drying

### DIFF
--- a/compass/ocean/tests/isomip_plus/__init__.py
+++ b/compass/ocean/tests/isomip_plus/__init__.py
@@ -67,7 +67,22 @@ class IsomipPlus(TestGroup):
                             time_varying_forcing=True,
                             time_varying_load='decreasing',
                             thin_film_present=True))
+                for vertical_coordinate in ['sigma']:
+                    self.add_test_case(
+                        IsomipPlusTest(
+                            test_group=self, resolution=resolution,
+                            experiment=experiment,
+                            vertical_coordinate=vertical_coordinate,
+                            tidal_forcing=True,
+                            thin_film_present=True))
                 for vertical_coordinate in ['single_layer']:
+                    self.add_test_case(
+                        IsomipPlusTest(
+                            test_group=self, resolution=resolution,
+                            experiment=experiment,
+                            vertical_coordinate=vertical_coordinate,
+                            tidal_forcing=True,
+                            thin_film_present=False))
                     self.add_test_case(
                         IsomipPlusTest(
                             test_group=self, resolution=resolution,

--- a/compass/ocean/tests/isomip_plus/files_for_e3sm.py
+++ b/compass/ocean/tests/isomip_plus/files_for_e3sm.py
@@ -153,8 +153,8 @@ class FilesForE3sm(Step):
         ncells = sum(1 for _ in open(graph_filename))
         min_graph_size = int(ncells / 6000)
         max_graph_size = int(ncells / 100)
-        logger.info('Creating graph files between {} and {}'.format(
-            min_graph_size, max_graph_size))
+        logger.info(f'Creating graph files between {min_graph_size} and '
+                    f'{max_graph_size}')
         n_power2 = 2**np.arange(1, 21)
         n_multiples12 = 12 * np.arange(1, 9)
 

--- a/compass/ocean/tests/isomip_plus/forward.py
+++ b/compass/ocean/tests/isomip_plus/forward.py
@@ -71,6 +71,7 @@ class Forward(Step):
         options = dict()
         if not thin_film_present:
             options = get_time_steps(resolution)
+            print(f'forward: dt = {options["config_dt"]}')
 
         if run_duration is not None:
             options['config_run_duration'] = run_duration
@@ -179,33 +180,39 @@ class Forward(Step):
             dsIce = xarray.open_dataset(
                 os.path.join(self.work_dir,
                              'land_ice_fluxes.nc'))
-            plotter.plot_horiz_series(
-                dsIce.topDragMagnitude,
-                'topDragMagnitude', 'topDragMagnitude', True,
-                vmin=0 + tol, vmax=np.max(dsIce.topDragMagnitude.values),
-                cmap_set_under='k')
-            plotter.plot_horiz_series(
-                dsIce.landIceHeatFlux,
-                'landIceHeatFlux', 'landIceHeatFlux', True,
-                vmin=np.min(dsIce.landIceHeatFlux.values),
-                vmax=np.max(dsIce.landIceHeatFlux.values))
-            plotter.plot_horiz_series(
-                dsIce.landIceInterfaceTemperature,
-                'landIceInterfaceTemperature', 'landIceInterfaceTemperature',
-                True,
-                vmin=np.min(dsIce.landIceInterfaceTemperature.values),
-                vmax=np.max(dsIce.landIceInterfaceTemperature.values))
-            plotter.plot_horiz_series(
-                dsIce.landIceFreshwaterFlux,
-                'landIceFreshwaterFlux', 'landIceFreshwaterFlux', True,
-                vmin=0 + tol, vmax=1e-4,
-                cmap_set_under='k', cmap_scale='log')
-            plotter.plot_horiz_series(
-                dsIce.landIceFraction,
-                'landIceFraction', 'landIceFraction', True,
-                vmin=0 + tol, vmax=1 - tol,
-                cmap='cmo.balance',
-                cmap_set_under='k', cmap_set_over='r')
+            if 'topDragMagnitude' in dsIce.keys():
+                plotter.plot_horiz_series(
+                    dsIce.topDragMagnitude,
+                    'topDragMagnitude', 'topDragMagnitude', True,
+                    vmin=0 + tol, vmax=np.max(dsIce.topDragMagnitude.values),
+                    cmap_set_under='k')
+            if 'landIceHeatFlux' in dsIce.keys():
+                plotter.plot_horiz_series(
+                    dsIce.landIceHeatFlux,
+                    'landIceHeatFlux', 'landIceHeatFlux', True,
+                    vmin=np.min(dsIce.landIceHeatFlux.values),
+                    vmax=np.max(dsIce.landIceHeatFlux.values))
+            if 'landIceInterfaceTemperature' in dsIce.keys():
+                plotter.plot_horiz_series(
+                    dsIce.landIceInterfaceTemperature,
+                    'landIceInterfaceTemperature',
+                    'landIceInterfaceTemperature',
+                    True,
+                    vmin=np.min(dsIce.landIceInterfaceTemperature.values),
+                    vmax=np.max(dsIce.landIceInterfaceTemperature.values))
+            if 'landIceFreshwaterFlux' in dsIce.keys():
+                plotter.plot_horiz_series(
+                    dsIce.landIceFreshwaterFlux,
+                    'landIceFreshwaterFlux', 'landIceFreshwaterFlux', True,
+                    vmin=0 + tol, vmax=1e-4,
+                    cmap_set_under='k', cmap_scale='log')
+            if 'landIceFraction' in dsIce.keys():
+                plotter.plot_horiz_series(
+                    dsIce.landIceFraction,
+                    'landIceFraction', 'landIceFraction', True,
+                    vmin=0 + tol, vmax=1 - tol,
+                    cmap='cmo.balance',
+                    cmap_set_under='k', cmap_set_over='r')
             if 'landIceFloatingFraction' in dsIce.keys():
                 plotter.plot_horiz_series(
                     dsIce.landIceFloatingFraction,
@@ -258,7 +265,6 @@ def get_time_steps(resolution):
     # https://stackoverflow.com/a/1384565/7728169
     # Note: this will drop any fractional seconds, which is usually okay
     dt = time.strftime('%H:%M:%S', time.gmtime(dt))
-
     btr_dt = time.strftime('%H:%M:%S', time.gmtime(btr_dt))
 
     return dict(config_dt="'{}'".format(dt),

--- a/compass/ocean/tests/isomip_plus/forward.py
+++ b/compass/ocean/tests/isomip_plus/forward.py
@@ -154,15 +154,15 @@ class Forward(Step):
         btr_dt = time.strftime(
             '%H:%M:%S', time.gmtime(dt_btr_per_km * resolution))
 
-        options = dict(config_dt="'{}'".format(dt),
-                       config_btr_dt="'{}'".format(btr_dt))
+        options = dict(config_dt=f"'{dt}'",
+                       config_btr_dt=f"'{btr_dt}'")
         self.update_namelist_at_runtime(options)
 
         run_model(self)
 
         if self.name == 'performance':
             # plot a few fields
-            plot_folder = '{}/plots'.format(self.work_dir)
+            plot_folder = f'{self.work_dir}/plots'
             if os.path.exists(plot_folder):
                 shutil.rmtree(plot_folder)
 

--- a/compass/ocean/tests/isomip_plus/isomip_plus.cfg
+++ b/compass/ocean/tests/isomip_plus/isomip_plus.cfg
@@ -37,6 +37,12 @@ iterations = 10
 # config options for ISOMIP+ test cases
 [isomip_plus]
 
+# The time step in s as a function of horizontal resolution in km
+dt_per_km = 120.
+
+# The barotropic time step in s as a function of horizontal resolution in km
+dt_btr_per_km = 5.
+
 # the lower bound of the domain in x km to avoid including needless amounts
 # of grounded ice
 x_min = 320.

--- a/compass/ocean/tests/isomip_plus/isomip_plus_test.py
+++ b/compass/ocean/tests/isomip_plus/isomip_plus_test.py
@@ -98,6 +98,7 @@ class IsomipPlusTest(TestCase):
         self.time_varying_forcing = time_varying_forcing
         self.time_varying_load = time_varying_load
         self.thin_film_present = thin_film_present
+        self.tidal_forcing = tidal_forcing
         self.planar = planar
 
         if resolution == int(resolution):
@@ -195,6 +196,8 @@ class IsomipPlusTest(TestCase):
         vertical_coordinate = self.vertical_coordinate
         thin_film_present = self.thin_film_present
         time_varying_load = self.time_varying_load
+        tidal_forcing = self.tidal_forcing
+
         config = self.config
         experiment = self.experiment
         planar = self.planar
@@ -267,6 +270,8 @@ class IsomipPlusTest(TestCase):
                 # default to 10 vertical levels instead of 36
                 config.set('vertical_grid', 'vert_levels', '10')
 
+        get_time_steps(config, resolution, thin_film_present, tidal_forcing)
+
     def validate(self):
         """
         Perform validation of variables
@@ -288,3 +293,24 @@ class IsomipPlusTest(TestCase):
              'accumulatedLandIceMass', 'accumulatedLandIceHeat']
         compare_variables(test_case=self, variables=variables,
                           filename1='performance/land_ice_fluxes.nc')
+
+
+def get_time_steps(config, resolution, thin_film_present, tidal_forcing):
+    """
+    Get the time step namelist replacements for the resolution
+
+    Parameters
+    ----------
+    resolution : float
+        The resolution in km
+    """
+
+    dt_per_km = 120.
+    if tidal_forcing or thin_film_present:
+        dt_per_km = min(dt_per_km, 10.)
+    config.set('isomip_plus', 'dt_per_km', f'{dt_per_km}')
+
+    dt_btr_per_km = min(dt_per_km / 5., 5.)
+    config.set('isomip_plus', 'dt_btr_per_km', f'{dt_btr_per_km}')
+
+    return

--- a/compass/ocean/tests/isomip_plus/isomip_plus_test.py
+++ b/compass/ocean/tests/isomip_plus/isomip_plus_test.py
@@ -28,6 +28,9 @@ class IsomipPlusTest(TestCase):
     vertical_coordinate : str
             The type of vertical coordinate (``z-star``, ``z-level``, etc.)
 
+    tidal_forcing: bool
+        Whether the case has tidal forcing
+
     time_varying_forcing : bool
         Whether the run includes time-varying land-ice forcing
 
@@ -270,7 +273,7 @@ class IsomipPlusTest(TestCase):
                 # default to 10 vertical levels instead of 36
                 config.set('vertical_grid', 'vert_levels', '10')
 
-        get_time_steps(config, resolution, thin_film_present, tidal_forcing)
+        _get_time_steps(config, resolution, thin_film_present, tidal_forcing)
 
     def validate(self):
         """
@@ -295,15 +298,7 @@ class IsomipPlusTest(TestCase):
                           filename1='performance/land_ice_fluxes.nc')
 
 
-def get_time_steps(config, resolution, thin_film_present, tidal_forcing):
-    """
-    Get the time step namelist replacements for the resolution
-
-    Parameters
-    ----------
-    resolution : float
-        The resolution in km
-    """
+def _get_time_steps(config, resolution, thin_film_present, tidal_forcing):
 
     dt_per_km = 120.
     if tidal_forcing or thin_film_present:

--- a/compass/ocean/tests/isomip_plus/namelist.tidal_forcing.forward
+++ b/compass/ocean/tests/isomip_plus/namelist.tidal_forcing.forward
@@ -3,3 +3,5 @@ config_use_tidal_forcing_tau = 100
 config_tidal_forcing_model = 'monochromatic'
 config_tidal_forcing_type = 'thickness_source'
 config_tidal_forcing_monochromatic_amp = 1.0
+config_disable_vel_coriolis = .true.
+config_land_ice_flux_mode = 'pressure_only'

--- a/compass/ocean/tests/isomip_plus/viz/__init__.py
+++ b/compass/ocean/tests/isomip_plus/viz/__init__.py
@@ -1,5 +1,7 @@
 import os
 
+import matplotlib.pyplot as plt
+import numpy as np
 import xarray
 from mpas_tools.io import write_netcdf
 
@@ -102,6 +104,24 @@ class Viz(Step):
             delssh = dsOut.ssh - dsOut.ssh[0, :]
             plotter.plot_horiz_series(delssh, 'delssh', 'delssh', True,
                                       cmap='cmo.curl', vmin=-1, vmax=1)
+
+        wct = dsOut.ssh + dsMesh.bottomDepth
+        idx_thin = np.logical_and(wct[0, :] > 1e-1,
+                                  wct[0, :] < 1)
+        wct_thin = wct[:, idx_thin]
+        wct_mean = wct_thin.mean(dim='nCells').values
+        time = dsOut.daysSinceStartOfSim.values
+        fig = plt.figure()
+        plt.plot(time, wct_mean, '.')
+        fig.set_xlabel('Time (days)')
+        fig.set_ylabel('Mean thickness of thin film (m)')
+        plt.savefig('wct_thin_t.png')
+        plt.close()
+
+        plotter.plot_horiz_series(wct, 'H', 'H',
+                                  True, vmin=min_column_thickness + 1e-10,
+                                  vmax=700, cmap_set_under='r',
+                                  cmap_scale='log')
 
         if os.path.exists(f'{sim_dir}/timeSeriesStatsMonthly.0001-01-01.nc'):
             ds = xarray.open_mfdataset(


### PR DESCRIPTION
This PR adds additional test cases with tidal forcing and a thin film for testing of the wetting and drying capability (i.e., grounding line motion). No changes to the documentation are needed. These tests are not added to the `wetdry` test suite; further testing of the wetting and drying scheme are needed to determine which `isomip_plus` tests are best suited for this purpose.

* [X] Document (in a comment titled `Testing` in this PR) any testing that was used to verify the changes