### PR TITLE
Add an option to setup coupled MALI-SLM runs in the ismip6 run testgroup

### DIFF
--- a/compass/landice/tests/ismip6_run/ismip6_ais_proj2300/__init__.py
+++ b/compass/landice/tests/ismip6_run/ismip6_ais_proj2300/__init__.py
@@ -76,10 +76,18 @@ class Ismip6AisProj2300(TestCase):
         sea_level_model = self.config.getboolean('ismip6_run_ais_2300',
                                                  'sea_level_model')
         if sea_level_model:
-            self.add_step(
-                CreateSlmMappingFiles(test_case=self, name='mapping_files',
-                                      subdir='mapping_files'))
-            self.steps_to_run.append('mapping_files')
+            subdir = 'mapping_files'
+            if os.path.exists(os.path.join(self.work_dir, subdir)):
+                print(f"WARNING: {subdir} path already exists; skipping.  "
+                      "Please remove the directory "
+                      f"{os.path.join(self.work_dir, subdir)} and execute "
+                      "'compass setup' again to set this experiment up.")
+            else:
+                self.add_step(
+                    CreateSlmMappingFiles(test_case=self,
+                                          name='mapping_files',
+                                          subdir=subdir))
+                self.steps_to_run.append('mapping_files')
 
     def run(self):
         """

--- a/compass/landice/tests/ismip6_run/ismip6_ais_proj2300/__init__.py
+++ b/compass/landice/tests/ismip6_run/ismip6_ais_proj2300/__init__.py
@@ -1,5 +1,8 @@
 import os
 
+from compass.landice.tests.ismip6_run.ismip6_ais_proj2300.create_slm_mapping_files import (  # noqa
+    CreateSlmMappingFiles,
+)
 from compass.landice.tests.ismip6_run.ismip6_ais_proj2300.set_up_experiment import (  # noqa
     SetUpExperiment,
 )
@@ -70,6 +73,14 @@ class Ismip6AisProj2300(TestCase):
         # each experiment (step) should be run manually
         self.steps_to_run = []
 
+        sea_level_model = self.config.getboolean('ismip6_run_ais_2300',
+                                                 'sea_level_model')
+        if sea_level_model:
+            self.add_step(
+                CreateSlmMappingFiles(test_case=self, name='mapping_files',
+                                      subdir='mapping_files'))
+            self.steps_to_run.append('mapping_files')
+
     def run(self):
         """
         A dummy run method
@@ -77,6 +88,9 @@ class Ismip6AisProj2300(TestCase):
         raise ValueError("ERROR: 'compass run' has no functionality at the "
                          "test case level for this test.  "
                          "Please submit the job script in "
-                         "each experiment's subdirectory manually instead.")
+                         "each experiment's subdirectory manually instead."
+                         "To create Sea-Level Model mapping files, submit"
+                         "job script or execute 'compass run' from the"
+                         "'mapping_files' subdirectory.")
 
     # no validate() method is needed

--- a/compass/landice/tests/ismip6_run/ismip6_ais_proj2300/albany_input.yaml
+++ b/compass/landice/tests/ismip6_run/ismip6_ais_proj2300/albany_input.yaml
@@ -17,8 +17,7 @@ ANONYMOUS:
           # Zero Effective Pressure On Floating Ice At Nodes: true
           Zero Beta On Floating Ice: true
 
-    Cubature Degree: 4
-    Basal Cubature Degree: 8
+    Cubature Degree: 8
 
 # Discretization Description
   Discretization:
@@ -93,12 +92,6 @@ ANONYMOUS:
 #             Preconditioner Information
               Preconditioner Type: MueLu
               Preconditioner Types:
-
-                Ifpack:
-                  Overlap: 1
-                  Prec Type: ILU
-                  Ifpack Settings:
-                    'fact: level-of-fill': 0
 
                 Ifpack2:
                   Overlap: 1
@@ -244,29 +237,3 @@ ANONYMOUS:
                       A: myRebalanceAFact
                       Coordinates: myRebalanceProlongatorFact
                       Importer: myRepartitionFact
-
-                ML:
-                  Base Method Defaults: none
-                  ML Settings:
-                    default values: SA
-                    ML output: 0
-                    'repartition: enable': 1
-                    'repartition: max min ratio': 1.327e+00
-                    'repartition: min per proc': 600
-                    'repartition: Zoltan dimensions': 2
-                    'repartition: start level': 4
-                    'semicoarsen: number of levels': 2
-                    'semicoarsen: coarsen rate': 14
-                    'smoother: sweeps': 4
-                    'smoother: type': Gauss-Seidel
-                    'smoother: Chebyshev eig boost': 1.2e+00
-                    'smoother: sweeps (level 0)': 1
-                    'smoother: type (level 0)': line Gauss-Seidel
-                    'smoother: line GS Type': standard
-                    'smoother: damping factor': 1.0e+00
-                    'smoother: pre or post': both
-                    'coarse: type': Gauss-Seidel
-                    'coarse: sweeps': 4
-                    'coarse: max size': 2000
-                    'coarse: pre or post': pre
-                    max levels: 7

--- a/compass/landice/tests/ismip6_run/ismip6_ais_proj2300/create_slm_mapping_files.py
+++ b/compass/landice/tests/ismip6_run/ismip6_ais_proj2300/create_slm_mapping_files.py
@@ -82,7 +82,7 @@ class CreateSlmMappingFiles(Step):
         shutil.copy(init_cond_path, mali_meshfile)
         args = ['set_lat_lon_fields_in_planar_grid.py',
                 '--file', mali_meshfile,
-                '--proj', 'ais-bedmap2']
+                '--proj', 'ais-bedmap2-sphere']
 
         check_call(args, logger=logger)
 

--- a/compass/landice/tests/ismip6_run/ismip6_ais_proj2300/create_slm_mapping_files.py
+++ b/compass/landice/tests/ismip6_run/ismip6_ais_proj2300/create_slm_mapping_files.py
@@ -1,4 +1,3 @@
-import os
 import shutil
 
 from mpas_tools.logging import check_call
@@ -83,7 +82,7 @@ class CreateSlmMappingFiles(Step):
         shutil.copy(init_cond_path, mali_meshfile)
         args = ['set_lat_lon_fields_in_planar_grid.py',
                 '--file', mali_meshfile,
-                '--proj', 'ais-bedmap2-sphere']
+                '--proj', 'ais-bedmap2']
 
         check_call(args, logger=logger)
 
@@ -121,8 +120,4 @@ class CreateSlmMappingFiles(Step):
 
         check_call(args, logger)
 
-        # remove the scripfiles and copied mesh file
-        logger.info('Removing the temporary mesh and scripfiles...')
-        os.remove(slm_scripfile)
-        os.remove(mali_scripfile)
-        os.remove(mali_meshfile)
+        logger.info('mapping file creation complete')

--- a/compass/landice/tests/ismip6_run/ismip6_ais_proj2300/create_slm_mapping_files.py
+++ b/compass/landice/tests/ismip6_run/ismip6_ais_proj2300/create_slm_mapping_files.py
@@ -27,8 +27,7 @@ class CreateSlmMappingFiles(Step):
         super().__init__(test_case=test_case, name=name, subdir=subdir)
 
     def setup(self):
