### PR TITLE
New Mesh: ECwISC30to60E3r5

### DIFF
--- a/compass/ocean/tests/global_ocean/global_ocean.cfg
+++ b/compass/ocean/tests/global_ocean/global_ocean.cfg
@@ -49,8 +49,6 @@ btr_dt_per_km = 1.5
 rx1_max = 20
 # the number of iterations of topography smoothing (0 means no smoothing)
 topo_smooth_num_passes = 0
-# the minimum value for maxLevelCell for smoothing to be applied
-topo_smooth_min_level = 1
 # The distance in km over which the Gaussian filter is applied
 topo_smooth_distance_limit = 200.0
 # The standard deviation in km of the Gaussian filter

--- a/compass/ocean/tests/global_ocean/global_ocean.cfg
+++ b/compass/ocean/tests/global_ocean/global_ocean.cfg
@@ -47,6 +47,14 @@ btr_dt_per_km = 1.5
 
 # Maximum allowed Haney number for configurations with ice-shelf cavities
 rx1_max = 20
+# the number of iterations of topography smoothing (0 means no smoothing)
+topo_smooth_num_passes = 0
+# the minimum value for maxLevelCell for smoothing to be applied
+topo_smooth_min_level = 1
+# The distance in km over which the Gaussian filter is applied
+topo_smooth_distance_limit = 200.0
+# The standard deviation in km of the Gaussian filter
+topo_smooth_std_deviation = 100.0
 
 # number of cores to use
 init_ntasks = 36

--- a/compass/ocean/tests/global_ocean/init/smooth_topo.template
+++ b/compass/ocean/tests/global_ocean/init/smooth_topo.template
@@ -1,0 +1,9 @@
+&smooth
+    filename_depth_in    = "initial_state.nc"
+    filename_depth_out   = "topo_smooth.nc"
+    filename_mpas_mesh   = "initial_state.nc"
+    distanceLimit        = {{ distance_limit }}
+    stdDeviation         = {{ std_deviation }}
+    numSmoothingPasses   = {{ num_passes }}
+    minLevelForSmoothing = {{ min_level }}
+/

--- a/compass/ocean/tests/global_ocean/init/smooth_topo.template
+++ b/compass/ocean/tests/global_ocean/init/smooth_topo.template
@@ -1,9 +1,8 @@
 &smooth
-    filename_depth_in    = "initial_state.nc"
-    filename_depth_out   = "topo_smooth.nc"
-    filename_mpas_mesh   = "initial_state.nc"
+    filename_depth_in    = "topography_culled.nc"
+    filename_depth_out   = "topography_orig_and_smooth.nc"
+    filename_mpas_mesh   = "mesh.nc"
     distanceLimit        = {{ distance_limit }}
     stdDeviation         = {{ std_deviation }}
     numSmoothingPasses   = {{ num_passes }}
-    minLevelForSmoothing = {{ min_level }}
 /

--- a/compass/ocean/tests/global_ocean/mesh/ec30to60/dynamic_adjustment.yaml
+++ b/compass/ocean/tests/global_ocean/mesh/ec30to60/dynamic_adjustment.yaml
@@ -28,9 +28,9 @@ dynamic_adjustment:
       Rayleigh_damping_coeff: 1.0e-6
 
     simulation:
-      run_duration: 10_00:00:00
+      run_duration: 20_00:00:00
       output_interval: 10_00:00:00
       restart_interval: 10_00:00:00
-      dt: 00:30:00
-      btr_dt: 00:01:00
+      dt: 00:20:00
+      btr_dt: 00:00:40
       Rayleigh_damping_coeff: None

--- a/compass/ocean/tests/global_ocean/mesh/ec30to60/dynamic_adjustment.yaml
+++ b/compass/ocean/tests/global_ocean/mesh/ec30to60/dynamic_adjustment.yaml
@@ -1,5 +1,5 @@
 dynamic_adjustment:
-  land_ice_flux_mode: data
+  land_ice_flux_mode: pressure_only
   get_dt_from_min_res: False
 
   steps:

--- a/compass/ocean/tests/global_ocean/mesh/ec30to60/ec30to60.cfg
+++ b/compass/ocean/tests/global_ocean/mesh/ec30to60/ec30to60.cfg
@@ -28,7 +28,7 @@ transition_levels = 28
 rx1_max = 10
 
 # the number of iterations of topography smoothing
-topo_smooth_num_passes = 1
+topo_smooth_num_passes = 0
 # The distance in km over which the Gaussian filter is applied
 topo_smooth_distance_limit = 200.0
 # The standard deviation in km of the Gaussian filter
@@ -45,16 +45,14 @@ mesh_description = MPAS Eddy Closure mesh for E3SM version ${e3sm_version} with
                    enhanced resolution around the equator (30 km), South pole
                    (35 km), Greenland (${min_res} km), ${max_res}-km resolution
                    at mid latitudes, and <<<levels>>> vertical levels.
