### PR TITLE
Fix dynamic adjustment time parsing for OSX

### DIFF
--- a/compass/ocean/tests/global_ocean/dynamic_adjustment/__init__.py
+++ b/compass/ocean/tests/global_ocean/dynamic_adjustment/__init__.py
@@ -1,6 +1,7 @@
 import glob
 import importlib.resources
 import os
+import platform
 from datetime import datetime, timedelta
 
 import xarray as xr
@@ -217,7 +218,10 @@ def _get_restart_time(start_time, run_duration):
     start = datetime.strptime(start_time, '%Y-%m-%d_%H:%M:%S')
     duration = _parse_duration(run_duration)
     restart = start + duration
-    restart_time = restart.strftime('%4Y-%m-%d_%H:%M:%S')
+    if platform.system() == 'Darwin':
+        restart_time = restart.strftime('%Y-%m-%d_%H:%M:%S')
+    else:
+        restart_time = restart.strftime('%4Y-%m-%d_%H:%M:%S')
     return restart_time
 
 


### PR DESCRIPTION
<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->

As discussed in https://github.com/python/cpython/issues/57514, there are discrepancies in the time parsing libraries on different systems.  This PR attempts to find a solution that works on OSX as well as the Linux systems we usually use.

<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [ ] Document (in a comment titled `Testing` in this PR) any testing that was used to verify the changes

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->