-        # no setup needed
-        pass
+        print("    Setting up mapping_file subdirectory")
 
     def run(self):
         """
@@ -59,7 +58,8 @@ class CreateSlmMappingFiles(Step):
         section = config['ismip6_run_ais_2300']
         init_cond_path = section.get('init_cond_path')
         nglv = section.getint('nglv')
-        ntasks = section.getint('ntasks')
+        section = config['parallel']
+        ntasks = section.getint('cores_per_node')
 
         # create the mapping files
         # first create scrip files

--- a/compass/landice/tests/ismip6_run/ismip6_ais_proj2300/create_slm_mapping_files.py
+++ b/compass/landice/tests/ismip6_run/ismip6_ais_proj2300/create_slm_mapping_files.py
@@ -1,0 +1,128 @@
+import os
+import shutil
+
+from mpas_tools.logging import check_call
+from mpas_tools.scrip.from_mpas import scrip_from_mpas
+
+from compass.step import Step
+
+
+class CreateSlmMappingFiles(Step):
+    """
+    A step for creating mapping files for the Sea Level Model
+
+    Attributes
+    ----------
+    """
+
+    def __init__(self, test_case, name, subdir):
+        """
+        Initialize step
+
+        Parameters
+        ----------
+
+        """
+
+        super().__init__(test_case=test_case, name=name, subdir=subdir)
+
+    def setup(self):
+        # no setup needed
+        pass
+
+    def run(self):
+        """
+        Run this step of the test case
+        """
+
+        config = self.config
+        logger = self.logger
+        section = config['ismip6_run_ais_2300']
+        sea_level_model = section.getboolean('sea_level_model')
+        if sea_level_model:
+            self._build_mapping_files(config, logger)
+
+    def _build_mapping_files(self, config, logger):
+        """
+        Build mapping files between the MALI mesh and the SLM grid.
+
+        Parameters
+        ----------
+        config : compass.config.CompassConfigParser
+            Configuration options for a ismip6 forcing test case
+
+        logger : logging.Logger
+            A logger for output from the step
+        """
+
+        config = self.config
+        section = config['ismip6_run_ais_2300']
+        init_cond_path = section.get('init_cond_path')
+        nglv = section.getint('nglv')
+        ntasks = section.getint('ntasks')
+
+        # create the mapping files
+        # first create scrip files
+        mali_scripfile = 'mali_scripfile.nc'
+        slm_scripfile = f'slm_nglv{nglv}scripfile.nc'
+        mali_meshfile = 'mali_meshfile_sphereLatLon.nc'
+
+        # slm scripfile
+        logger.info(f'creating scripfile for the SLM grid with '
+                    f'{nglv} Gauss-Legendre points in latitude')
+
+        args = ['ncremap',
+                '-g', slm_scripfile,
+                '-G',
+                f'latlon={nglv},{2*int(nglv)}#lat_typ=gss#lat_drc=n2s']
+
+        check_call(args, logger=logger)
+
+        # mali scripfile
+        # first have to adjust lat-lon values as if they are on sphere
+        shutil.copy(init_cond_path, mali_meshfile)
+        args = ['set_lat_lon_fields_in_planar_grid.py',
+                '--file', mali_meshfile,
+                '--proj', 'ais-bedmap2-sphere']
+
+        check_call(args, logger=logger)
+
+        logger.info('creating scrip file for the mali mesh')
+        scrip_from_mpas(mali_meshfile, mali_scripfile)
+
+        # create mapping file from MALI mesh to SLM grid
+        logger.info('creating MALI -> SLM grid mapfile with bilinear method')
+
+        parallel_executable = config.get("parallel", "parallel_executable")
+        # split the parallel executable into constituents
+        args = parallel_executable.split(' ')
+        args.extend(['-n', f'{ntasks}',
+                     'ESMF_RegridWeightGen',
+                     '-s', mali_scripfile,
+                     '-d', slm_scripfile,
+                     '-w', 'mapfile_mali_to_slm.nc',
+                     '-m', 'conserve',
+                     '-i', '-64bit_offset', '--netcdf4',
+                     '--src_regional'])
+
+        check_call(args, logger)
+
+        # create mapping file from SLM grid to MALI mesh
+        logger.info('SLM -> MALI mesh mapfile with bilinear method')
+        args = parallel_executable.split(' ')
+        args.extend(['-n', f'{ntasks}',
+                     'ESMF_RegridWeightGen',
+                     '-s', slm_scripfile,
+                     '-d', mali_scripfile,
+                     '-w', 'mapfile_slm_to_mali.nc',
+                     '-m', 'bilinear',
+                     '-i', '-64bit_offset', '--netcdf4',
+                     '--dst_regional'])
+
+        check_call(args, logger)
+
+        # remove the scripfiles and copied mesh file
+        logger.info('Removing the temporary mesh and scripfiles...')
+        os.remove(slm_scripfile)
+        os.remove(mali_scripfile)
+        os.remove(mali_meshfile)

--- a/compass/landice/tests/ismip6_run/ismip6_ais_proj2300/ismip6_ais_proj2300.cfg
+++ b/compass/landice/tests/ismip6_run/ismip6_ais_proj2300/ismip6_ais_proj2300.cfg
@@ -44,3 +44,19 @@ von_mises_parameter_path = UNKNOWN
 
 # Whether facemelting should be included in the runs
 use_face_melting = False
+
+# True if running coupled MALI-sea level model simulation
+sea_level_model = True
+
+# NOTE: for the directories related to the sea-level model input/outputs, the slash '/' at the end of the directory name is necessary.
+# Path to the directory containing globally defined ice thickness field for the sea-level model
+slm_input_ice = /global/cfs/cdirs/fanssie/MALI_projects/SeaLevelModel_Inputs/icemodel/
+
+# Path to the directory containing earth model for the sea-level model
+slm_input_earth = /global/cfs/cdirs/fanssie/MALI_projects/SeaLevelModel_Inputs/earthmodel/
+
+# Path to the diectory containing other input files (present-day global topography and sea-level model grid files)
+slm_input_others = /global/cfs/cdirs/fanssie/MALI_projects/SeaLevelModel_Inputs/others/
+
+# number of gauss-legendre nodes in latitude (typically an integer multiple of 512)
+nglv = 2048

--- a/compass/landice/tests/ismip6_run/ismip6_ais_proj2300/ismip6_ais_proj2300.cfg
+++ b/compass/landice/tests/ismip6_run/ismip6_ais_proj2300/ismip6_ais_proj2300.cfg
@@ -46,7 +46,7 @@ von_mises_parameter_path = UNKNOWN
 use_face_melting = False
 
 # True if running coupled MALI-sea level model simulation
-sea_level_model = True
+sea_level_model = False
 
 # NOTE: for the directories related to the sea-level model input/outputs, the slash '/' at the end of the directory name is necessary.
 # Path to the directory containing globally defined ice thickness field for the sea-level model

--- a/compass/landice/tests/ismip6_run/ismip6_ais_proj2300/ismip6_ais_proj2300.cfg
+++ b/compass/landice/tests/ismip6_run/ismip6_ais_proj2300/ismip6_ais_proj2300.cfg
@@ -55,6 +55,15 @@ slm_input_ice = /global/cfs/cdirs/fanssie/MALI_projects/SeaLevelModel_Inputs/ice
 # Path to the directory containing earth model for the sea-level model
 slm_input_earth = /global/cfs/cdirs/fanssie/MALI_projects/SeaLevelModel_Inputs/earthmodel/
 
+# Earth structure profile
+# possible values: any file name string of earth model file.
+# Note that there is no single representative earth model for the globe or
+# any region of the globe (e.g., West Antarctica, East Antarctica, Greenland)
+# But for this test, we use 'prem_512.l60K2C.sum18p6.dum19p2.tz19p4.lm22' for West Antarctica
+# and 'prem_coll_512.l120C.ump5.lm10' for East Antarctica. Other earthmodels that can be used
+# should exist in the path defined in the config option 'slm_input_earth'.
+slm_earth_structure = prem_512.l60K2C.sum18p6.dum19p2.tz19p4.lm22
+
 # Path to the diectory containing other input files (present-day global topography and sea-level model grid files)
 slm_input_others = /global/cfs/cdirs/fanssie/MALI_projects/SeaLevelModel_Inputs/others/
 

--- a/compass/landice/tests/ismip6_run/ismip6_ais_proj2300/ismip6_ais_proj2300_4km_chicoma.cfg
+++ b/compass/landice/tests/ismip6_run/ismip6_ais_proj2300/ismip6_ais_proj2300_4km_chicoma.cfg
@@ -54,6 +54,15 @@ slm_input_ice = /usr/projects/climate/hollyhan/SeaLevelModel_Inputs/icemodel/
 # Path to the directory containing earth model for the sea-level model
 slm_input_earth = /usr/projects/climate/hollyhan/SeaLevelModel_Inputs/earthmodel/
 
+# Earth structure profile
+# possible values: any file name string of earth model file.
+# Note that there is no single representative earth model for the globe or
+# any region of the globe (e.g., West Antarctica, East Antarctica, Greenland)
+# But for this test, we use 'prem_512.l60K2C.sum18p6.dum19p2.tz19p4.lm22' for West Antarctica
+# and 'prem_coll_512.l120C.ump5.lm10' for East Antarctica. Other earthmodels that can be used
+# should exist in the path defined in the config option 'slm_input_earth'.
+slm_earth_structure = prem_512.l60K2C.sum18p6.dum19p2.tz19p4.lm22
+
 # Path to the diectory containing other input files (present-day global topography and sea-level model grid files)
 slm_input_others = /usr/projects/climate/hollyhan/SeaLevelModel_Inputs/others/
 

--- a/compass/landice/tests/ismip6_run/ismip6_ais_proj2300/ismip6_ais_proj2300_4km_chicoma.cfg
+++ b/compass/landice/tests/ismip6_run/ismip6_ais_proj2300/ismip6_ais_proj2300_4km_chicoma.cfg
@@ -3,7 +3,7 @@
 # Can be "tier1", "tier2", "all", or a comma-delimited list of runs
 # "tier1" is expAE01-expAE06 plus hist and ctrlAE
 # "tier2" is expAE07-expAE14
-exp_list = hist,ctrlAE,expAE05
+exp_list = hist,ctrlAE,expAE01,expAE02,expAE05
 
 # Resolution that will be set up, in km.  Should be one of 4, 8, as those are
 # the two resolutions currently supported.
@@ -43,3 +43,19 @@ von_mises_parameter_path = UNKNOWN
 
 # Whether facemelting should be included in the runs
 use_face_melting = True
+
+# True if running coupled MALI-sea level model simulation
+sea_level_model = True
+
+# NOTE: for the directories related to the sea-level model input/outputs, the slash '/' at the end of the directory name is necessary.
+# Path to the base directory containing globally defined ice thickness field for the sea-level model
+slm_input_ice = /usr/projects/climate/hollyhan/SeaLevelModel_Inputs/icemodel/
+
+# Path to the directory containing earth model for the sea-level model
+slm_input_earth = /usr/projects/climate/hollyhan/SeaLevelModel_Inputs/earthmodel/
+
+# Path to the diectory containing other input files (present-day global topography and sea-level model grid files)
+slm_input_others = /usr/projects/climate/hollyhan/SeaLevelModel_Inputs/others/
+
+# number of gauss-legendre nodes in latitude (typically an integer multiple of 512)
+nglv = 2048

--- a/compass/landice/tests/ismip6_run/ismip6_ais_proj2300/ismip6_ais_proj2300_4km_chicoma.cfg
+++ b/compass/landice/tests/ismip6_run/ismip6_ais_proj2300/ismip6_ais_proj2300_4km_chicoma.cfg
@@ -45,7 +45,7 @@ von_mises_parameter_path = UNKNOWN
 use_face_melting = True
 
 # True if running coupled MALI-sea level model simulation
-sea_level_model = True
+sea_level_model = False
 
 # NOTE: for the directories related to the sea-level model input/outputs, the slash '/' at the end of the directory name is necessary.
 # Path to the base directory containing globally defined ice thickness field for the sea-level model

--- a/compass/landice/tests/ismip6_run/ismip6_ais_proj2300/ismip6_ais_proj2300_4km_nersc.cfg
+++ b/compass/landice/tests/ismip6_run/ismip6_ais_proj2300/ismip6_ais_proj2300_4km_nersc.cfg
@@ -44,3 +44,19 @@ von_mises_parameter_path = UNKNOWN
 
 # Whether facemelting should be included in the runs
 use_face_melting = False
+
+# True if running coupled MALI-sea level model simulation
+sea_level_model = True
+
+# NOTE: for the directories related to the sea-level model input/outputs, the slash '/' at the end of the directory name is necessary.
+# Path to the base directory containing globally defined ice thickness field for the sea-level model
+slm_input_ice = /global/cfs/cdirs/fanssie/MALI_projects/SeaLevelModel_Inputs/icemodel/
+
+# Path to the directory containing earth model for the sea-level model
+slm_input_earth = /global/cfs/cdirs/fanssie/MALI_projects/SeaLevelModel_Inputs/earthmodel/
+
+# Path to the diectory containing other input files (present-day global topography and sea-level model grid files)
+slm_input_others = /global/cfs/cdirs/fanssie/MALI_projects/SeaLevelModel_Inputs/others/
+
+# number of gauss-legendre nodes in latitude (typically an integer multiple of 512)
+nglv = 2048

--- a/compass/landice/tests/ismip6_run/ismip6_ais_proj2300/ismip6_ais_proj2300_4km_nersc.cfg
+++ b/compass/landice/tests/ismip6_run/ismip6_ais_proj2300/ismip6_ais_proj2300_4km_nersc.cfg
@@ -46,7 +46,7 @@ von_mises_parameter_path = UNKNOWN
 use_face_melting = False
 
 # True if running coupled MALI-sea level model simulation
-sea_level_model = True
+sea_level_model = False
 
 # NOTE: for the directories related to the sea-level model input/outputs, the slash '/' at the end of the directory name is necessary.
 # Path to the base directory containing globally defined ice thickness field for the sea-level model

--- a/compass/landice/tests/ismip6_run/ismip6_ais_proj2300/ismip6_ais_proj2300_4km_nersc.cfg
+++ b/compass/landice/tests/ismip6_run/ismip6_ais_proj2300/ismip6_ais_proj2300_4km_nersc.cfg
@@ -55,6 +55,15 @@ slm_input_ice = /global/cfs/cdirs/fanssie/MALI_projects/SeaLevelModel_Inputs/ice
 # Path to the directory containing earth model for the sea-level model
 slm_input_earth = /global/cfs/cdirs/fanssie/MALI_projects/SeaLevelModel_Inputs/earthmodel/
 
+# Earth structure profile
+# possible values: any file name string of earth model file.
+# Note that there is no single representative earth model for the globe or
+# any region of the globe (e.g., West Antarctica, East Antarctica, Greenland)
+# But for this test, we use 'prem_512.l60K2C.sum18p6.dum19p2.tz19p4.lm22' for West Antarctica
+# and 'prem_coll_512.l120C.ump5.lm10' for East Antarctica. Other earthmodels that can be used
+# should exist in the path defined in the config option 'slm_input_earth'.
+slm_earth_structure = prem_512.l60K2C.sum18p6.dum19p2.tz19p4.lm22
+
 # Path to the diectory containing other input files (present-day global topography and sea-level model grid files)
 slm_input_others = /global/cfs/cdirs/fanssie/MALI_projects/SeaLevelModel_Inputs/others/
 

--- a/compass/landice/tests/ismip6_run/ismip6_ais_proj2300/ismip6_ais_proj2300_4km_nersc.cfg
+++ b/compass/landice/tests/ismip6_run/ismip6_ais_proj2300/ismip6_ais_proj2300_4km_nersc.cfg
@@ -43,7 +43,7 @@ calving_method = restore
 von_mises_parameter_path = UNKNOWN
 
 # Whether facemelting should be included in the runs
-use_face_melting = False
+use_face_melting = True
 
 # True if running coupled MALI-sea level model simulation
 sea_level_model = False

--- a/compass/landice/tests/ismip6_run/ismip6_ais_proj2300/ismip6_ais_proj2300_8km_nersc.cfg
+++ b/compass/landice/tests/ismip6_run/ismip6_ais_proj2300/ismip6_ais_proj2300_8km_nersc.cfg
@@ -44,3 +44,19 @@ von_mises_parameter_path = UNKNOWN
 
 # Whether facemelting should be included in the runs
 use_face_melting = False
+
+# True if running coupled MALI-sea level model simulation
+sea_level_model = True
+
+# NOTE: for the directories related to the sea-level model input/outputs, the slash '/' at the end of the directory name is necessary.
+# Path to the directory containing globally defined ice thickness field for the sea-level model
+slm_input_ice = /global/cfs/cdirs/fanssie/MALI_projects/SeaLevelModel_Inputs/icemodel/
+
+# Path to the directory containing earth model for the sea-level model
+slm_input_earth = /global/cfs/cdirs/fanssie/MALI_projects/SeaLevelModel_Inputs/earthmodel/
+
+# Path to the diectory containing other input files (present-day global topography and sea-level model grid files)
+slm_input_others = /global/cfs/cdirs/fanssie/MALI_projects/SeaLevelModel_Inputs/others/
+
+# number of gauss-legendre nodes in latitude (typically an integer multiple of 512)
+nglv = 2048

--- a/compass/landice/tests/ismip6_run/ismip6_ais_proj2300/ismip6_ais_proj2300_8km_nersc.cfg
+++ b/compass/landice/tests/ismip6_run/ismip6_ais_proj2300/ismip6_ais_proj2300_8km_nersc.cfg
@@ -46,7 +46,7 @@ von_mises_parameter_path = UNKNOWN
 use_face_melting = False
 
 # True if running coupled MALI-sea level model simulation
-sea_level_model = True
+sea_level_model = False
 
 # NOTE: for the directories related to the sea-level model input/outputs, the slash '/' at the end of the directory name is necessary.
 # Path to the directory containing globally defined ice thickness field for the sea-level model

--- a/compass/landice/tests/ismip6_run/ismip6_ais_proj2300/ismip6_ais_proj2300_8km_nersc.cfg
+++ b/compass/landice/tests/ismip6_run/ismip6_ais_proj2300/ismip6_ais_proj2300_8km_nersc.cfg
@@ -55,6 +55,15 @@ slm_input_ice = /global/cfs/cdirs/fanssie/MALI_projects/SeaLevelModel_Inputs/ice
 # Path to the directory containing earth model for the sea-level model
 slm_input_earth = /global/cfs/cdirs/fanssie/MALI_projects/SeaLevelModel_Inputs/earthmodel/
 
+# Earth structure profile
+# possible values: any file name string of earth model file.
+# Note that there is no single representative earth model for the globe or
+# any region of the globe (e.g., West Antarctica, East Antarctica, Greenland)
+# But for this test, we use 'prem_512.l60K2C.sum18p6.dum19p2.tz19p4.lm22' for West Antarctica
+# and 'prem_coll_512.l120C.ump5.lm10' for East Antarctica. Other earthmodels that can be used
+# should exist in the path defined in the config option 'slm_input_earth'.
+slm_earth_structure = prem_512.l60K2C.sum18p6.dum19p2.tz19p4.lm22
+
 # Path to the diectory containing other input files (present-day global topography and sea-level model grid files)
 slm_input_others = /global/cfs/cdirs/fanssie/MALI_projects/SeaLevelModel_Inputs/others/
 

--- a/compass/landice/tests/ismip6_run/ismip6_ais_proj2300/namelist.landice
+++ b/compass/landice/tests/ismip6_run/ismip6_ais_proj2300/namelist.landice
@@ -6,6 +6,11 @@
     config_thickness_advection = 'fo'
     config_tracer_advection = 'fo'
 
+    config_uplift_method = 'none'
+    config_slm_coupling_interval = '0005-00-00_00:00:00'
+    config_MALI_to_SLM_weights_file = 'mapfile_mali_to_slm.nc'
+    config_SLM_to_MALI_weights_file = 'mapfile_slm_to_mali.nc'
+
     config_calving = 'none'
     config_apply_calving_mask = .false.
     config_restore_calving_front_prevent_retreat = .false.

--- a/compass/landice/tests/ismip6_run/ismip6_ais_proj2300/namelist.landice
+++ b/compass/landice/tests/ismip6_run/ismip6_ais_proj2300/namelist.landice
@@ -7,7 +7,7 @@
     config_tracer_advection = 'fo'
 
     config_uplift_method = 'none'
-    config_slm_coupling_interval = '0005-00-00_00:00:00'
+    config_slm_coupling_interval = 5
     config_MALI_to_SLM_weights_file = 'mapfile_mali_to_slm.nc'
     config_SLM_to_MALI_weights_file = 'mapfile_slm_to_mali.nc'
 
@@ -55,7 +55,7 @@
     config_do_restart = .true.
     config_restart_timestamp_name = 'restart_timestamp'
     config_start_time ='file'
-    config_stop_time = '2300-01-01_00:00:00'
+    config_stop_time = '2301-01-01_00:00:00'
     config_calendar_type = 'noleap'
 
     config_stats_interval = 0

--- a/compass/landice/tests/ismip6_run/ismip6_ais_proj2300/namelist.sealevel.template
+++ b/compass/landice/tests/ismip6_run/ismip6_ais_proj2300/namelist.sealevel.template
@@ -1,0 +1,66 @@
+&time_config
+    itersl = 1
+    starttime = 2015
+    dt1 = 5
+
+/
+&model_resolution
+    norder = 512
+    nglv = "{{ nglv }}"
+
+/
+&io_directory
+    inputfolder_ice = "{{ slm_input_ice }}"
+    inputfolder = "{{ slm_input_others }}"
+    planetfolder = "{{ slm_input_earth }}"
+    gridfolder = "{{ slm_input_others }}"
+    outputfolder = OUTPUT_SLM/
+    outputfolder_ice = ICELOAD_SLM/
+    folder_coupled = ''
+
+/
+&file_format
+    ext =''
+    fType_in = 'text'
+    fType_out = 'both'
+
+/
+&file_name
+    planetmodel   = 'prem_512.l60K2C.sum18p6.dum19p2.tz19p4.lm22'
+    icemodel      = 'iceGlobalDomain_'
+    icemodel_out  = 'iceload_out_'
+    timearray     = 'times'
+    topomodel     = 'etopo2_{{ nglv }}_AISbedmap2'
+    topo_initial  = 'etopo2_{{ nglv }}_AISbedmap2'
+    grid_lat      = 'GLlat_{{ nglv }}.txt'
+    grid_lon      = 'GLlon_{{ nglv}}.txt'
+
+/
+&model_config
+    checkmarine = .true.
+    tpw = .true.
+    calcRG = .true.
+    input_times = .false.
+    initial_topo = .true.
+    iceVolume = .true.
+    coupling = .true.
+    patch_ice = .false.
+
+/
+&timewindow_config
+    L_sim = 285
+    dt1 = 5
+    dt2 = 10
+    dt3 = 10
+    dt4 = 10
+    Ldt1 = 285
+    Ldt2 = 0
+    Ldt3 = 0
+    Ldt4 = 0
+
+/
+&others
+    whichplanet = 'earth'
+
+
+/

--- a/compass/landice/tests/ismip6_run/ismip6_ais_proj2300/namelist.sealevel.template
+++ b/compass/landice/tests/ismip6_run/ismip6_ais_proj2300/namelist.sealevel.template
@@ -27,7 +27,7 @@
 /
 &file_name
     planetmodel   = 'prem_512.l60K2C.sum18p6.dum19p2.tz19p4.lm22'
-    icemodel      = 'iceGlobalDomain_'
+    icemodel      = 'iceGlobalDomain_zeroField_GL{{ nglv }}_`
     icemodel_out  = 'iceload_out_'
     timearray     = 'times'
     topomodel     = 'etopo2_{{ nglv }}_AISbedmap2'
@@ -37,7 +37,7 @@
 
 /
 &model_config
-    checkmarine = .true.
+    checkmarine = .false.
     tpw = .true.
     calcRG = .true.
     input_times = .false.

--- a/compass/landice/tests/ismip6_run/ismip6_ais_proj2300/namelist.sealevel.template
+++ b/compass/landice/tests/ismip6_run/ismip6_ais_proj2300/namelist.sealevel.template
@@ -1,21 +1,21 @@
 &time_config
     itersl = 1
-    starttime = 2015
+    starttime = 2000
     dt1 = 5
 
 /
 &model_resolution
     norder = 512
-    nglv = "{{ nglv }}"
+    nglv = {{ nglv }}
 
 /
 &io_directory
-    inputfolder_ice = "{{ slm_input_ice }}"
-    inputfolder = "{{ slm_input_others }}"
-    planetfolder = "{{ slm_input_earth }}"
-    gridfolder = "{{ slm_input_others }}"
-    outputfolder = OUTPUT_SLM/
-    outputfolder_ice = ICELOAD_SLM/
+    inputfolder_ice = '{{ slm_input_ice }}'
+    inputfolder = '{{ slm_input_others }}'
+    planetfolder = '{{ slm_input_earth }}'
+    gridfolder = '{{ slm_input_others }}'
+    outputfolder = 'OUTPUT_SLM/'
+    outputfolder_ice = 'ICELOAD_SLM/'
     folder_coupled = ''
 
 /
@@ -27,13 +27,13 @@
 /
 &file_name
     planetmodel   = '{{  slm_earth_structure  }}'
-    icemodel      = 'iceGlobalDomain_zeroField_GL{{ nglv }}_`
+    icemodel      = 'iceGlobalDomain_zeroField_GL{{ nglv }}_'
     icemodel_out  = 'iceload_out_'
     timearray     = 'times'
-    topomodel     = 'etopo2_{{ nglv }}_AISbedmap2'
-    topo_initial  = 'etopo2_{{ nglv }}_AISbedmap2'
+    topomodel     = 'etopo2_nglv{{ nglv }}_outside_AIS'
+    topo_initial  = 'etopo2_nglv{{ nglv }}_outside_AIS'
     grid_lat      = 'GLlat_{{ nglv }}.txt'
-    grid_lon      = 'GLlon_{{ nglv}}.txt'
+    grid_lon      = 'GLlon_{{ nglv }}.txt'
 
 /
 &model_config
@@ -64,3 +64,5 @@
 
 
 /
+
+! end of the namelist file

--- a/compass/landice/tests/ismip6_run/ismip6_ais_proj2300/namelist.sealevel.template
+++ b/compass/landice/tests/ismip6_run/ismip6_ais_proj2300/namelist.sealevel.template
@@ -26,7 +26,7 @@
 
 /
 &file_name
-    planetmodel   = 'prem_512.l60K2C.sum18p6.dum19p2.tz19p4.lm22'
+    planetmodel   = '{{  slm_earth_structure  }}'
     icemodel      = 'iceGlobalDomain_zeroField_GL{{ nglv }}_`
     icemodel_out  = 'iceload_out_'
     timearray     = 'times'

--- a/compass/landice/tests/ismip6_run/ismip6_ais_proj2300/set_up_experiment.py
+++ b/compass/landice/tests/ismip6_run/ismip6_ais_proj2300/set_up_experiment.py
@@ -5,8 +5,6 @@ import sys
 from importlib import resources
 
 from jinja2 import Template
-from mpas_tools.logging import check_call
-from mpas_tools.scrip.from_mpas import scrip_from_mpas
 
 from compass.io import symlink
 from compass.job import write_job_script
@@ -252,7 +250,7 @@ class SetUpExperiment(Step):
                                    slm_earth_structure=slm_earth_structure,
                                    slm_input_others=slm_input_others)
 
-            # write out the namelise.sealevel file
+            # write out the namelist.sealevel file
             file_slm_nl = os.path.join(self.work_dir, 'namelist.sealevel')
             with open(file_slm_nl, 'w') as handle:
                 handle.write(text)
@@ -262,6 +260,14 @@ class SetUpExperiment(Step):
                         exist_ok='True')
             os.makedirs(os.path.join(self.work_dir, 'ICELOAD_SLM/'),
                         exist_ok='True')
+
+            # link in SLM mapping files
+            # they don't exist yet, but we can create symlinks now
+            map_dir = os.path.join('..', 'mapping_files')
+            for map_file in ('mapfile_mali_to_slm.nc',
+                             'mapfile_slm_to_mali.nc'):
+                os.symlink(os.path.join(map_dir, map_file),
+                           os.path.join(self.work_dir, map_file))
 
         # For all projection runs, symlink the restart file for the
         # historical run
@@ -314,93 +320,18 @@ class SetUpExperiment(Step):
         """
 
         config = self.config
