### PR TITLE
Use pyremap 1.0.1

### DIFF
--- a/compass/ocean/mesh/remap_topography.py
+++ b/compass/ocean/mesh/remap_topography.py
@@ -2,7 +2,7 @@ import os
 
 import xarray as xr
 from mpas_tools.io import write_netcdf
-from pyremap import LatLonGridDescriptor, MpasCellMeshDescriptor, Remapper
+from pyremap import LatLonGridDescriptor, MpasMeshDescriptor, Remapper
 
 from compass.step import Step
 
@@ -108,8 +108,8 @@ class RemapTopography(Step):
         in_mesh_name = in_descriptor.meshName
 
         out_mesh_name = self.mesh_name
-        out_descriptor = MpasCellMeshDescriptor(fileName='base_mesh.nc',
-                                                meshName=self.mesh_name)
+        out_descriptor = MpasMeshDescriptor(fileName='base_mesh.nc',
+                                            meshName=self.mesh_name)
 
         mapping_file_name = \
             f'map_{in_mesh_name}_to_{out_mesh_name}_{method}.nc'

--- a/compass/ocean/tests/global_ocean/files_for_e3sm/diagnostic_maps.py
+++ b/compass/ocean/tests/global_ocean/files_for_e3sm/diagnostic_maps.py
@@ -4,8 +4,7 @@ import os
 import numpy
 import pyproj
 from pyremap import (
-    MpasCellMeshDescriptor,
-    MpasVertexMeshDescriptor,
+    MpasMeshDescriptor,
     ProjectionGridDescriptor,
     Remapper,
     get_lat_lon_descriptor,
@@ -206,7 +205,7 @@ def _make_mapping_file(mesh_name, out_grid_name, mesh_filename, out_descriptor,
 
     parallel_executable = config.get('parallel', 'parallel_executable')
 
-    in_descriptor = MpasCellMeshDescriptor(mesh_filename, mesh_name)
+    in_descriptor = MpasMeshDescriptor(mesh_filename, mesh_name)
 
     mapping_file_name = f'map_{mesh_name}_to_{out_grid_name}_bilinear.nc'
 
@@ -217,7 +216,7 @@ def _make_mapping_file(mesh_name, out_grid_name, mesh_filename, out_descriptor,
                                 esmf_parallel_exec=parallel_executable)
 
     # now the same on vertices (e.g. for streamfunctions)
-    in_descriptor = MpasVertexMeshDescriptor(mesh_filename, mesh_name)
+    in_descriptor = MpasMeshDescriptor(mesh_filename, mesh_name, vertices=True)
     mapping_file_name = \
         f'map_{mesh_name}_vertices_to_{out_grid_name}_bilinear.nc'
 

--- a/compass/ocean/tests/global_ocean/files_for_e3sm/remap_iceberg_climatology.py
+++ b/compass/ocean/tests/global_ocean/files_for_e3sm/remap_iceberg_climatology.py
@@ -3,7 +3,7 @@ import os
 import numpy as np
 import xarray as xr
 from mpas_tools.io import write_netcdf
-from pyremap import LatLonGridDescriptor, MpasCellMeshDescriptor, Remapper
+from pyremap import LatLonGridDescriptor, MpasMeshDescriptor, Remapper
 
 from compass.io import symlink
 from compass.ocean.tests.global_ocean.files_for_e3sm.files_for_e3sm_step import (  # noqa: E501
@@ -142,7 +142,7 @@ def remap_iceberg_climo(in_filename, mesh_filename, mesh_name,
     src_mesh_name = src_descriptor.meshName
 
     logger.info('Creating the destination MPAS mesh descriptor...')
-    dst_descriptor = MpasCellMeshDescriptor(mesh_filename, mesh_name)
+    dst_descriptor = MpasMeshDescriptor(mesh_filename, mesh_name)
 
     mapping_filename = \
         f'{mapping_directory}/map_{src_mesh_name}_to_{mesh_name}_{method}.nc'

--- a/compass/ocean/tests/global_ocean/files_for_e3sm/remap_sea_surface_salinity_restoring.py
+++ b/compass/ocean/tests/global_ocean/files_for_e3sm/remap_sea_surface_salinity_restoring.py
@@ -2,7 +2,7 @@ import os
 
 import xarray as xr
 from mpas_tools.io import write_netcdf
-from pyremap import LatLonGridDescriptor, MpasCellMeshDescriptor, Remapper
+from pyremap import LatLonGridDescriptor, MpasMeshDescriptor, Remapper
 
 from compass.io import symlink
 from compass.ocean.tests.global_ocean.files_for_e3sm.files_for_e3sm_step import (  # noqa: E501
@@ -111,7 +111,7 @@ def remap_sss(in_filename, mesh_filename, mesh_name, out_filename, logger,
     src_descriptor = LatLonGridDescriptor.read(fileName=in_filename)
     src_mesh_name = src_descriptor.meshName
 
-    dst_descriptor = MpasCellMeshDescriptor(mesh_filename, mesh_name)
+    dst_descriptor = MpasMeshDescriptor(mesh_filename, mesh_name)
 
     mapping_filename = \
         f'{mapping_directory}/map_{src_mesh_name}_to_{mesh_name}_{method}.nc'

--- a/compass/ocean/tests/global_ocean/files_for_e3sm/seaice_graph_partition.py
+++ b/compass/ocean/tests/global_ocean/files_for_e3sm/seaice_graph_partition.py
@@ -5,7 +5,7 @@ import numpy as np
 import xarray as xr
 from mpas_tools.io import write_netcdf
 from mpas_tools.logging import check_call
-from pyremap import MpasCellMeshDescriptor, Remapper
+from pyremap import MpasMeshDescriptor, Remapper
 
 from compass.io import symlink
 from compass.ocean.tests.global_ocean.files_for_e3sm.files_for_e3sm_step import (  # noqa: E501
@@ -154,8 +154,8 @@ def _make_mapping_file(in_mesh_filename, in_mesh_name, out_mesh_filename,
 
     mapping_file_name = f'map_{in_mesh_name}_to_{out_mesh_name}_{method}.nc'
 
-    in_descriptor = MpasCellMeshDescriptor(in_mesh_filename, in_mesh_name)
-    out_descriptor = MpasCellMeshDescriptor(out_mesh_filename, out_mesh_name)
+    in_descriptor = MpasMeshDescriptor(in_mesh_filename, in_mesh_name)
+    out_descriptor = MpasMeshDescriptor(out_mesh_filename, out_mesh_name)
 
     remapper = Remapper(in_descriptor, out_descriptor, mapping_file_name)
 

--- a/compass/ocean/tests/global_ocean/init/remap_ice_shelf_melt.py
+++ b/compass/ocean/tests/global_ocean/init/remap_ice_shelf_melt.py
@@ -4,7 +4,7 @@ import pyproj
 import xarray as xr
 from mpas_tools.cime.constants import constants
 from mpas_tools.io import write_netcdf
-from pyremap import MpasCellMeshDescriptor, ProjectionGridDescriptor, Remapper
+from pyremap import MpasMeshDescriptor, ProjectionGridDescriptor, Remapper
 
 from compass.step import Step
 
@@ -172,7 +172,7 @@ def remap_adusumilli(in_filename, mesh_filename, mesh_name,
     write_netcdf(ds, 'Adusumilli_2020_ismf_2010-2018_v0.nc')
     logger.info('done.')
 
-    out_descriptor = MpasCellMeshDescriptor(mesh_filename, mesh_name)
+    out_descriptor = MpasMeshDescriptor(mesh_filename, mesh_name)
 
     mapping_filename = \
         f'{mapping_directory}/map_{in_grid_name}_to_{mesh_name}.nc'

--- a/conda/compass_env/spec-file.template
+++ b/conda/compass_env/spec-file.template
@@ -32,7 +32,7 @@ otps=2021.10
 progressbar2
 pyamg >=4.2.2
 pyproj
-pyremap>=1.0.1,<2.0.0
+pyremap=1.0.1
 requests
 ruamel.yaml
 # having pip check problems with this version

--- a/conda/compass_env/spec-file.template
+++ b/conda/compass_env/spec-file.template
@@ -32,7 +32,7 @@ otps=2021.10
 progressbar2
 pyamg >=4.2.2
 pyproj
-pyremap>=1.1.0,<2.0.0
+pyremap>=1.0.1,<2.0.0
 requests
 ruamel.yaml
 # having pip check problems with this version


### PR DESCRIPTION
<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->
I changed my mind about #698.  We should not make this change until after the E3SM v3 meshes are done because we risk having meshes without ice-shelf cavities not matching meshes with them.

I will revive #698 once we're done with E3SM v3 meshes.  For now, we will stick with pyremap 1.0.1.