### PR TITLE
Temporary fix to reinstall mamba=1.5.1

### DIFF
--- a/conda/compass_env/load_compass.template
+++ b/conda/compass_env/load_compass.template
@@ -1,6 +1,7 @@
 echo Loading conda environment
 source {{ conda_base }}/etc/profile.d/conda.sh
-conda activate {{ compass_env }}
+source {{ conda_base }}/etc/profile.d/mamba.sh
+mamba activate {{ compass_env }}
 echo Done.
 echo
 

--- a/conda/shared.py
+++ b/conda/shared.py
@@ -181,6 +181,8 @@ def install_miniconda(conda_base, activate_base, logger):
     check_call(commands, logger=logger)
 
     commands = f'{activate_base} && ' \
+               f'conda install -y --force-reinstall' \
+               f'   mamba=1.5.1 conda=23.7.4 && ' \
                f'mamba update -y --all && ' \
                f'mamba init'
 


### PR DESCRIPTION
There is an issue where the latest mamba isn't compatible with the latest conda but locally cached versions of the mamba package don't know this.  The mamba package has been patched to a reinstall will fix teh issue. This should be fixed more permanently in mamba 1.5.2, which should be released soon.

<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->

<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [ ] Document (in a comment titled `Testing` in this PR) any testing that was used to verify the changes

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->