-        logger = self.logger
         section = config['ismip6_run_ais_2300']
         sea_level_model = section.getboolean('sea_level_model')
         if sea_level_model:
-            self._build_mapping_files(config, logger)
+            # Check if mapping files were generated
+            map_dir = os.path.join('..', 'mapping_files')
+            for map_file in ('mapfile_mali_to_slm.nc',
+                             'mapfile_slm_to_mali.nc'):
+                if not os.path.isfile(os.path.join(map_dir, map_file)):
+                    sys.exit(f"ERROR: 'mapping_files/{map_file}'"
+                             "does not exist in workdir."
+                             "Please run the 'mapping_files' step"
+                             "before proceeding.")
 
         run_model(step=self, namelist='namelist.landice',
                   streams='streams.landice')
-
-    def _build_mapping_files(self, config, logger):
-        """
-        Build mapping files between the MALI mesh and the SLM grid.
-
-        Parameters
-        ----------
-        config : compass.config.CompassConfigParser
-            Configuration options for a ismip6 forcing test case
-
-        logger : logging.Logger
-            A logger for output from the step
-        """
-
-        config = self.config
-        section = config['ismip6_run_ais_2300']
-        init_cond_path = section.get('init_cond_path')
-        nglv = section.getint('nglv')
-
-        # create the mapping files
-        # first create scrip files
-        mali_scripfile = 'mali_scripfile.nc'
-        slm_scripfile = f'slm_nglv{nglv}scripfile.nc'
-        mali_meshfile = 'mali_meshfile_sphereLatLon.nc'
-
-        # slm scripfile
-        logger.info(f'creating scripfile for the SLM grid with '
-                    f'{nglv} Gauss-Legendre points in latitude')
-
-        args = ['ncremap',
-                '-g', slm_scripfile,
-                '-G',
-                f'latlon={nglv},{2*int(nglv)}#lat_typ=gss#lat_drc=n2s']
-
-        check_call(args, logger=logger)
-
-        # mali scripfile
-        # first have to adjust lat-lon values as if they are on sphere
-        shutil.copy(init_cond_path, mali_meshfile)
-        args = ['set_lat_lon_fields_in_planar_grid.py',
-                '--file', mali_meshfile,
-                '--proj', 'ais-bedmap2-sphere']
-
-        check_call(args, logger=logger)
-
-        logger.info('creating scrip file for the mali mesh')
-        scrip_from_mpas(mali_meshfile, mali_scripfile)
-
-        # create mapping file from MALI mesh to SLM grid
-        logger.info('creating MALI -> SLM grid mapfile with bilinear method')
-
-        parallel_executable = config.get("parallel", "parallel_executable")
-        # split the parallel executable into constituents
-        args = parallel_executable.split(' ')
-        args.extend(['ESMF_RegridWeightGen',
-                     '-s', mali_scripfile,
-                     '-d', slm_scripfile,
-                     '-w', 'mapfile_mali_to_slm.nc',
-                     '-m', 'conserve',
-                     '-i', '-64bit_offset', '--netcdf4',
-                     '--src_regional'])
-
-        check_call(args, logger)
-
-        # create mapping file from SLM grid to MALI mesh
-        logger.info('SLM -> MALI mesh mapfile with bilinear method')
-        args = parallel_executable.split(' ')
-        args.extend(['ESMF_RegridWeightGen',
-                     '-s', slm_scripfile,
-                     '-d', mali_scripfile,
-                     '-w', 'mapfile_slm_to_mali.nc',
-                     '-m', 'bilinear',
-                     '-i', '-64bit_offset', '--netcdf4',
-                     '--dst_regional'])
-
-        check_call(args, logger)
-
-        # remove the scripfiles and copied mesh file
-        logger.info('Removing the temporary mesh and scripfiles...')
-        os.remove(slm_scripfile)
-        os.remove(mali_scripfile)
-        os.remove(mali_meshfile)

