### PR TITLE
Fix ISOMIP+ plotting

### DIFF
--- a/compass/ocean/tests/isomip_plus/viz/plot.py
+++ b/compass/ocean/tests/isomip_plus/viz/plot.py
@@ -929,7 +929,7 @@ def _compute_cell_patches(dsMesh, mask):
         vertices[:, 0] = 1e-3 * xVertex[vertexIndices]
         vertices[:, 1] = 1e-3 * yVertex[vertexIndices]
 
-        polygon = Polygon(vertices, True)
+        polygon = Polygon(vertices, closed=True)
         patches.append(polygon)
 
     p = PatchCollection(patches, alpha=1.)


### PR DESCRIPTION
We need to make what was an argument to `Polygon` before a keyword argument `closed=True` for compatibility with more recent versions of matplotlib.

<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->

<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [x] Document (in a comment titled `Testing` in this PR) any testing that was used to verify the changes

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->
