### PR TITLE
Fix conversion to absolute paths in config files

### DIFF
--- a/compass/config.py
+++ b/compass/config.py
@@ -38,5 +38,8 @@ class CompassConfigParser(MpasConfigParser):
             if not config.has_section(section):
                 continue
             for option, value in config.items(section):
-                value = os.path.abspath(value)
-                config.set(section, option, value)
+                # not safe to make paths that start with other config options
+                # into absolute paths
+                if not value.startswith('$'):
+                    value = os.path.abspath(value)
+                    config.set(section, option, value)


### PR DESCRIPTION
We don't want to do this for config options that start with other config options.

Backport of https://github.com/E3SM-Project/polaris/pull/136

<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->

<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [x] Document (in a comment titled `Testing` in this PR) any testing that was used to verify the changes

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->
