### PR TITLE
Update to 1.2.0-alpha.7

### DIFF
--- a/compass/version.py
+++ b/compass/version.py
@@ -1,1 +1,1 @@
-__version__ = '1.2.0-alpha.6'
+__version__ = '1.2.0-alpha.7'

--- a/conda/bootstrap.py
+++ b/conda/bootstrap.py
@@ -448,6 +448,7 @@ def build_spack_env(config, update_spack, machine, compiler, mpi,  # noqa: C901
             f'@{parallelio}+pnetcdf~timing"')
 
     if albany != 'None':
+        specs.append(f'"trilinos-for-albany@{albany}"')
         specs.append(f'"albany@{albany}+mpas"')
 
     yaml_template = f'{spack_template_path}/{machine}_{compiler}_{mpi}.yaml'

--- a/conda/compass_env/spec-file.template
+++ b/conda/compass_env/spec-file.template
@@ -18,7 +18,7 @@ jigsawpy=0.3.3
 jupyter
 lxml
 {% if include_mache %}
-mache=1.16.0
+mache=1.17.0
 {% endif %}
 matplotlib-base
 metis

--- a/conda/configure_compass_env.py
+++ b/conda/configure_compass_env.py
@@ -101,7 +101,7 @@ def main():
     if local_mache:
         mache = ''
     else:
-        mache = '"mache=1.16.0"'
+        mache = '"mache=1.17.0"'
 
     setup_install_env(env_name, activate_base, args.use_local, logger,
                       args.recreate, conda_base, mache)

--- a/conda/default.cfg
+++ b/conda/default.cfg
@@ -20,7 +20,7 @@ python = 3.10
 mpi = nompi
 
 # the version of various packages to include if using spack
-albany = develop
+albany = compass-2023-08-03
 # cmake newer than 3.23.0 needed for Trilinos
 cmake = 3.23.0:
 esmf = 8.4.2

--- a/conda/recipe/meta.yaml
+++ b/conda/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "compass" %}
-{% set version = "1.2.0alpha.6" %}
+{% set version = "1.2.0alpha.7" %}
 {% set build = 0 %}
 
 {% if mpi == "nompi" %}
@@ -54,7 +54,7 @@ requirements:
     - jigsawpy 0.3.3
     - jupyter
     - lxml
-    - mache 1.16.0
+    - mache 1.17.0
     - matplotlib-base
     - metis
     - mpas_tools 0.26.0


### PR DESCRIPTION
This merge also updates mache to 1.17.0, which updates support for Chicoma.

<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [x] Document (in a comment titled `Testing` in this PR) any testing that was used to verify the changes

## Deployed

MPAS-Ocean with `pr`:
- [x] Anvil
  - [x] intel and impi
  - [x] intel and openmpi
  - [x] gnu and openmpi
  - [x] gnu and mvapich
- [x] Chicoma
  - [x] gnu and mpich
- [x] Chrysalis
  - [x] intel and openmpi
  - [x] gnu and openmpi
- [x] Compy
  - [x] intel and impi - all tests pass except those documented in #502 
- [x] Perlmutter 
  - [x] gnu and mpich

MALI with `full_integration`:
- [x] Chicoma
  - [x] gnu and mpich
- [x] Chrysalis 
  - [x] gnu and openmpi - humboldt tests currently failing because of permission issues 
- [x] Perlmutter
  - [x] gnu and mpich

MPAS-Ocean with `nonhydro` - warnings about namelist options reported in #712:
- [x] Anvil
  - [x] intel and impi
  - [x] gnu and openmpi
- [x] Chicoma
  - [x] gnu and mpich
- [x] Chrysalis
  - [x] intel and openmpi
  - [x] gnu and openmpi
- [x] Compy
  - [x] intel and impi
- [x] Perlmutter
  - [x] gnu and mpich
