### PR TITLE
New Mesh: WCwISC14to60E3r1

### DIFF
--- a/compass/ocean/tests/global_ocean/dynamic_adjustment/__init__.py
+++ b/compass/ocean/tests/global_ocean/dynamic_adjustment/__init__.py
@@ -206,7 +206,8 @@ class DynamicAdjustment(ForwardTestCase):
         if previous_restart_filename is not None:
             step.add_input_file(filename=f'../{previous_restart_filename}')
         step.add_output_file(filename=f'../{restart_filename}')
-        step.add_output_file(filename='output.nc')
+        if step_name == 'simulation':
+            step.add_output_file(filename='output.nc')
 
         self.add_step(step)
 

--- a/compass/ocean/tests/global_ocean/mesh/wc14/wc14.cfg
+++ b/compass/ocean/tests/global_ocean/mesh/wc14/wc14.cfg
@@ -45,7 +45,7 @@ min_res = 14
 # the maximum (coarsest) resolution in the mesh, can be the same as min_res
 max_res = 60
 # The URL of the pull request documenting the creation of the mesh
-pull_request = https://github.com/MPAS-Dev/MPAS-Model/pull/628
+pull_request = https://github.com/MPAS-Dev/compass/pull/699
 
 
 # config options related to initial condition and diagnostics support files

--- a/compass/ocean/tests/global_ocean/mesh/wc14/wc14.cfg
+++ b/compass/ocean/tests/global_ocean/mesh/wc14/wc14.cfg
@@ -24,6 +24,9 @@ transition_levels = 28
 # options for global ocean testcases
 [global_ocean]
 
+# Maximum allowed Haney number for configurations with ice-shelf cavities
+rx1_max = 10
+
 # the approximate number of cells in the mesh
 approx_cell_count = 410000
 

--- a/compass/ocean/tests/global_ocean/metadata.py
+++ b/compass/ocean/tests/global_ocean/metadata.py
@@ -107,7 +107,7 @@ def add_mesh_and_init_metadata(output_filenames, config, init_filename):
             metadata = _get_metadata(dsInit, config)
 
         for filename in output_filenames:
-            if filename.endswith('.nc'):
+            if filename.endswith('.nc') and os.path.exists(filename):
                 args = ['ncks']
                 for key, value in metadata.items():
                     args.extend(['--glb_att_add', f'{key}={value}'])


### PR DESCRIPTION
<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->

Long name: WCwISC14to60kmL64E3SMv3r1

This version of the Water Cycle (WC) Regionally Refined Mesh (RRM) has the same distribution of resolution as in [WC14to60E2r3](https://github.com/MPAS-Dev/MPAS-Model/pull/628), including:
* 14 km resolution around North America and in the Arctic
* 60 km resolution at mid latitudes
* 30 km resolution at the equator
* 35 km resolution in the Southern Ocean

It matches the EC30to60 mesh except in the Southern Ocean and north Atlantic.  This mesh is with Ice Shelf Cavities (wIsC) and has 64 vertical levels, with surface levels distributed similarly to those in the E3SM v2 WC14 initial condition.

Mesh, initial condition, dynamic adjustment and files for E3SM are on Chrysalis at:
```
/lcrc/group/e3sm/ac.xylar/compass_1.2/chrysalis/e3smv3-meshes/wcwisc14to60e3r1
```

<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [ ] Document (in a comment titled `Testing` in this PR) any testing that was used to verify the changes

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->
