### PR TITLE
Remove mamba commands and switch to Miniforge

### DIFF
--- a/.github/workflows/build_workflow.yml
+++ b/.github/workflows/build_workflow.yml
@@ -82,13 +82,10 @@ jobs:
 
       - if: ${{ steps.skip_check.outputs.should_skip != 'true' }}
         name: Set up Conda Environment
-        uses: conda-incubator/setup-miniconda@v2
+        uses: conda-incubator/setup-miniconda@v3
         with:
           activate-environment: "compass_ci"
-          miniforge-variant: Mambaforge
           miniforge-version: latest
-          use-mamba: true
-          mamba-version: "*"
           channels: conda-forge,e3sm/label/compass,defaults
           channel-priority: strict
           auto-update-conda: true

--- a/.github/workflows/docs_workflow.yml
+++ b/.github/workflows/docs_workflow.yml
@@ -34,13 +34,10 @@ jobs:
 
       - if: ${{ steps.skip_check.outputs.should_skip != 'true' }}
         name: Set up Conda Environment
-        uses: conda-incubator/setup-miniconda@v2
+        uses: conda-incubator/setup-miniconda@v3
         with:
           activate-environment: "compass_ci"
-          miniforge-variant: Mambaforge
           miniforge-version: latest
-          use-mamba: true
-          mamba-version: "*"
           channels: conda-forge,e3sm/label/compass,defaults
           channel-priority: strict
           auto-update-conda: true

--- a/conda/bootstrap.py
+++ b/conda/bootstrap.py
@@ -22,7 +22,7 @@ from shared import (
     get_conda_base,
     get_logger,
     get_spack_base,
-    install_miniconda,
+    install_miniforge,
     log_message,
     parse_args,
 )
@@ -42,7 +42,7 @@ def get_config(config_file, machine):
             config.read(str(machine_config))
 
         machine_config = os.path.join(here, '..', 'compass', 'machines',
-                                      '{}.cfg'.format(machine))
+                                      f'{machine}.cfg')
         config.read(machine_config)
 
     if config_file is not None:
