### PR TITLE
New Mesh: ECwISC30to60E3r4

### DIFF
--- a/compass/ocean/tests/global_ocean/global_ocean.cfg
+++ b/compass/ocean/tests/global_ocean/global_ocean.cfg
@@ -47,6 +47,11 @@ btr_dt_per_km = 1.5
 
 # Maximum allowed Haney number for configurations with ice-shelf cavities
 rx1_max = 20
+# the number of iterations of topography smoothing
+topo_smooth_iterations = 0
+# the weight given to the central cell during each iteration of smoothing,
+# where the n cellsOnCell (neighbors) are given a weight (1-weight)/n.
+topo_smooth_weight = 0.9
 
 # number of cores to use
 init_ntasks = 36

--- a/compass/ocean/tests/global_ocean/init/initial_state.py
+++ b/compass/ocean/tests/global_ocean/init/initial_state.py
@@ -139,9 +139,21 @@ class InitialState(Step):
         Get resources at setup from config options
         """
         self._get_resources()
-        rx1_max = self.config.getfloat('global_ocean', 'rx1_max')
-        self.add_namelist_options({'config_rx1_max': f'{rx1_max}'},
-                                  mode='init')
+        section = self.config['global_ocean']
+        rx1_max = section.getfloat('rx1_max')
+        topo_smooth_iterations = section.getint('topo_smooth_iterations')
+        topo_smooth_weight = section.getfloat('topo_smooth_weight')
+
+        options = {
+            'config_rx1_max':
+                f'{rx1_max}',
+            'config_global_ocean_topography_smooth_iterations':
+                f'{topo_smooth_iterations}',
+            'config_global_ocean_topography_smooth_weight':
+                f'{topo_smooth_weight}',
+        }
+
+        self.add_namelist_options(options, mode='init')
 
     def constrain_resources(self, available_resources):
         """

--- a/compass/ocean/tests/global_ocean/init/namelist.init
+++ b/compass/ocean/tests/global_ocean/init/namelist.init
@@ -53,4 +53,3 @@ config_global_ocean_depth_conversion_factor = 1.0
 config_global_ocean_minimum_depth = 10
 config_global_ocean_deepen_critical_passages = .false.
 config_block_decomp_file_prefix = 'graph.info.part.'
-config_global_ocean_topography_smooth_iterations = 0

--- a/compass/ocean/tests/global_ocean/mesh/ec30to60/dynamic_adjustment.yaml
+++ b/compass/ocean/tests/global_ocean/mesh/ec30to60/dynamic_adjustment.yaml
@@ -7,30 +7,30 @@ dynamic_adjustment:
       run_duration: 10_00:00:00
       output_interval: 10_00:00:00
       restart_interval: 10_00:00:00
-      dt: 00:15:00
-      btr_dt: 00:00:30
+      dt: 00:10:00
+      btr_dt: 00:00:20
       Rayleigh_damping_coeff: 1.0e-4
 
     damped_adjustment_2:
-      run_duration: 10_00:00:00
+      run_duration: 90_00:00:00
       output_interval: 10_00:00:00
       restart_interval: 10_00:00:00
-      dt: 00:15:00
-      btr_dt: 00:00:30
+      dt: 00:10:00
+      btr_dt: 00:00:20
       Rayleigh_damping_coeff: 1.0e-5
 
     damped_adjustment_3:
       run_duration: 10_00:00:00
       output_interval: 10_00:00:00
       restart_interval: 10_00:00:00
-      dt: 00:20:00
-      btr_dt: 00:00:40
+      dt: 00:10:00
+      btr_dt: 00:00:20
       Rayleigh_damping_coeff: 1.0e-6
 
     simulation:
       run_duration: 10_00:00:00
       output_interval: 10_00:00:00
       restart_interval: 10_00:00:00
-      dt: 00:30:00
-      btr_dt: 00:01:00
+      dt: 00:10:00
+      btr_dt: 00:02:00
       Rayleigh_damping_coeff: None

--- a/compass/ocean/tests/global_ocean/mesh/ec30to60/ec30to60.cfg
+++ b/compass/ocean/tests/global_ocean/mesh/ec30to60/ec30to60.cfg
@@ -26,6 +26,11 @@ transition_levels = 28
 
 # Maximum allowed Haney number for configurations with ice-shelf cavities
 rx1_max = 10
+# the number of iterations of topography smoothing
+topo_smooth_iterations = 65
+# the weight given to the central cell during each iteration of smoothing,
+# where the n cellsOnCell (neighbors) are given a weight (1-weight)/n.
+topo_smooth_weight = 0.6
 
 # the approximate number of cells in the mesh
 approx_cell_count = 240000
@@ -37,15 +42,16 @@ prefix = EC
 mesh_description = MPAS Eddy Closure mesh for E3SM version ${e3sm_version} with
                    enhanced resolution around the equator (30 km), South pole
                    (35 km), Greenland (${min_res} km), ${max_res}-km resolution
-                   at mid latitudes, and <<<levels>>> vertical levels
+                   at mid latitudes, and <<<levels>>> vertical levels.
+                   Topography has been smoothed over ~6 grid cell (180-360 km).
 # E3SM version that the mesh is intended for
 e3sm_version = 3
 # The revision number of the mesh, which should be incremented each time the
 # mesh is revised
-mesh_revision = 2
+mesh_revision = 4
 # the minimum (finest) resolution in the mesh
 min_res = 30
 # the maximum (coarsest) resolution in the mesh, can be the same as min_res
 max_res = 60
 # The URL of the pull request documenting the creation of the mesh
-pull_request = https://github.com/MPAS-Dev/compass/pull/689
+pull_request = https://github.com/MPAS-Dev/compass/pull/715

--- a/compass/ocean/tests/global_ocean/streams.forward
+++ b/compass/ocean/tests/global_ocean/streams.forward
@@ -18,6 +18,7 @@
     <var name="xtime"/>
     <var name="normalVelocity"/>
     <var name="layerThickness"/>
+    <var name="kineticEnergyCell"/>
 </stream>
 
 <stream name="forcing_data"


### PR DESCRIPTION
<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->

Long name: ECwISC30to60L64E3SMv3r4

As with previous versions of the mesh, this Eddy Closure (EC) mesh has:
* 30 km resolution at the equator
* 60 km resolution at mid latitudes
* 35 km resolution near the poles

This mesh differs from ECwISC30to60E3r2 (#689) only in having topography smoothing of approximately 6 grid cells (180-360 km), see comment below.

The `mesh` test case is a symlink to that of the `ECwISC30to60E3r2` to guarantee that they are identical.

Initial condition, dynamic adjustment and files for E3SM will be on Chrysalis at:
```
/lcrc/group/e3sm/ac.xylar/compass_1.2/chrysalis/e3smv3-meshes/ecwisc30to60e3r4
```

<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [ ] Document (in a comment titled `Testing` in this PR) any testing that was used to verify the changes

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->