-                   Topography has been smoothed over ~100 km using a Gaussian
-                   filter.
 # E3SM version that the mesh is intended for
 e3sm_version = 3
 # The revision number of the mesh, which should be incremented each time the
 # mesh is revised
-mesh_revision = 4
+mesh_revision = 5
 # the minimum (finest) resolution in the mesh
 min_res = 30
 # the maximum (coarsest) resolution in the mesh, can be the same as min_res
 max_res = 60
 # The URL of the pull request documenting the creation of the mesh
-pull_request = https://github.com/MPAS-Dev/compass/pull/733
+pull_request = https://github.com/MPAS-Dev/compass/pull/736

--- a/compass/ocean/tests/global_ocean/mesh/ec30to60/ec30to60.cfg
+++ b/compass/ocean/tests/global_ocean/mesh/ec30to60/ec30to60.cfg
@@ -37,15 +37,17 @@ prefix = EC
 mesh_description = MPAS Eddy Closure mesh for E3SM version ${e3sm_version} with
                    enhanced resolution around the equator (30 km), South pole
                    (35 km), Greenland (${min_res} km), ${max_res}-km resolution
-                   at mid latitudes, and <<<levels>>> vertical levels
+                   at mid latitudes, and <<<levels>>> vertical levels.
+                   Topography has been smoothed over ~100 km using a Gaussian
+                   filter.
 # E3SM version that the mesh is intended for
 e3sm_version = 3
 # The revision number of the mesh, which should be incremented each time the
 # mesh is revised
-mesh_revision = 2
+mesh_revision = 4
 # the minimum (finest) resolution in the mesh
 min_res = 30
 # the maximum (coarsest) resolution in the mesh, can be the same as min_res
 max_res = 60
 # The URL of the pull request documenting the creation of the mesh
-pull_request = https://github.com/MPAS-Dev/compass/pull/689
+pull_request = https://github.com/MPAS-Dev/compass/pull/733

--- a/compass/ocean/tests/global_ocean/mesh/ec30to60/ec30to60.cfg
+++ b/compass/ocean/tests/global_ocean/mesh/ec30to60/ec30to60.cfg
@@ -29,9 +29,6 @@ rx1_max = 10
 
 # the number of iterations of topography smoothing
 topo_smooth_num_passes = 1
-# the minimum value for maxLevelCell for smoothing to be applied (default is
-# level 5, about 50 m depth)
-topo_smooth_min_level = 5
 # The distance in km over which the Gaussian filter is applied
 topo_smooth_distance_limit = 200.0
 # The standard deviation in km of the Gaussian filter

--- a/compass/ocean/tests/global_ocean/mesh/ec30to60/ec30to60.cfg
+++ b/compass/ocean/tests/global_ocean/mesh/ec30to60/ec30to60.cfg
@@ -27,6 +27,16 @@ transition_levels = 28
 # Maximum allowed Haney number for configurations with ice-shelf cavities
 rx1_max = 10
 
+# the number of iterations of topography smoothing
+topo_smooth_num_passes = 1
+# the minimum value for maxLevelCell for smoothing to be applied (default is
+# level 5, about 50 m depth)
+topo_smooth_min_level = 5
+# The distance in km over which the Gaussian filter is applied
+topo_smooth_distance_limit = 200.0
+# The standard deviation in km of the Gaussian filter
+topo_smooth_std_deviation = 100.0
+
 # the approximate number of cells in the mesh
 approx_cell_count = 240000
 

--- a/compass/ocean/tests/global_ocean/streams.forward
+++ b/compass/ocean/tests/global_ocean/streams.forward
@@ -18,6 +18,7 @@
     <var name="xtime"/>
     <var name="normalVelocity"/>
     <var name="layerThickness"/>
+    <var name="kineticEnergyCell"/>
 </stream>
 
 <stream name="forcing_data"

--- a/conda/compass_env/spec-file.template
+++ b/conda/compass_env/spec-file.template
@@ -22,7 +22,7 @@ mache=1.16.0
 {% endif %}
 matplotlib-base
 metis
-mpas_tools=0.26.0
+mpas_tools=0.28.0
 nco
 netcdf4=*=nompi_*
 numpy


### PR DESCRIPTION
<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->

Long name: ECwISC30to60L64E3SMv3r5

As with previous versions of the mesh, this Eddy Closure (EC) mesh has:

* 30 km resolution at the equator
* 60 km resolution at mid latitudes
* 35 km resolution near the poles

This mesh differs from ECwISC30to60E3r2 (#689) primarily in having the the bug fix in #732, but also it has been produced with updated versions of the `mpas_tools` and `pyremap` packages, leading to small changes in the topography and coast line.

It differs from ECwISC30to60E3r4 (#733) in not having additional topographic smoothing.

Mesh, initial condition, dynamic adjustment and files for E3SM will be on Chrysalis at:
```
/lcrc/group/e3sm/ac.xylar/compass_1.2/chrysalis/e3smv3-meshes/ecwisc30to60e3r5
```

<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [ ] Document (in a comment titled `Testing` in this PR) any testing that was used to verify the changes

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->
