### PR TITLE
New Mesh: IcoswISC30E3r4

### DIFF
--- a/compass/ocean/tests/global_ocean/global_ocean.cfg
+++ b/compass/ocean/tests/global_ocean/global_ocean.cfg
@@ -47,6 +47,12 @@ btr_dt_per_km = 1.5
 
 # Maximum allowed Haney number for configurations with ice-shelf cavities
 rx1_max = 20
+# the number of iterations of topography smoothing (0 means no smoothing)
+topo_smooth_num_passes = 0
+# The distance in km over which the Gaussian filter is applied
+topo_smooth_distance_limit = 200.0
+# The standard deviation in km of the Gaussian filter
+topo_smooth_std_deviation = 100.0
 
 # number of cores to use
 init_ntasks = 36

--- a/compass/ocean/tests/global_ocean/init/smooth_topo.template
+++ b/compass/ocean/tests/global_ocean/init/smooth_topo.template
@@ -1,0 +1,8 @@
+&smooth
+    filename_depth_in    = "topography_culled.nc"
+    filename_depth_out   = "topography_orig_and_smooth.nc"
+    filename_mpas_mesh   = "mesh.nc"
+    distanceLimit        = {{ distance_limit }}
+    stdDeviation         = {{ std_deviation }}
+    numSmoothingPasses   = {{ num_passes }}
+/

--- a/compass/ocean/tests/global_ocean/mesh/qu/dynamic_adjustment.yaml
+++ b/compass/ocean/tests/global_ocean/mesh/qu/dynamic_adjustment.yaml
@@ -1,5 +1,5 @@
 dynamic_adjustment:
-  land_ice_flux_mode: data
+  land_ice_flux_mode: pressure_only
   get_dt_from_min_res: True
 
   steps:

--- a/compass/ocean/tests/global_ocean/mesh/qu/dynamic_adjustment.yaml
+++ b/compass/ocean/tests/global_ocean/mesh/qu/dynamic_adjustment.yaml
@@ -16,7 +16,7 @@ dynamic_adjustment:
       Rayleigh_damping_coeff: 1.0e-5
 
     simulation:
-      run_duration: 10_00:00:00
+      run_duration: 80_00:00:00
       output_interval: 10_00:00:00
       restart_interval: 10_00:00:00
       Rayleigh_damping_coeff: None

--- a/compass/ocean/tests/global_ocean/mesh/qu/qu.cfg
+++ b/compass/ocean/tests/global_ocean/mesh/qu/qu.cfg
@@ -49,4 +49,4 @@ max_res = ${qu_resolution}
 pull_request = https://github.com/MPAS-Dev/compass/pull/691
 
 # the resolution of the QU or Icos mesh in km
-qu_resolution = 120
+qu_resolution = 30

--- a/compass/ocean/tests/global_ocean/mesh/qu/qu.cfg
+++ b/compass/ocean/tests/global_ocean/mesh/qu/qu.cfg
@@ -27,6 +27,13 @@ transition_levels = 28
 # Maximum allowed Haney number for configurations with ice-shelf cavities
 rx1_max = 10
 
+# the number of iterations of topography smoothing
+topo_smooth_num_passes = 1
+# The distance in km over which the Gaussian filter is applied
+topo_smooth_distance_limit = 200.0
+# The standard deviation in km of the Gaussian filter
+topo_smooth_std_deviation = 100.0
+
 ## metadata related to the mesh
 # the prefix (e.g. QU, EC, WC, SO)
 prefix = QU
@@ -34,19 +41,19 @@ prefix = QU
 # a description of the mesh
 mesh_description = MPAS quasi-uniform mesh for E3SM version ${e3sm_version} at
                    ${min_res}-km global resolution with <<<levels>>> vertical
-                   level
-
+                   levels.  Topography has been smoothed over ~100 km using a
+                   Gaussian filter.
 # E3SM version that the mesh is intended for
 e3sm_version = 3
 # The revision number of the mesh, which should be incremented each time the
 # mesh is revised
-mesh_revision = 2
+mesh_revision = 4
 # the minimum (finest) resolution in the mesh
 min_res = ${qu_resolution}
 # the maximum (coarsest) resolution in the mesh, can be the same as min_res
 max_res = ${qu_resolution}
 # The URL of the pull request documenting the creation of the mesh
-pull_request = https://github.com/MPAS-Dev/compass/pull/691
+pull_request = https://github.com/MPAS-Dev/compass/pull/734
 
 # the resolution of the QU or Icos mesh in km
 qu_resolution = 30

--- a/compass/ocean/tests/global_ocean/streams.forward
+++ b/compass/ocean/tests/global_ocean/streams.forward
@@ -18,6 +18,7 @@
     <var name="xtime"/>
     <var name="normalVelocity"/>
     <var name="layerThickness"/>
+    <var name="kineticEnergyCell"/>
 </stream>
 
 <stream name="forcing_data"

--- a/conda/compass_env/spec-file.template
+++ b/conda/compass_env/spec-file.template
@@ -22,7 +22,7 @@ mache=1.16.0
 {% endif %}
 matplotlib-base
 metis
-mpas_tools=0.26.0
+mpas_tools=0.28.0
 nco
 netcdf4=*=nompi_*
 numpy


### PR DESCRIPTION
<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->

Long name: IcoswISC30L64E3SMv3r4

This nearly uniform 30 km mesh is the dual mesh of a subdivided icosahedron (Icos).

This mesh differs from IcoswISC30E3r2 (#691) in having topography smoothing using a Gaussian filter with a characteristic length scale of 100 km.

Because of the bug fix in #732, the horizontal mesh has been recreated as well and is not identical to the IcoswISC30E3r2 mesh.

Mesh, initial condition, dynamic adjustment and files for E3SM will be on Chrysalis at:
```
/lcrc/group/e3sm/ac.xylar/compass_1.2/chrysalis/e3smv3-meshes/icoswisc30e3r4
```

<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [ ] Document (in a comment titled `Testing` in this PR) any testing that was used to verify the changes

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->
