### PR TITLE
Update conda `parallelio` to 2.6.2

### DIFF
--- a/.github/workflows/build_workflow.yml
+++ b/.github/workflows/build_workflow.yml
@@ -98,16 +98,16 @@ jobs:
         name: Install compass
         run: |
           ./conda/configure_compass_env.py \
-            --env_only \
             --env_name compass_test \
             --python=${{ matrix.python-version }} \
+            --mpi=mpich \
             --verbose
-          source load_compass_test.sh
+          source load_compass_test_mpich.sh
 
       - if: ${{ steps.skip_check.outputs.should_skip != 'true' }}
         name: Build Sphinx Docs
         run: |
-          source load_compass_test.sh
+          source load_compass_test_mpich.sh
           cd docs
           make html
 
@@ -116,7 +116,7 @@ jobs:
         env:
           CHECK_IMAGES: False
         run: |
-          source load_compass_test.sh
+          source load_compass_test_mpich.sh
           python -c "import compass"
           compass list
           compass list --machines

--- a/conda/compass_env/spec-file.template
+++ b/conda/compass_env/spec-file.template
@@ -50,7 +50,7 @@ cxx-compiler
 fortran-compiler
 libnetcdf=4.9.2={{ mpi_prefix }}_*
 libpnetcdf=1.12.3={{ mpi_prefix }}_*
-parallelio=2.6.0={{ mpi_prefix }}_*
+parallelio=2.6.2={{ mpi_prefix }}_*
 m4
 make
 {{ mpi }}


### PR DESCRIPTION
<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->

This is needed for compatibility with the MPAS-Tools update in #718.

This merge drops the `--env_only` flag in GitHub Actions in the hopes that this will catch this kind of issue in the future.

<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [x] Document (in a comment titled `Testing` in this PR) any testing that was used to verify the changes

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->