--- a/compass/landice/tests/ismip6_run/ismip6_ais_proj2300/set_up_experiment.py
+++ b/compass/landice/tests/ismip6_run/ismip6_ais_proj2300/set_up_experiment.py
@@ -229,6 +229,7 @@ class SetUpExperiment(Step):
             # get config options
             slm_input_ice = section.get('slm_input_ice')
             slm_input_earth = section.get('slm_input_earth')
+            slm_earth_structure = section.get('slm_earth_structure')
             slm_input_others = section.get('slm_input_others')
             nglv = section.getint('nglv')
 
@@ -248,6 +249,7 @@ class SetUpExperiment(Step):
                                  'namelist.sealevel.template'))
             text = template.render(nglv=int(nglv), slm_input_ice=slm_input_ice,
                                    slm_input_earth=slm_input_earth,
+                                   slm_earth_structure=slm_earth_structure,
                                    slm_input_others=slm_input_others)
 
             # write out the namelise.sealevel file

--- a/compass/landice/tests/ismip6_run/ismip6_ais_proj2300/set_up_experiment.py
+++ b/compass/landice/tests/ismip6_run/ismip6_ais_proj2300/set_up_experiment.py
@@ -5,6 +5,8 @@ import sys
 from importlib import resources
 
 from jinja2 import Template
