### PR TITLE
Fix land-locked cells at calving fronts

### DIFF
--- a/compass/ocean/tests/global_ocean/global_ocean.cfg
+++ b/compass/ocean/tests/global_ocean/global_ocean.cfg
@@ -10,6 +10,10 @@ cull_mesh_min_cpus_per_task = 1
 cull_mesh_max_memory = 1000
 # Whether to convert the culled mesh file to CDF5 format
 convert_culled_mesh_to_cdf5 = False
+# Minimum latitude, in degrees, for masking land-locked cells
+latitude_threshold = 43.0
+# Maximum number of sweeps to search for land-locked cells
+sweep_count = 20
 
 
 # Options relate to adjusting the sea-surface height or land-ice pressure

--- a/compass/ocean/tests/hurricane/hurricane.cfg
+++ b/compass/ocean/tests/hurricane/hurricane.cfg
@@ -4,3 +4,7 @@
 # Config options related to the step for culling land from the mesh
 # Whether to convert the culled mesh file to CDF5 format
 convert_culled_mesh_to_cdf5 = False
+# Minimum latitude, in degrees, for masking land-locked cells
+latitude_threshold = 43.0
+# Maximum number of sweeps to search for land-locked cells
+sweep_count = 20


### PR DESCRIPTION
<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->

If there are land-locked cells at calving fronts of ice shelves, they need to be added to the land-ice mask so sea-ice doesn't get trapped there.

This merge also gets the minimum latitude and number of sweeps used in finding land-locked cells from config options.

<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [x] Document (in a comment titled `Testing` in this PR) any testing that was used to verify the changes

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->

closes #746 