### PR TITLE
Add info about viewing compiled docs via www at NERSC

### DIFF
--- a/docs/developers_guide/building_docs.rst
+++ b/docs/developers_guide/building_docs.rst
@@ -23,3 +23,11 @@ script was last sourced.  The load script will reinstall compass into the conda
 environment when it is sourced in the root of the compass branch.
 
 You can view the documentation by opening ``_build/html/index.html``.
+From any machine, you can scp the ``html`` directory to your local computer for
+viewing.
+On NERSC, you can conveniently make use of their
+`web Science Gateway <https://docs.nersc.gov/services/science-gateways/#web-methods-for-data>`_
+to avoid transferring data.  By copying your compiled documentation to
+an appropriately named subdirectory at
+``/global/cfs/cdirs/myproj/www``, it can then be viewed from a browser at
+``https://portal.nersc.gov/cfs/myproj/``.

--- a/docs/developers_guide/building_docs.rst
+++ b/docs/developers_guide/building_docs.rst
@@ -25,9 +25,15 @@ environment when it is sourced in the root of the compass branch.
 You can view the documentation by opening ``_build/html/index.html``.
 From any machine, you can scp the ``html`` directory to your local computer for
 viewing.
+
 On NERSC, you can conveniently make use of their
 `web Science Gateway <https://docs.nersc.gov/services/science-gateways/#web-methods-for-data>`_
 to avoid transferring data.  By copying your compiled documentation to
 an appropriately named subdirectory at
-``/global/cfs/cdirs/myproj/www``, it can then be viewed from a browser at
-``https://portal.nersc.gov/cfs/myproj/``.
+``/global/cfs/cdirs/<myproj>/www/`` and then running ``chmod -R ugo+rX .`` on that directory
+(and perhaps its parent directories), it can then be viewed from a browser at
+``https://portal.nersc.gov/cfs/<myproj>/``.
+
+LCRC also has a web portal.  You can copy the compiled documentation to a subdirectory in
+``/lcrc/group/e3sm/public_html/diagnostic_output/<username>/``.  Then, you can
+view it at ``https://web.lcrc.anl.gov/public/e3sm/diagnostic_output/<username>/``


### PR DESCRIPTION
<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->
This merge adds information about how to view compiled documentation via NERSC's web Science Gateway to avoid needing to scp the compiled documentation locally.
<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist

* [x] Developer's Guide has been updated
* [x] Documentation has been [built locally](https://mpas-dev.github.io/compass/latest/developers_guide/building_docs.html) and changes look as expected

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->
