### PR TITLE
Fixed issue with convert_culled_mesh_to_cdf5 for hurricane test case

### DIFF
--- a/compass/ocean/tests/hurricane/configure.py
+++ b/compass/ocean/tests/hurricane/configure.py
@@ -1,6 +1,6 @@
-from compass.ocean.tests.global_ocean.metadata import \
-    get_author_and_email_from_git
-
+from compass.ocean.tests.global_ocean.metadata import (
+    get_author_and_email_from_git,
+)
 
 def configure_hurricane(test_case, mesh):
     """

--- a/compass/ocean/tests/hurricane/configure.py
+++ b/compass/ocean/tests/hurricane/configure.py
@@ -2,6 +2,7 @@ from compass.ocean.tests.global_ocean.metadata import (
     get_author_and_email_from_git,
 )
 
+
 def configure_hurricane(test_case, mesh):
     """
     Modify the configuration options for this test case

--- a/compass/ocean/tests/hurricane/configure.py
+++ b/compass/ocean/tests/hurricane/configure.py
@@ -17,6 +17,7 @@ def configure_hurricane(test_case, mesh):
     config = test_case.config
 
     config.add_from_package('compass.mesh', 'mesh.cfg')
+    config.add_from_package('compass.ocean.tests.hurricane', 'hurricane.cfg')
     config.add_from_package(mesh.package, mesh.mesh_config_filename,
                             exception=True)
 

--- a/compass/ocean/tests/hurricane/hurricane.cfg
+++ b/compass/ocean/tests/hurricane/hurricane.cfg
@@ -1,0 +1,2 @@
+[spherical_mesh]
+convert_culled_mesh_to_cdf5 = False

--- a/compass/ocean/tests/hurricane/hurricane.cfg
+++ b/compass/ocean/tests/hurricane/hurricane.cfg
@@ -1,6 +1,6 @@
 # options for spherical meshes
 [spherical_mesh]
 
-## config options related to the step for culling land from the mesh
+# Config options related to the step for culling land from the mesh
 # Whether to convert the culled mesh file to CDF5 format
 convert_culled_mesh_to_cdf5 = False

--- a/compass/ocean/tests/hurricane/hurricane.cfg
+++ b/compass/ocean/tests/hurricane/hurricane.cfg
@@ -1,2 +1,6 @@
+# options for spherical meshes
 [spherical_mesh]
+
+## config options related to the step for culling land from the mesh
+# Whether to convert the culled mesh file to CDF5 format
 convert_culled_mesh_to_cdf5 = False


### PR DESCRIPTION
This PR fixes this error:

> configparser.NoOptionError: No option 'convert_culled_mesh_to_cdf5' in section: 'spherical_mesh'

when running the cull mesh step for the`mesh_lts` hurricane test case.

<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->

<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [ ] User's Guide has been updated
* [ ] Developer's Guide has been updated
* [ ] API documentation in the Developer's Guide (`api.rst`) has any new or modified class, method and/or functions listed
* [ ] Documentation has been [built locally](https://mpas-dev.github.io/compass/latest/developers_guide/building_docs.html) and changes look as expected
* [ ] The `E3SM-Project` submodule has been updated with relevant E3SM changes
* [ ] The `MALI-Dev` submodule has been updated with relevant MALI changes
* [ ] Document (in a comment titled `Testing` in this PR) any testing that was used to verify the changes
* [ ] New tests have been added to a test suite

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->

closes #725 