+from mpas_tools.logging import check_call
+from mpas_tools.scrip.from_mpas import scrip_from_mpas
 
 from compass.io import symlink
 from compass.job import write_job_script
@@ -259,9 +261,6 @@ class SetUpExperiment(Step):
             os.makedirs(os.path.join(self.work_dir, 'ICELOAD_SLM/'),
                         exist_ok='True')
 
-            # create the mapping files
-            # HH place holder
-
         # For all projection runs, symlink the restart file for the
         # historical run
         # don't symlink restart_timestamp or you'll have a mighty mess
@@ -311,5 +310,95 @@ class SetUpExperiment(Step):
         """
         Run this step of the test case
         """
+
+        config = self.config
+        logger = self.logger
+        section = config['ismip6_run_ais_2300']
+        sea_level_model = section.getboolean('sea_level_model')
+        if sea_level_model:
+            self._build_mapping_files(config, logger)
+
         run_model(step=self, namelist='namelist.landice',
                   streams='streams.landice')
+
+    def _build_mapping_files(self, config, logger):
+        """
+        Build mapping files between the MALI mesh and the SLM grid.
+
+        Parameters
+        ----------
+        config : compass.config.CompassConfigParser
+            Configuration options for a ismip6 forcing test case
+
+        logger : logging.Logger
+            A logger for output from the step
+        """
+
+        config = self.config
+        section = config['ismip6_run_ais_2300']
+        init_cond_path = section.get('init_cond_path')
+        nglv = section.getint('nglv')
+
+        # create the mapping files
+        # first create scrip files
+        mali_scripfile = 'mali_scripfile.nc'
+        slm_scripfile = f'slm_nglv{nglv}scripfile.nc'
+        mali_meshfile = 'mali_meshfile.nc'
+
+        # slm scripfile
+        logger.info(f'creating scripfile for the SLM grid with '
+                    f'{nglv} Gauss-Legendre points in latitude')
+
+        args = ['ncremap',
+                '-g', slm_scripfile,
+                '-G',
+                f'latlon={nglv},{2*int(nglv)}#lat_typ=gss#lat_drc=n2s']
+
+        check_call(args, logger=logger)
+
+        # mali scripfile
+        # first have to adjust lat-lon values as if they are on sphere
+        shutil.copy(init_cond_path, mali_meshfile)
+        args = ['set_lat_lon_fields_in_planar_grid.py',
+                '--file', mali_meshfile,
+                '--proj', 'ais-bedmap2-sphere']
+
+        check_call(args, logger=logger)
+
+        logger.info('creating scrip file for the mali mesh')
+        scrip_from_mpas(mali_meshfile, mali_scripfile)
+
+        # create mapping file from MALI mesh to SLM grid
+        logger.info('creating MALI -> SLM grid mapfile with bilinear method')
+
+        parallel_executable = config.get("parallel", "parallel_executable")
+        # split the parallel executable into constituents
+        args = parallel_executable.split(' ')
+        args.extend(['ESMF_RegridWeightGen',
+                     '-s', mali_scripfile,
+                     '-d', slm_scripfile,
+                     '-w', 'mapfile_mali_to_slm.nc',
+                     '-m', 'conserve',
+                     '-i', '-64bit_offset', '--netcdf4',
+                     '--src_regional'])
+
+        check_call(args, logger)
+
+        # create mapping file from SLM grid to MALI mesh
+        logger.info('SLM -> MALI mesh mapfile with blinear method')
+        args = parallel_executable.split(' ')
+        args.extend(['ESMF_RegridWeightGen',
+                     '-s', slm_scripfile,
+                     '-d', mali_scripfile,
+                     '-w', 'mapfile_slm_to_mali.nc',
+                     '-m', 'bilinear',
+                     '-i', '-64bit_offset', '--netcdf4',
+                     '--dst_regional'])
+
+        check_call(args, logger)
+
+        # remove the scripfiles and copied mesh file
+        logger.info('Removing the temporary mesh and scripfiles...')
+        os.remove(slm_scripfile)
+        os.remove(mali_scripfile)
+        os.remove(mali_meshfile)

