### PR TITLE
New Mesh: SO12to60E3r2

### DIFF
--- a/compass/ocean/tests/global_ocean/mesh/so12to60/so12to60.cfg
+++ b/compass/ocean/tests/global_ocean/mesh/so12to60/so12to60.cfg
@@ -43,13 +43,13 @@ mesh_description = MPAS Southern Ocean regionally refined mesh for E3SM version
 e3sm_version = 3
 # The revision number of the mesh, which should be incremented each time the
 # mesh is revised
-mesh_revision = 1
+mesh_revision = 2
 # the minimum (finest) resolution in the mesh
 min_res = 12
 # the maximum (coarsest) resolution in the mesh, can be the same as min_res
 max_res = 60
 # The URL of the pull request documenting the creation of the mesh
-pull_request = https://github.com/MPAS-Dev/compass/pull/669
+pull_request = https://github.com/MPAS-Dev/compass/pull/701
 
 
 # config options related to initial condition and diagnostics support files


### PR DESCRIPTION
Long name: SO12to60kmL64E3SMv3r2

This version of the Southern Ocean Regionally Refined Mesh (SORRM) has the same distribution of resolution as in
[SOwISC12to60E3r1](https://github.com/MPAS-Dev/compass/pull/669):
* 12 km resolution around Antarctica
* 45 km resolution at southern mid-latitudes
* 30 km resolution at the equator and the north Atlantic
* 60 km resolution in the north Pacific
* 35 km resolution in the Arctic

It matches the EC30to60 mesh except in the Southern Ocean and north Atlantic.

This version of the mesh does not include the ice-shelf cavities around Antarctica.

Mesh, initial condition, dynamic adjustment and files for E3SM are on Chrysalis at:
```
/lcrc/group/e3sm/ac.xylar/compass_1.2/chrysalis/e3smv3-meshes/so12to60e3r2
```

<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [ ] Document (in a comment titled `Testing` in this PR) any testing that was used to verify the changes