@@ -229,10 +229,9 @@ def get_env_setup(args, config, machine, compiler, mpi, env_type, source_path,
     env_path = os.path.join(conda_base, 'envs', env_name)
 
     source_activation_scripts = \
-        f'source {conda_base}/etc/profile.d/conda.sh && ' \
-        f'source {conda_base}/etc/profile.d/mamba.sh'
+        f'source {conda_base}/etc/profile.d/conda.sh'
 
-    activate_env = f'{source_activation_scripts} && mamba activate {env_name}'
+    activate_env = f'{source_activation_scripts} && conda activate {env_name}'
 
     return python, recreate, conda_mpi, activ_suffix, env_suffix, \
         activ_path, env_path, env_name, activate_env, spack_env
@@ -244,7 +243,7 @@ def build_conda_env(env_type, recreate, mpi, conda_mpi, version,
                     local_conda_build, logger, local_mache):
 
     if env_type != 'dev':
-        install_miniconda(conda_base, activate_base, logger)
+        install_miniforge(conda_base, activate_base, logger)
 
     if conda_mpi == 'nompi':
         mpi_prefix = 'nompi'
@@ -268,8 +267,7 @@ def build_conda_env(env_type, recreate, mpi, conda_mpi, version,
 
     activate_env = \
         f'source {conda_base}/etc/profile.d/conda.sh &&' \
-        f'source {conda_base}/etc/profile.d/mamba.sh &&' \
-        f'mamba activate {env_name}'
+        f'conda activate {env_name}'
 
     with open(f'{conda_template_path}/spec-file.template', 'r') as f:
         template = Template(f.read())
@@ -299,7 +297,7 @@ def build_conda_env(env_type, recreate, mpi, conda_mpi, version,
             # install dev dependencies and compass itself
             commands = \
                 f'{activate_base} && ' \
-                f'mamba create -y -n {env_name} {channels} ' \
+                f'conda create -y -n {env_name} {channels} ' \
                 f'--file {spec_filename} {packages}'
             check_call(commands, logger=logger)
 
@@ -314,7 +312,7 @@ def build_conda_env(env_type, recreate, mpi, conda_mpi, version,
             version_conda = version.replace('-', '')
             packages = f'{packages} "compass={version_conda}={mpi_prefix}_*"'
             commands = f'{activate_base} && ' \
-                       f'mamba create -y -n {env_name} {channels} {packages}'
+                       f'conda create -y -n {env_name} {channels} {packages}'
             check_call(commands, logger=logger)
     else:
         if env_type == 'dev':
@@ -322,7 +320,7 @@ def build_conda_env(env_type, recreate, mpi, conda_mpi, version,
             # install dev dependencies and compass itself
             commands = \
                 f'{activate_base} && ' \
-                f'mamba install -y -n {env_name} {channels} ' \
+                f'conda install -y -n {env_name} {channels} ' \
                 f'--file {spec_filename} {packages}'
             check_call(commands, logger=logger)
 
@@ -929,10 +927,9 @@ def main():  # noqa: C901
     conda_base = os.path.abspath(conda_base)
 
     source_activation_scripts = \
-        f'source {conda_base}/etc/profile.d/conda.sh && ' \
-        f'source {conda_base}/etc/profile.d/mamba.sh'
+        f'source {conda_base}/etc/profile.d/conda.sh'
 
-    activate_base = f'{source_activation_scripts} && mamba activate'
+    activate_base = f'{source_activation_scripts} && conda activate'
 
     compilers, mpis = get_compilers_mpis(config, machine, args.compilers,
                                          args.mpis, source_path)
@@ -995,7 +992,6 @@ def main():  # noqa: C901
             if local_mache:
                 print('Install local mache\n')
                 commands = f'source {conda_base}/etc/profile.d/conda.sh && ' \
-                           f'source {conda_base}/etc/profile.d/mamba.sh && ' \
                            f'conda activate {conda_env_name} && ' \
                            'cd ../build_mache/mache && ' \
                            'python -m pip install .'

--- a/conda/compass_env/load_compass.template
+++ b/conda/compass_env/load_compass.template
@@ -21,8 +21,7 @@ else
 
 echo Loading conda environment
 source {{ conda_base }}/etc/profile.d/conda.sh
-source {{ conda_base }}/etc/profile.d/mamba.sh
-mamba activate {{ compass_env }}
+conda activate {{ compass_env }}
 echo Done.
 echo
 

--- a/conda/configure_compass_env.py
+++ b/conda/configure_compass_env.py
@@ -8,7 +8,7 @@ from shared import (
     check_call,
     get_conda_base,
     get_logger,
-    install_miniconda,
+    install_miniforge,
     parse_args,
 )
 
@@ -48,11 +48,11 @@ def setup_install_env(env_name, activate_base, use_local, logger, recreate,
     if recreate or not os.path.exists(env_path):
         print('Setting up a conda environment for installing compass\n')
         commands = f'{activate_base} && ' \
-                   f'mamba create -y -n {env_name} {channels} {packages}'
+                   f'conda create -y -n {env_name} {channels} {packages}'
     else:
         print('Updating conda environment for installing compass\n')
         commands = f'{activate_base} && ' \
-                   f'mamba install -y -n {env_name} {channels} {packages}'
+                   f'conda install -y -n {env_name} {channels} {packages}'
 
     check_call(commands, logger=logger)
 
@@ -75,8 +75,7 @@ def main():
     env_name = 'compass_bootstrap'
 
     source_activation_scripts = \
-        f'source {conda_base}/etc/profile.d/conda.sh && ' \
-        f'source {conda_base}/etc/profile.d/mamba.sh'
+        f'source {conda_base}/etc/profile.d/conda.sh'
 
     activate_base = f'{source_activation_scripts} && conda activate'
 
@@ -94,8 +93,8 @@ def main():
         logger = get_logger(log_filename='conda/logs/prebootstrap.log',
                             name=__name__)
 
-    # install miniconda if needed
-    install_miniconda(conda_base, activate_base, logger)
+    # install miniforge if needed
+    install_miniforge(conda_base, activate_base, logger)
 
     local_mache = args.mache_fork is not None and args.mache_branch is not None
     if local_mache:

--- a/conda/shared.py
+++ b/conda/shared.py
@@ -147,28 +147,27 @@ def check_call(commands, env=None, logger=None):
         raise subprocess.CalledProcessError(process.returncode, commands)
 
 
-def install_miniconda(conda_base, activate_base, logger):
+def install_miniforge(conda_base, activate_base, logger):
     if not os.path.exists(conda_base):
-        print('Installing Mambaforge')
+        print('Installing Miniforge3')
         if platform.system() == 'Linux':
             system = 'Linux'
         elif platform.system() == 'Darwin':
             system = 'MacOSX'
         else:
             system = 'Linux'
-        miniconda = f'Mambaforge-{system}-x86_64.sh'
-        url = f'https://github.com/conda-forge/miniforge/releases/latest/download/{miniconda}'  # noqa: E501
+        miniforge = f'Miniforge3-{system}-x86_64.sh'
+        url = f'https://github.com/conda-forge/miniforge/releases/latest/download/{miniforge}'  # noqa: E501
         print(url)
         req = Request(url, headers={'User-Agent': 'Mozilla/5.0'})
-        f = urlopen(req)
-        html = f.read()
-        with open(miniconda, 'wb') as outfile:
-            outfile.write(html)
-        f.close()
+        with urlopen(req) as f:
+            html = f.read()
+            with open(miniforge, 'wb') as outfile:
+                outfile.write(html)
 
-        command = f'/bin/bash {miniconda} -b -p {conda_base}'
+        command = f'/bin/bash {miniforge} -b -p {conda_base}'
         check_call(command, logger=logger)
-        os.remove(miniconda)
+        os.remove(miniforge)
 
     backup_bashrc()
 
@@ -181,8 +180,8 @@ def install_miniconda(conda_base, activate_base, logger):
     check_call(commands, logger=logger)
 
     commands = f'{activate_base} && ' \
-               f'mamba update -y --all && ' \
-               f'mamba init'
+               f'conda update -y --all && ' \
+               f'conda init'
 
     check_call(commands, logger=logger)
 

--- a/docs/developers_guide/deploying_spack.rst
+++ b/docs/developers_guide/deploying_spack.rst
@@ -164,7 +164,7 @@ in this case) as a local worktree:
     cd ../simplify_local_mache/
 
 You will also need a local installation of
-`Mambaforge <https://github.com/conda-forge/miniforge#mambaforge>`_.
+`Miniforge <https://github.com/conda-forge/miniforge?tab=readme-ov-file#miniforge3>`_.
 Compass can do this for you if you haven't already installed it.  If you want
 to download it manually, use the Linux x86_64 version for all our supported
 machines.
@@ -172,20 +172,20 @@ machines.
 .. note::
 
     We have found that an existing Miniconda3 installation **does not** always
-    work well for compass, so please start with Mambaforge instead.
+    work well for compass, so please start with Miniforge3 instead.
 
 .. note::
 
-  You definitely need your own local Mambaforge installation -- you can’t use
+  You definitely need your own local Miniforge3 installation -- you can’t use
   a system version or a shared one like E3SM-Unified.
 
-Define a location where Mambaforge is installed or where you want to install
+Define a location where Miniforge3 is installed or where you want to install
 it:
 
 .. code-block:: bash
 
     # change to your conda installation
-    export CONDA_BASE=${HOME}/mambaforge
+    export CONDA_BASE=${HOME}/miniforge
 
 Okay, we're finally ready to do a test spack build for compass.
 To do this, we call the ``configure_compass_env.py`` script using
@@ -207,7 +207,7 @@ To do this, we call the ``configure_compass_env.py`` script using
         --recreate
 
 The directory you point to with ``--conda`` either doesn't exist or contains
-your existing installation of Mambaforge.
+your existing installation of Miniforge3.
 
 When you supply ``--mache_fork`` and ``--mache_branch``, compass will clone
 a fork of the ``mache`` repo and check out the requested branch, then install

--- a/docs/developers_guide/ocean/test_groups/drying_slope.rst
+++ b/docs/developers_guide/ocean/test_groups/drying_slope.rst
@@ -16,7 +16,7 @@ framework
 The shared config options for the ``drying_slope`` test group are described
 in :ref:`ocean_drying_slope` in the User's Guide.
 
-Additionally, the test group has shared ``namelist.init`` and 
+Additionally, the test group has shared ``namelist.init`` and
 ``namelist.forward`` files with a few common namelist options related to run
 duration, bottom drag, and tidal forcing options, as well as shared
 ``streams.init`` and ``streams.forward`` files that defines ``mesh``, ``input``,
@@ -51,7 +51,7 @@ forward
 
 The class :py:class:`compass.ocean.tests.drying_slope.forward.Forward`
 defines a step for running MPAS-Ocean from the initial condition produced in
-the ``initial_state`` step. If ``damping_coeff`` is provided as an argument to 
+the ``initial_state`` step. If ``damping_coeff`` is provided as an argument to
 the constructor, the associate namelist option
 (``config_Rayleigh_damping_coeff``) will be given this value. MPAS-Ocean is run
 in ``run()``. The time step is determined as a function of resolution by the
@@ -66,11 +66,11 @@ defines a visualization step which serves the purpose of validation. This
 validation is tailored for the default config options and the two Rayleigh
 damping coefficients set by the default sigma-coordinate test case, 0.0025 and
 0.01. One plot verifies that the time evolution of the ssh forcing at the
-boundary matches the analytical solution intended to drive the test case. 
+boundary matches the analytical solution intended to drive the test case.
 Another plot compares the time evolution of the ssh profile across the channel
 between the analytical solution, MPAS-Ocean and ROMS. Similar plots are used
 to create a movie showing the solution from MPAS-Ocean at more fine-grained
-time intervals. 
+time intervals.
 
 analysis
 ~~~~~~~~
@@ -92,7 +92,7 @@ test performs two 12-hour runs on 4 cores. It doesn't contain any
 types are supported. For ``sigma`` coordinates, this case is hard-coded to run
 two cases at different values of ``config_Rayleigh_damping_coeff``, 0.0025 and
 0.01, for which there is comparison data. The ``single_layer`` case runs at one
-value of the implicit bottom drag coefficient. 
+value of the implicit bottom drag coefficient.
 
 .. _dev_ocean_drying_slope_convergence:
 
@@ -114,8 +114,8 @@ test performs two 12-hour runs on 1 and 12 cores, respectively.
 This class accepts resolution and coordinate type ``coord_type`` as arguments.
 Both ``sigma`` and ``single_layer`` coordinate types are supported. For
 ``sigma`` coordinates, this case is hard-coded to run with
- ``config_Rayleigh_damping_coeff`` equal to 0.01. The ``single_layer`` case
-runs at one value of the implicit bottom drag coefficient. 
+``config_Rayleigh_damping_coeff`` equal to 0.01. The ``single_layer`` case
+runs at one value of the implicit bottom drag coefficient.
 
 
 loglaw

--- a/docs/developers_guide/quick_start.rst
+++ b/docs/developers_guide/quick_start.rst
@@ -54,18 +54,18 @@ package because these don't get added automatically.
 
 Whether you are on one of the :ref:`dev_supported_machines` or an "unknown"
 machine, you will need to specify a path where
-`Mambaforge <https://github.com/conda-forge/miniforge#mambaforge>`_ either has
+`Miniforge3 <https://github.com/conda-forge/miniforge?tab=readme-ov-file#miniforge3>`_ either has
 already been installed or an empty directory where the script can install it.
 You must have write permission in the base environment (if it exists).
 
 .. note::
 
     We have found that an existing Miniconda3 installation **does not** always
-    work well for ``compass``, so please start with Mambaforge instead.
+    work well for ``compass``, so please start with Miniforge3 instead.
 
 .. note::
 
-    It is *very* important that you not use a shared installation of Mambaforge
+    It is *very* important that you not use a shared installation of Miniforge3
     or Miniconda3 such as the base environment for E3SM-Unified for ``compass``
     development. Most developers will not have write access to shared
     environments, meaning that you will get write-permission errors when you
@@ -76,8 +76,8 @@ You must have write permission in the base environment (if it exists).
     would be creating your compass development environment in a shared space,
     which could cause confusion.
 
-    Please use your own personal installation of Mambaforge for development,
-    letting ``configure_compass_env.py`` download and install Mambaforge for
+    Please use your own personal installation of Miniforge3 for development,
+    letting ``configure_compass_env.py`` download and install Miniforge3 for
     you if you don't already have it installed.
 
 Supported machines
@@ -91,8 +91,8 @@ If you are on one of the :ref:`dev_supported_machines`, run:
         -c <compiler> [--mpi <mpi>] [-m <machine>] [--with_albany] \
         [--with_petsc]
 
-The ``<base_path_to_install_or_update_conda>`` is typically ``~/mambaforge``.
-This is the location where you would like to install Mambaforge or where it is
+The ``<base_path_to_install_or_update_conda>`` is typically ``~/miniforge3``.
+This is the location where you would like to install Miniforge3 or where it is
 already installed. If you have limited space in your home directory, you may
 want to give another path.  If you already have it installed, that path will
 be used to add (or update) the compass test environment.
@@ -142,8 +142,8 @@ workstation, you will need to specify which flavor of MPI you want to use
 
   ./conda/configure_compass_env.py --conda <conda_path> --mpi <mpi>
 
-Again, the ``<conda_path>`` is typically ``~/mambaforge``, and is the location
-where you would like to install Mambaforge or where it is already installed.
+Again, the ``<conda_path>`` is typically ``~/miniforge3``, and is the location
+where you would like to install Miniforge3 or where it is already installed.
 If you already have it installed, that path will be used to add (or update) the
 compass test environment.
 
@@ -169,7 +169,7 @@ in :ref:`config_files`.
 What the script does
 ~~~~~~~~~~~~~~~~~~~~
 
-In addition to installing Mambaforge and creating the conda environment for
+In addition to installing Miniforge3 and creating the conda environment for
 you, this script will also:
 
 * install the ``compass`` package from the local branch in "development" mode

--- a/docs/tutorials/dev_add_rrm.rst
+++ b/docs/tutorials/dev_add_rrm.rst
@@ -35,9 +35,9 @@ your needs.
 .. code-block:: bash
 
   # this one will take a while the first time
-  ./conda/configure_compass_env.py --conda $HOME/mambaforge --env_name compass_yam
+  ./conda/configure_compass_env.py --conda $HOME/miniforge --env_name compass_yam
 
-If you don't already have Mambaforge installed in the directory pointed to by
+If you don't already have Miniforge3 installed in the directory pointed to by
 ``--conda``, it will be installed automatically for you.  If all goes well, you
 will have a file named ``load_compass_yam*.sh``, where the details of the
 ``*`` depend on your specific machine and compilers.  For example, on

--- a/docs/tutorials/dev_add_test_group.rst
+++ b/docs/tutorials/dev_add_test_group.rst
@@ -34,9 +34,9 @@ your needs.
 .. code-block:: bash
 
   # this one will take a while the first time
-  ./conda/configure_compass_env.py --conda $HOME/mambaforge
+  ./conda/configure_compass_env.py --conda $HOME/miniforge
 
-If you don't already have Mambaforge installed in the directory pointed to by
+If you don't already have Miniforge3 installed in the directory pointed to by
 ``--conda``, it will be installed automatically for you.  If all goes well, you
 will have a file named ``load_dev_compass_1.0.0*.sh``, where the details of the
 ``*`` depend on your specific machine and compilers.  For example, on

--- a/docs/tutorials/dev_porting_legacy.rst
+++ b/docs/tutorials/dev_porting_legacy.rst
@@ -41,7 +41,7 @@ your needs.
 .. code-block:: bash
 
   # this one will take a while the first time
-  ./conda/configure_compass_env.py --conda $HOME/mambaforge
+  ./conda/configure_compass_env.py --conda $HOME/miniforge
 
 If all goes well, you will have a file named ``load_dev_compass_1.0.0*.sh``, where
 the details of the ``*`` depend on your specific machine and compilers.  For

--- a/docs/users_guide/machines/index.rst
+++ b/docs/users_guide/machines/index.rst
@@ -181,7 +181,7 @@ probably via a
 In this case, the ``parallel_executable`` is ``mpirun``.
 
 To install the ``compass`` package into a conda environment, you will first
-need to install `Mambaforge <https://github.com/conda-forge/miniforge#mambaforge>`_
+need to install `Miniforge3 <https://github.com/conda-forge/miniforge?tab=readme-ov-file#miniforge3>`_
 (if it is not already installed).  Then, you will run one of the following
 three commands, depending on how you would like to handle MPI support in the
 conda packages.

--- a/docs/users_guide/quick_start.rst
+++ b/docs/users_guide/quick_start.rst
@@ -64,7 +64,7 @@ other machines
 ~~~~~~~~~~~~~~
 
 To install your own ``compass`` conda environment on other machines, first,
-install `Mambaforge <https://github.com/conda-forge/miniforge#mambaforge>`_
+install `Miniforge3 <https://github.com/conda-forge/miniforge?tab=readme-ov-file#miniforge3>`_
 (if it is not already installed), then create a new conda environment (called
 ``compass`` in this example) as follows:
 

--- a/utils/e3sm_update/README.md
+++ b/utils/e3sm_update/README.md
@@ -15,7 +15,7 @@ Instructions
    compiler and mpi library, e.g.:
    ```shell
    ./conda/configure_compass_env.py --env_name compass_e3sm_update \
-       --compiler intel --mpi openmpi --conda ~/mambaforge/
+       --compiler intel --mpi openmpi --conda ~/miniforge3/
    ```
 
 2. Copy `example.cfg` to the base of the branch:


### PR DESCRIPTION
<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->

Yet again, I ran into problems with the `mamba` command today.  It seems it is time to abandon it and return to the `conda` command instead (along with the `libmamba` solver).

<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [x] User's Guide has been updated
* [x] Developer's Guide has been updated
* [x] Documentation has been [built locally](https://mpas-dev.github.io/compass/latest/developers_guide/building_docs.html) and changes look as expected
* [x] Document (in a comment titled `Testing` in this PR) any testing that was used to verify the changes

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->