--- a/compass/landice/tests/ismip6_run/ismip6_ais_proj2300/set_up_experiment.py
+++ b/compass/landice/tests/ismip6_run/ismip6_ais_proj2300/set_up_experiment.py
@@ -232,7 +232,7 @@ class SetUpExperiment(Step):
             slm_input_others = section.get('slm_input_others')
             nglv = section.getint('nglv')
 
-            # complate the full paths to the SLM inputs
+            # complete the full paths to the SLM inputs
             slm_input_ice = os.path.join(slm_input_ice,
                                          f'GL{nglv}/ice_noGrIS_GL{nglv}/')
             slm_input_others = os.path.join(slm_input_others,
@@ -343,7 +343,7 @@ class SetUpExperiment(Step):
         # first create scrip files
         mali_scripfile = 'mali_scripfile.nc'
         slm_scripfile = f'slm_nglv{nglv}scripfile.nc'
-        mali_meshfile = 'mali_meshfile.nc'
+        mali_meshfile = 'mali_meshfile_sphereLatLon.nc'
 
         # slm scripfile
         logger.info(f'creating scripfile for the SLM grid with '
@@ -385,7 +385,7 @@ class SetUpExperiment(Step):
         check_call(args, logger)
 
         # create mapping file from SLM grid to MALI mesh
-        logger.info('SLM -> MALI mesh mapfile with blinear method')
+        logger.info('SLM -> MALI mesh mapfile with bilinear method')
         args = parallel_executable.split(' ')
         args.extend(['ESMF_RegridWeightGen',
                      '-s', slm_scripfile,

--- a/compass/landice/tests/ismip6_run/ismip6_ais_proj2300/set_up_experiment.py
+++ b/compass/landice/tests/ismip6_run/ismip6_ais_proj2300/set_up_experiment.py
@@ -228,8 +228,13 @@ class SetUpExperiment(Step):
             slm_input_ice = section.get('slm_input_ice')
             slm_input_earth = section.get('slm_input_earth')
             slm_input_others = section.get('slm_input_others')
-            # nglv = section.getint('nglv')
+            nglv = section.getint('nglv')
 
+            # complate the full paths to the SLM inputs
+            slm_input_ice = os.path.join(slm_input_ice,
+                                         f'GL{nglv}/ice_noGrIS_GL{nglv}/')
+            slm_input_others = os.path.join(slm_input_others,
+                                            f'GL{nglv}/')
             # incorporate the SLM config in the landice namelist
             options = {'config_uplift_method': "'sealevelmodel'"}
             self.add_namelist_options(options=options,
@@ -239,7 +244,7 @@ class SetUpExperiment(Step):
             template = Template(resources.read_text
                                 (resource_location,
                                  'namelist.sealevel.template'))
-            text = template.render(slm_input_ice=slm_input_ice,
+            text = template.render(nglv=int(nglv), slm_input_ice=slm_input_ice,
                                    slm_input_earth=slm_input_earth,
                                    slm_input_others=slm_input_others)
 

--- a/docs/developers_guide/landice/test_groups/ismip6_run.rst
+++ b/docs/developers_guide/landice/test_groups/ismip6_run.rst
@@ -5,6 +5,7 @@ ismip6_run
 
 The ``ismip6_run`` test group (:py:class:`compass.landice.tests.ismip6_run`)
 sets up experiments from the ISMIP6 experimental protocol.
+Additionally, the test group has an option to setup coupled MALI-Sea Level Model (SLM) simulations.
 (see :ref:`landice_ismip6_run`).
 
 framework
@@ -18,7 +19,7 @@ ismip6_ais_proj2300
 -------------------
 
 The :py:class:`compass.landice.tests.ismip6_run.ismip6_ais_proj2300.Ismip6AisProj2300`
-sets up an ensemble of ISMIP6 Antarctica 2300
+sets up an ensemble of ISMIP6 Antarctica 2300 (standalone MALI and coupled MALI-SLM)
 simulations.  The constructor (``__init__``) does nothing other than
 allow the ``ismip6_ais_proj2300`` test case to be listed by ``compass list``
 without having all individual experiments listed in a verbose listing.
@@ -54,5 +55,7 @@ submitted as an independent slurm job.
 Finally, a symlink to the compass load script is added to the run work
 directory, which compass does not do by default.
 
-The ``run`` method runs MALI for the given experiment.
+The ``run`` runs MALI for the given experiment. It also builds mapping files
+between MALI and the SLM by calling a local method ``_build_mapping_files``
+if the SLM option in the config file is enabled.
 

--- a/docs/developers_guide/landice/test_groups/ismip6_run.rst
+++ b/docs/developers_guide/landice/test_groups/ismip6_run.rst
@@ -59,3 +59,25 @@ The ``run`` runs MALI for the given experiment. It also builds mapping files
 between MALI and the SLM by calling a local method ``_build_mapping_files``
 if the SLM option in the config file is enabled.
 
+Important notes for analyzing coupled MALI-SLM simulations
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Currently, MALI uses a planar mesh that projects the south pole with
+polar stereographic projection of ellipsoidal Earth, and the sea-level model
+uses a global grid of spherical Earth. This inconsistency in the Earth's
+assumed shape (ellipsoid vs. sphere) in MALI and the SLM causes discrepancies
+in the comparison of post-simulation ice mass calculations from the model outputs.
+To address this issue, an interim solution has been made to project the southern
+polar region onto the MALI planar mesh assuming a sphere (this is done by setting
+the lat/long in the MALI mesh using the 'aid-bedmap2-sphere' projection string in
+calling the function in 'set_lat_lon_fields_in_planar_grid.py'. Thus, the resulting
+MALI mesh for coupled MALI-SLM simulations that are setup from this testgroup have
+the lat/long values based off sphere. Once the simulation outputs are generated,
+it is necessary to calculate and apply the scaling factors to the MALI outputs
+to correct for the areal distortion arose from projecting the south pole on a sphere
+onto plane. Only after applying the scaling factor, the MALI outputs will be
+comparable to the SLM outputs. The equations to calculate the scaling factors are shown in
+Eqn. 21-4 in https://pubs.usgs.gov/pp/1395/report.pdf
+An example of the calculation for the MALI-SLM case can also be found in
+the ``compass`` testgroup/testcase/ ``compass/landice/test/slm/circ_icesheet/``,
+``visualize`` step (https://github.com/MPAS-Dev/compass/pull/748).

--- a/docs/users_guide/landice/test_groups/ismip6_run.rst
+++ b/docs/users_guide/landice/test_groups/ismip6_run.rst
@@ -158,3 +158,26 @@ Steps for setting up and running experiments
 Note that the ``hist`` run must be completed before any of the other
 experiments can be run.  A symlink to the ``hist`` restart file from year
 2015 exists in each of the other experiment subdirectories.
+
+Important notes for analyzing coupled MALI-SLM simulations
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Currently, MALI uses a planar mesh that projects the south pole with
+polar stereographic projection of ellipsoidal Earth, and the sea-level model
+uses a global grid of spherical Earth. This inconsistency in the Earth's
+assumed shape (ellipsoid vs. sphere) in MALI and the SLM causes discrepancies
+in the comparison of post-simulation ice mass calculations from the model outputs.
+To address this issue, an interim solution has been made to project the southern
+polar region onto the MALI planar mesh assuming a sphere (this is done by setting
+the lat/long in the MALI mesh using the 'aid-bedmap2-sphere' projection string in
+calling the function in 'set_lat_lon_fields_in_planar_grid.py'. Thus, the resulting
+MALI mesh for coupled MALI-SLM simulations that are setup from this testgroup have
+the lat/long values based off sphere. Once the simulation outputs are generated,
+it is necessary to calculate and apply the scaling factors to the MALI outputs
+to correct for the areal distortion arose from projecting the south pole on a sphere
+onto plane. Only after applying the scaling factor, the MALI outputs will be
+comparable to the SLM outputs. The equations to calculate the scaling factors are shown in
+Eqn. 21-4 in https://pubs.usgs.gov/pp/1395/report.pdf
+An example of the calculation for the MALI-SLM case can also be found in
+the ``compass`` testgroup/testcase/ ``compass/landice/test/slm/circ_icesheet/``,
+``visualize`` step (https://github.com/MPAS-Dev/compass/pull/748).

--- a/docs/users_guide/landice/test_groups/ismip6_run.rst
+++ b/docs/users_guide/landice/test_groups/ismip6_run.rst
@@ -89,6 +89,22 @@ for new runs
     # Whether facemelting should be included in the runs
     include_face_melting = False
 
+    # True if running coupled MALI-sea level model simulation
+    sea_level_model = True
+
+    # NOTE: for the directories related to the sea-level model input/outputs, the slash '/' at the end of the directory name is necessary.
+    # Path to the base directory containing globally defined ice thickness field for the sea-level model
+    slm_input_ice = /global/cfs/cdirs/fanssie/MALI_projects/SeaLevelModel_Inputs/icemodel/
+
+    # Path to the directory containing earth model for the sea-level model
+    slm_input_earth = /global/cfs/cdirs/fanssie/MALI_projects/SeaLevelModel_Inputs/earthmodel/
+
+    # Path to the diectory containing other input files (present-day global topography and sea-level model grid files)
+    slm_input_others = /global/cfs/cdirs/fanssie/MALI_projects/SeaLevelModel_Inputs/others/
+
+    # number of gauss-legendre nodes in latitude (typically an integer multiple of 512)
+    nglv = 2048
+
 Additionally, a user should also include the following options (and possibly
 others) that will be used for submitting the jobs for each ensemble member
 (set to appropriate values for their usage situation):

--- a/docs/users_guide/landice/test_groups/ismip6_run.rst
+++ b/docs/users_guide/landice/test_groups/ismip6_run.rst
@@ -99,6 +99,15 @@ for new runs
     # Path to the directory containing earth model for the sea-level model
     slm_input_earth = /global/cfs/cdirs/fanssie/MALI_projects/SeaLevelModel_Inputs/earthmodel/
 
+    # Earth structure profile
+    # possible values: any file name string of earth model file.
+    # Note that there is no single representative earth model for the globe or
+    # any region of the globe (e.g., West Antarctica, East Antarctica, Greenland)
+    # But for this test, we use 'prem_512.l60K2C.sum18p6.dum19p2.tz19p4.lm22' for West Antarctica
+    # and 'prem_coll_512.l120C.ump5.lm10' for East Antarctica. Other earthmodels that can be used
+    # should exist in the path defined in the config option 'slm_input_earth'.
+    slm_earth_structure = prem_512.l60K2C.sum18p6.dum19p2.tz19p4.lm22
+
     # Path to the diectory containing other input files (present-day global topography and sea-level model grid files)
     slm_input_others = /global/cfs/cdirs/fanssie/MALI_projects/SeaLevelModel_Inputs/others/
 

--- a/docs/users_guide/landice/test_groups/ismip6_run.rst
+++ b/docs/users_guide/landice/test_groups/ismip6_run.rst
@@ -125,10 +125,10 @@ others) that will be used for submitting the jobs for each ensemble member
     qos = regular
 
     [job]
-    wall_time = 10:00:00 
+    wall_time = 10:00:00
 
 Steps for setting up and running experiments
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+--------------------------------------------
 
 1. With a compass conda environment set up, run, e.g.,
    ``compass setup -t landice/ismip6_run/ismip6_ais_proj2300 -w WORK_DIR_PATH -f USER.cfg``
@@ -159,8 +159,11 @@ Note that the ``hist`` run must be completed before any of the other
 experiments can be run.  A symlink to the ``hist`` restart file from year
 2015 exists in each of the other experiment subdirectories.
 
-Important notes for analyzing coupled MALI-SLM simulations
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Important notes for running coupled MALI-SLM simulations
+--------------------------------------------------------
+
+Projection handling
+~~~~~~~~~~~~~~~~~~~
 
 Currently, MALI uses a planar mesh that projects the south pole with
 polar stereographic projection of ellipsoidal Earth, and the sea-level model
@@ -181,3 +184,24 @@ Eqn. 21-4 in https://pubs.usgs.gov/pp/1395/report.pdf
 An example of the calculation for the MALI-SLM case can also be found in
 the ``compass`` testgroup/testcase/ ``compass/landice/test/slm/circ_icesheet/``,
 ``visualize`` step (https://github.com/MPAS-Dev/compass/pull/748).
+
+Mapping files
+~~~~~~~~~~~~~
+
+Coupling between the Sea-Level Model and MALI requires the generation of mapping files
+before simulations are run.  When ``sea_level_model=True`` in the cfg file, an
+additional test case step is created named ``mapping_files``.  Before any MALI
+simulations are started, the user should run this step.  It will generate the required
+mapping files, and they will be available in each experiment directory through symlinks.
+Once the mapping files have been generated, the user can proceed to running the ``hist``
+experiment.
+
+Restarts
+~~~~~~~~
+
+Additionally, for restarts with the SLM to work correctly, the entire history of the
+``OUTPUT_SLM`` and ``ICELOAD_SLM`` directories must be present.  Because the projection
+experiments (ctrl and exp*) are branched off the hist run as restarts, this means these
+two directories from the hist run must be manually copied to each projection run before
+beginning it. There is not an easy way for this to happen automatically, so this step
+must be done manually.


### PR DESCRIPTION
This PR adds to the `/landice/ismip6_run/ismip_ais_proj2300` testcase the option to setup coupled MALI-Sea Level Model simulations using the ismip6-Antarctica-2300 experimental protocol. 

With these changes, inclusion of the SLM can be activated through a test case cfg option.  This will set up required namelist and input settings, as well as the namelist.sealevel file used by SLM.  It will also set up an additional test case step that generates the required mapping files between MALI and SLM.  This must be run before any of the experiments are run.

This PR requires addition of Pyproj string `projections['ais-bedmap2-sphere'] = '+proj=stere +lat_ts=-71.0 +lat_0=-90 +lon_0=0.0 +k_0=1.0 +x_0=0.0 +y_0=0.0 +ellps=sphere'` in the MPAS-Tools script `set_lat_lon_fields_in_planar_grid.py` to set the latitude and longitude values as if MALI was projected on sphere rather than ellipse. The requirement has been merged here (https://github.com/MPAS-Dev/MPAS-Tools/pull/559/files).