### PR TITLE
New Mesh: RRS6to18E3r2

### DIFF
--- a/compass/ocean/tests/global_ocean/mesh/rrs6to18/dynamic_adjustment.yaml
+++ b/compass/ocean/tests/global_ocean/mesh/rrs6to18/dynamic_adjustment.yaml
@@ -63,6 +63,6 @@ dynamic_adjustment:
       run_duration: 18_00:00:00
       output_interval: 10_00:00:00
       restart_interval: 06_00:00:00
-      dt: 00:06:00
-      btr_dt: 00:00:12
+      dt: 00:05:00
+      btr_dt: 00:00:10
       Rayleigh_damping_coeff: None

--- a/compass/ocean/tests/global_ocean/mesh/rrs6to18/rrs6to18.cfg
+++ b/compass/ocean/tests/global_ocean/mesh/rrs6to18/rrs6to18.cfg
@@ -59,7 +59,7 @@ min_res = 6
 # the maximum (coarsest) resolution in the mesh, can be the same as min_res
 max_res = 18
 # The URL of the pull request documenting the creation of the mesh
-pull_request = <<<Missing>>>
+pull_request = https://github.com/MPAS-Dev/compass/pull/668
 
 
 # config options related to remapping topography to an MPAS-Ocean mesh

--- a/compass/ocean/tests/global_ocean/mesh/rrs6to18/rrs6to18.cfg
+++ b/compass/ocean/tests/global_ocean/mesh/rrs6to18/rrs6to18.cfg
@@ -53,13 +53,13 @@ mesh_description = MPAS Eddy Closure mesh for E3SM version ${e3sm_version} with
 e3sm_version = 3
 # The revision number of the mesh, which should be incremented each time the
 # mesh is revised
-mesh_revision = 1
+mesh_revision = 2
 # the minimum (finest) resolution in the mesh
 min_res = 6
 # the maximum (coarsest) resolution in the mesh, can be the same as min_res
 max_res = 18
 # The URL of the pull request documenting the creation of the mesh
-pull_request = https://github.com/MPAS-Dev/compass/pull/668
+pull_request = https://github.com/MPAS-Dev/compass/pull/706
 
 
 # config options related to remapping topography to an MPAS-Ocean mesh


### PR DESCRIPTION
<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->

Long name: RRS6to18L80E3SMv3r2

This RRS (Rossby-radius scaled) mesh has:
* 6 km resolution near the poles
* 18 km resolution at the equator

Mesh, initial condition, dynamic adjustment and files for E3SM will soon on Chrysalis at:
```
/lcrc/group/e3sm/ac.xylar/compass_1.2/chrysalis/e3smv3-meshes/rrs6to18e3r2
```

<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [ ] Document (in a comment titled `Testing` in this PR) any testing that was used to verify the changes

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->
