### PR TITLE
Remove temporary fix for mamba 1.5.1

### DIFF
--- a/conda/shared.py
+++ b/conda/shared.py
@@ -181,8 +181,6 @@ def install_miniconda(conda_base, activate_base, logger):
     check_call(commands, logger=logger)
 
     commands = f'{activate_base} && ' \
-               f'conda install -y --force-reinstall' \
-               f'   mamba=1.5.1 conda=23.7.4 && ' \
                f'mamba update -y --all && ' \
                f'mamba init'
 


### PR DESCRIPTION
A temporary constraint on conda and mamba is no longer needed, now that `mamba` 1.5.2 is available and compatible with the latest `conda`.