### PR TITLE
Fixup ISOMIP+ land ice pressure

### DIFF
--- a/compass/ocean/iceshelf.py
+++ b/compass/ocean/iceshelf.py
@@ -40,40 +40,6 @@ def compute_land_ice_pressure_from_thickness(land_ice_thickness, modify_mask,
     return land_ice_pressure
 
 
-def compute_land_ice_density_from_draft(land_ice_draft, land_ice_thickness,
-                                        floating_mask, ref_density=None):
-    """
-    Compute the spatially-averaged ice density needed to match the ice draft
-
-    Parameters
-    ----------
-    land_ice_draft : xarray.DataArray
-        The ice draft (sea surface height)
-
-    land_ice_thickness: xarray.DataArray
-        The ice thickness
-
-    floating_mask : xarray.DataArray
-        A mask that is 1 where the ice is assumed in hydrostatic equilibrium
-
-    ref_density : float, optional
-        A reference density for seawater displaced by the ice shelf
-
-    Returns
-    -------
-    land_ice_density: float
-        The ice density
-    """
-    if ref_density is None:
-        ref_density = constants['SHR_CONST_RHOSW']
-    land_ice_draft = numpy.where(floating_mask, land_ice_draft, numpy.nan)
-    land_ice_thickness = numpy.where(floating_mask, land_ice_thickness,
-                                     numpy.nan)
-    land_ice_density = \
-        numpy.nanmean(-ref_density * land_ice_draft / land_ice_thickness)
-    return land_ice_density
-
-
 def compute_land_ice_pressure_from_draft(land_ice_draft, modify_mask,
                                          ref_density=None):
     """

--- a/compass/ocean/iceshelf.py
+++ b/compass/ocean/iceshelf.py
@@ -14,7 +14,7 @@ from compass.model import partition, run_model
 def compute_land_ice_pressure_from_thickness(land_ice_thickness, modify_mask,
                                              land_ice_density=None):
     """
-    Compute the pressure from and overlying ice shelf
+    Compute the pressure from an overlying ice shelf from ice thickness
 
     Parameters
     ----------
@@ -43,7 +43,7 @@ def compute_land_ice_pressure_from_thickness(land_ice_thickness, modify_mask,
 def compute_land_ice_pressure_from_draft(land_ice_draft, modify_mask,
                                          ref_density=None):
     """
-    Compute the pressure from and overlying ice shelf
+    Compute the pressure from an overlying ice shelf from ice draft
 
     Parameters
     ----------

--- a/compass/ocean/iceshelf.py
+++ b/compass/ocean/iceshelf.py
@@ -11,34 +11,34 @@ from compass.io import symlink
 from compass.model import partition, run_model
 
 
-def compute_land_ice_pressure_and_draft(ssh, modify_mask, ref_density):
+def compute_land_ice_pressure_from_draft(land_ice_draft, modify_mask,
+                                         ref_density=None):
     """
-    Compute the pressure from and overlying ice shelf and the ice-shelf draft
+    Compute the pressure from and overlying ice shelf
 
     Parameters
     ----------
-    ssh : xarray.DataArray
-        The sea surface height (the ice draft)
+    land_ice_draft : xarray.DataArray
+        The ice draft (sea surface height)
 
     modify_mask : xarray.DataArray
         A mask that is 1 where ``landIcePressure`` can be deviate from 0
 
-    ref_density : float
+    ref_density : float, optional
         A reference density for seawater displaced by the ice shelf
 
     Returns
     -------
-    landIcePressure : xarray.DataArray
+    land_ice_pressure : xarray.DataArray
         The pressure from the overlying land ice on the ocean
-
-    landIceDraft : xarray.DataArray
-        The ice draft, equal to the initial ``ssh``
     """
     gravity = constants['SHR_CONST_G']
-    landIcePressure = \
-        modify_mask * numpy.maximum(-ref_density * gravity * ssh, 0.)
-    landIceDraft = ssh
-    return landIcePressure, landIceDraft
+    if ref_density is None:
+        ref_density = constants['SHR_CONST_RHOSW']
+    land_ice_pressure = \
+        modify_mask * numpy.maximum(-ref_density * gravity * land_ice_draft,
+                                    0.)
+    return land_ice_pressure
 
 
 def adjust_ssh(variable, iteration_count, step, update_pio=True,

--- a/compass/ocean/tests/ice_shelf_2d/initial_state.py
+++ b/compass/ocean/tests/ice_shelf_2d/initial_state.py
@@ -5,7 +5,7 @@ from mpas_tools.io import write_netcdf
 from mpas_tools.mesh.conversion import convert, cull
 from mpas_tools.planar_hex import make_planar_hex_mesh
 
-from compass.ocean.iceshelf import compute_land_ice_pressure_and_draft
+from compass.ocean.iceshelf import compute_land_ice_pressure_from_draft
 from compass.ocean.vertical import init_vertical_coord
 from compass.step import Step
 
@@ -103,8 +103,10 @@ class InitialState(Step):
         landIceFloatingMask = landIceMask.copy()
 
         ref_density = constants['SHR_CONST_RHOSW']
-        landIcePressure, landIceDraft = compute_land_ice_pressure_and_draft(
-            ssh=ds.ssh, modify_mask=modify_mask, ref_density=ref_density)
+        landIceDraft = ds.ssh
+        landIcePressure = compute_land_ice_pressure_from_draft(
+            land_ice_draft=landIceDraft, modify_mask=modify_mask,
+            ref_density=ref_density)
 
         salinity = surface_salinity + ((bottom_salinity - surface_salinity) *
                                        (ds.zMid / (-bottom_depth)))

--- a/compass/ocean/tests/isomip_plus/geom.py
+++ b/compass/ocean/tests/isomip_plus/geom.py
@@ -111,11 +111,12 @@ def interpolate_geom(ds_mesh, ds_geom, min_ocean_fraction, thin_film_present):
                                   ds_geom.landIceGroundedFraction)
 
     # mask the topography to the ocean region before interpolation
-    for var in ['Z_bed', 'Z_ice_draft', 'landIceFraction',
+    for var in ['Z_bed', 'Z_ice_surface', 'Z_ice_draft', 'landIceFraction',
                 'landIceFloatingFraction', 'smoothedDraftMask']:
         ds_geom[var] = ds_geom[var] * ds_geom['oceanFraction']
 
     fields = {'bottomDepthObserved': 'Z_bed',
+              'landIceThickness': 'iceThickness',
               'ssh': 'Z_ice_draft',
               'oceanFracObserved': 'oceanFraction',
               'landIceFraction': 'landIceFraction',

--- a/compass/ocean/tests/isomip_plus/geom.py
+++ b/compass/ocean/tests/isomip_plus/geom.py
@@ -157,7 +157,7 @@ def _get_geom_fields(ds_geom, ds_mesh, thin_film_present):
     y_cell = ds_mesh.yIsomipCell.values
 
     if thin_film_present:
-        ocean_fraction = - ds_geom['landFraction'] + 1.0
+        ocean_fraction = xarray.where(ds_geom['Z_bed'] > 0., 0., 1.)
     else:
         ocean_fraction = (ds_geom['landIceFloatingFraction'] +
                           ds_geom['openOceanFraction'])

--- a/compass/ocean/tests/isomip_plus/initial_state.py
+++ b/compass/ocean/tests/isomip_plus/initial_state.py
@@ -7,7 +7,7 @@ import xarray as xr
 from mpas_tools.cime.constants import constants
 from mpas_tools.io import write_netcdf
 
-from compass.ocean.iceshelf import compute_land_ice_pressure_and_draft
+from compass.ocean.iceshelf import compute_land_ice_pressure_from_draft
 from compass.ocean.tests.isomip_plus.geom import interpolate_geom
 from compass.ocean.tests.isomip_plus.viz.plot import MoviePlotter
 from compass.ocean.vertical import init_vertical_coord
@@ -126,8 +126,10 @@ class InitialState(Step):
         ds['landIceFraction'] = xr.where(mask, ds.landIceFraction, 0.)
 
         ref_density = constants['SHR_CONST_RHOSW']
-        landIcePressure, landIceDraft = compute_land_ice_pressure_and_draft(
-            ssh=ds.ssh, modify_mask=ds.ssh < 0., ref_density=ref_density)
+        landIceDraft = ds.ssh
+        landIcePressure = compute_land_ice_pressure_from_draft(
+            land_ice_draft=landIceDraft, modify_mask=ds.ssh < 0.,
+            ref_density=ref_density)
 
         ds['landIcePressure'] = landIcePressure
         ds['landIceDraft'] = landIceDraft

--- a/compass/ocean/tests/isomip_plus/initial_state.py
+++ b/compass/ocean/tests/isomip_plus/initial_state.py
@@ -147,6 +147,7 @@ class InitialState(Step):
                 land_ice_draft=land_ice_draft, modify_mask=land_ice_draft < 0.)
 
         ds['landIcePressure'] = land_ice_pressure
+        ds['landIceDraft'] = land_ice_draft
 
         section = config['isomip_plus']
 

--- a/compass/ocean/tests/isomip_plus/initial_state.py
+++ b/compass/ocean/tests/isomip_plus/initial_state.py
@@ -248,16 +248,19 @@ class InitialState(Step):
                                sectionY=section_y, dsMesh=ds, ds=ds,
                                showProgress=show_progress)
 
-        ds['oceanFracObserved'] = \
+        ssh = ds['ssh'].expand_dims(dim='Time', axis=0)
+        oceanFracObserved = \
             ds['oceanFracObserved'].expand_dims(dim='Time', axis=0)
-        ds['landIceThickness'] = \
+        oceanFracObserved = \
+            ds['oceanFracObserved'].expand_dims(dim='Time', axis=0)
+        landIcePressure = \
+            ds['landIcePressure'].expand_dims(dim='Time', axis=0)
+        landIceThickness = \
             ds['landIceThickness'].expand_dims(dim='Time', axis=0)
-        ds['landIceGroundedFraction'] = \
+        landIceGroundedFraction = \
             ds['landIceGroundedFraction'].expand_dims(dim='Time', axis=0)
-        ds['bottomDepth'] = ds['bottomDepth'].expand_dims(dim='Time', axis=0)
-        ds['totalColThickness'] = ds['ssh']
-        ds['totalColThickness'].values = \
-            ds['layerThickness'].sum(dim='nVertLevels')
+        bottomDepth = ds['bottomDepth'].expand_dims(dim='Time', axis=0)
+        totalColThickness = ds.layerThickness.sum(dim='nVertLevels')
         tol = 1e-10
         plotter.plot_horiz_series(ds.landIceMask,
                                   'landIceMask', 'landIceMask',
@@ -265,23 +268,22 @@ class InitialState(Step):
         plotter.plot_horiz_series(ds.landIceFloatingMask,
                                   'landIceFloatingMask', 'landIceFloatingMask',
                                   True)
-        plotter.plot_horiz_series(ds.landIcePressure,
+        plotter.plot_horiz_series(landIcePressure,
                                   'landIcePressure', 'landIcePressure',
                                   True, vmin=1e5, vmax=1e7, cmap_scale='log')
-        plotter.plot_horiz_series(ds.landIceThickness,
+        plotter.plot_horiz_series(landIceThickness,
                                   'landIceThickness', 'landIceThickness',
                                   True, vmin=0, vmax=1e3)
-        plotter.plot_horiz_series(ds.ssh,
-                                  'ssh', 'ssh',
+        plotter.plot_horiz_series(ssh, 'ssh', 'ssh',
                                   True, vmin=-700, vmax=0)
-        plotter.plot_horiz_series(ds.bottomDepth,
+        plotter.plot_horiz_series(bottomDepth,
                                   'bottomDepth', 'bottomDepth',
                                   True, vmin=0, vmax=700)
-        plotter.plot_horiz_series(ds.ssh + ds.bottomDepth,
+        plotter.plot_horiz_series(ds.ssh + bottomDepth,
                                   'H', 'H', True,
                                   vmin=min_column_thickness + tol, vmax=700,
                                   cmap_set_under='r', cmap_scale='log')
-        plotter.plot_horiz_series(ds.totalColThickness,
+        plotter.plot_horiz_series(totalColThickness,
                                   'totalColThickness', 'totalColThickness',
                                   True, vmin=min_column_thickness + 1e-10,
                                   vmax=700, cmap_set_under='r')
@@ -296,13 +298,13 @@ class InitialState(Step):
                                   True, vmin=0 + tol, vmax=1 - tol,
                                   cmap='cmo.balance',
                                   cmap_set_under='k', cmap_set_over='r')
-        plotter.plot_horiz_series(ds.landIceGroundedFraction,
+        plotter.plot_horiz_series(landIceGroundedFraction,
                                   'landIceGroundedFraction',
                                   'landIceGroundedFraction',
                                   True, vmin=0 + tol, vmax=1 - tol,
                                   cmap='cmo.balance',
                                   cmap_set_under='k', cmap_set_over='r')
-        plotter.plot_horiz_series(ds.oceanFracObserved,
+        plotter.plot_horiz_series(oceanFracObserved,
                                   'oceanFracObserved', 'oceanFracObserved',
                                   True, vmin=0 + tol, vmax=1 - tol,
                                   cmap='cmo.balance',
@@ -417,7 +419,7 @@ class InitialState(Step):
                 land_ice_pressure=land_ice_pressure,
                 modify_mask=ds_init.bottomDepth > 0.)
             land_ice_draft = np.maximum(land_ice_draft, -ds_init.bottomDepth)
-            land_ice_draft = land_ice_draft.transpose()
+            land_ice_draft = land_ice_draft.transpose('nCells', 'nVertLevels')
         else:
             land_ice_draft = ds_init.landIceDraft
             land_ice_pressure = ds_init.landIcePressure

--- a/compass/ocean/tests/isomip_plus/isomip_plus.cfg
+++ b/compass/ocean/tests/isomip_plus/isomip_plus.cfg
@@ -78,6 +78,9 @@ min_smoothed_draft_mask = 0.01
 # considered a land-ice cell by MPAS-Ocean (landIceMask == 1).
 min_land_ice_fraction = 0.5
 
+# the density of ice prescribed in ISOMIP+
+ice_density = 918
+
 # the initial temperature at the sea surface
 init_top_temp = -1.9
 # the initial temperature at the sea floor

--- a/compass/ocean/tests/isomip_plus/process_geom.py
+++ b/compass/ocean/tests/isomip_plus/process_geom.py
@@ -171,10 +171,18 @@ class ProcessGeom(Step):
                                       mode='constant', cval=0.)
         bed[mask] /= smoothed_mask[mask]
 
+        # We only use the ice surface where the ocean is present to compute
+        # land ice pressure
+        ice_thickness = filters.gaussian_filter(
+            ds.iceThickness * ocean_fraction, filter_sigma, mode='constant',
+            cval=0.)
+        ice_thickness[mask] /= smoothed_mask[mask]
+
         smoothed_draft_mask = filters.gaussian_filter(
             ds.landIceFloatingFraction, filter_sigma, mode='constant', cval=0.)
         smoothed_draft_mask[mask] /= smoothed_mask[mask]
 
         ds['Z_ice_draft'] = (('y', 'x'), draft)
         ds['Z_bed'] = (('y', 'x'), bed)
+        ds['iceThickness'] = (('y', 'x'), ice_thickness)
         ds['smoothedDraftMask'] = (('y', 'x'), smoothed_draft_mask)

--- a/docs/developers_guide/ocean/api.rst
+++ b/docs/developers_guide/ocean/api.rst
@@ -1009,7 +1009,9 @@ ocean framework
 
    haney.compute_haney_number
 
-   iceshelf.compute_land_ice_pressure_and_draft
+   iceshelf.compute_land_ice_draft_from_pressure
+   iceshelf.compute_land_ice_pressure_from_draft
+   iceshelf.compute_land_ice_pressure_from_thickness
    iceshelf.adjust_ssh
 
    particles.write

--- a/docs/users_guide/ocean/test_groups/isomip_plus.rst
+++ b/docs/users_guide/ocean/test_groups/isomip_plus.rst
@@ -125,6 +125,9 @@ The ``isomip_plus`` test cases share the following config options:
     # considered a land-ice cell by MPAS-Ocean (landIceMask == 1).
     min_land_ice_fraction = 0.5
 
+    # the density of ice prescribed in ISOMIP+
+    ice_density = 918
+
     # the initial temperature at the sea surface
     init_top_temp = -1.9
     # the initial temperature at the sea floor


### PR DESCRIPTION
This PR changes the calculation of land ice pressure for ISOMIP+ thin-film test cases so that it is a function of the land ice thickness rather than land ice draft. The land ice pressure is not perfectly identical between `Ocean0` and `thin_film_Ocean0` test cases, mostly because in the former case we smooth the draft and in the latter we smooth ice thickness. This PR also fixes a bug wherein the thin film region was culled from the domain.

Checklist
* [X] User's Guide has been updated
* [X] API documentation in the Developer's Guide (`api.rst`) has any new or modified class, method and/or functions listed
* [X] Documentation has been [built locally](https://mpas-dev.github.io/compass/latest/developers_guide/building_docs.html) and changes look as expected
* [X] Document (in a comment titled `Testing` in this PR) any testing that was used to verify the changes