### PR TITLE
New Mesh: Icos30E3r3

### DIFF
--- a/compass/ocean/tests/global_ocean/mesh/qu/qu.cfg
+++ b/compass/ocean/tests/global_ocean/mesh/qu/qu.cfg
@@ -40,13 +40,13 @@ mesh_description = MPAS quasi-uniform mesh for E3SM version ${e3sm_version} at
 e3sm_version = 3
 # The revision number of the mesh, which should be incremented each time the
 # mesh is revised
-mesh_revision = 2
+mesh_revision = 3
 # the minimum (finest) resolution in the mesh
 min_res = ${qu_resolution}
 # the maximum (coarsest) resolution in the mesh, can be the same as min_res
 max_res = ${qu_resolution}
 # The URL of the pull request documenting the creation of the mesh
-pull_request = https://github.com/MPAS-Dev/compass/pull/691
+pull_request = https://github.com/MPAS-Dev/compass/pull/710
 
 # the resolution of the QU or Icos mesh in km
 qu_resolution = 120


### PR DESCRIPTION
<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->

Long name: Icos30L64E3SMv3r3

This Icosahedral (Icos) mesh is made by subdividing an icosahedron and has nearly uniform 30 km resolution.

Mesh, initial condition, dynamic adjustment and files for E3SM are on Chrysalis at:
```
/lcrc/group/e3sm/ac.xylar/compass_1.2/chrysalis/e3smv3-meshes/icos30e3r3
```

<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [x] Document (in a comment titled `Testing` in this PR) any testing that was used to verify the changes

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->
