### PR TITLE
Allow culled mesh to be converted to CDF-5 format

### DIFF
--- a/compass/ocean/iceshelf.py
+++ b/compass/ocean/iceshelf.py
@@ -157,7 +157,7 @@ def adjust_ssh(variable, iteration_count, step, update_pio=True,
                 write_filename = out_filename
             write_netcdf(ds_out, write_filename)
             if convert_to_cdf5:
-                args = ['ncks', '-5', write_filename, out_filename]
+                args = ['ncks', '-O', '-5', write_filename, out_filename]
                 subprocess.check_call(args)
 
             # Write the largest change in SSH and its lon/lat to a file

--- a/compass/ocean/tests/global_ocean/global_ocean.cfg
+++ b/compass/ocean/tests/global_ocean/global_ocean.cfg
@@ -8,6 +8,8 @@ cull_mesh_cpus_per_task = 128
 cull_mesh_min_cpus_per_task = 1
 # maximum memory usage allowed (in MB)
 cull_mesh_max_memory = 1000
+# Whether to convert the culled mesh file to CDF5 format
+convert_culled_mesh_to_cdf5 = False
 
 
 # Options relate to adjusting the sea-surface height or land-ice pressure

--- a/compass/ocean/tests/global_ocean/mesh/rrs6to18/rrs6to18.cfg
+++ b/compass/ocean/tests/global_ocean/mesh/rrs6to18/rrs6to18.cfg
@@ -5,6 +5,13 @@
 grid_type = 80layerE3SMv1
 
 
+# options for spherical meshes
+[spherical_mesh]
+
+# Whether to convert the culled mesh file to CDF5 format
+convert_culled_mesh_to_cdf5 = True
+
+
 # Options relate to adjusting the sea-surface height or land-ice pressure
 # below ice shelves to they are dynamically consistent with one another
 [ssh_adjustment]


### PR DESCRIPTION
<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->

We will do this for large meshes like RRS6to18 for better performance.

This merge also fixes an `ncks` call for converting to CDF5 format but overwriting the file if it already exists.

<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [x] Document (in a comment titled `Testing` in this PR) any testing that was used to verify the changes

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->
