### PR TITLE
New Mesh: RRSwISC6to18E3r4

### DIFF
--- a/compass/ocean/tests/global_ocean/global_ocean.cfg
+++ b/compass/ocean/tests/global_ocean/global_ocean.cfg
@@ -10,6 +10,10 @@ cull_mesh_min_cpus_per_task = 1
 cull_mesh_max_memory = 1000
 # Whether to convert the culled mesh file to CDF5 format
 convert_culled_mesh_to_cdf5 = False
+# Minimum latitude, in degrees, for masking land-locked cells
+latitude_threshold = 43.0
+# Maximum number of sweeps to search for land-locked cells
+sweep_count = 20
 
 
 # Options relate to adjusting the sea-surface height or land-ice pressure

--- a/compass/ocean/tests/global_ocean/mesh/rrs6to18/dynamic_adjustment.yaml
+++ b/compass/ocean/tests/global_ocean/mesh/rrs6to18/dynamic_adjustment.yaml
@@ -63,6 +63,6 @@ dynamic_adjustment:
       run_duration: 18_00:00:00
       output_interval: 10_00:00:00
       restart_interval: 06_00:00:00
-      dt: 00:06:00
-      btr_dt: 00:00:12
+      dt: 00:05:00
+      btr_dt: 00:00:10
       Rayleigh_damping_coeff: None

--- a/compass/ocean/tests/global_ocean/mesh/rrs6to18/rrs6to18.cfg
+++ b/compass/ocean/tests/global_ocean/mesh/rrs6to18/rrs6to18.cfg
@@ -45,21 +45,22 @@ approx_cell_count = 4000000
 # the prefix (e.g. QU, EC, WC, SO)
 prefix = RRS
 # a description of the mesh and initial condition
-mesh_description = MPAS Eddy Closure mesh for E3SM version ${e3sm_version} with
-                   enhanced resolution around the equator (30 km), South pole
-                   (35 km), Greenland (${min_res} km), ${max_res}-km resolution
-                   at mid latitudes, and ${levels} vertical levels
+mesh_description = MPAS Rossby-radius scaled (RRS) mesh for E3SM version
+                   ${e3sm_version} with ${min_res}-km resolution at the poles,
+                   ${max_res}-km resolution at the equator, and <<<levels>>>
+                   vertical levels. This mesh includes cavities under the ice
+                   shelves around Antarctica.
 # E3SM version that the mesh is intended for
 e3sm_version = 3
 # The revision number of the mesh, which should be incremented each time the
 # mesh is revised
-mesh_revision = 1
+mesh_revision = 4
 # the minimum (finest) resolution in the mesh
 min_res = 6
 # the maximum (coarsest) resolution in the mesh, can be the same as min_res
 max_res = 18
 # The URL of the pull request documenting the creation of the mesh
-pull_request = <<<Missing>>>
+pull_request = https://github.com/MPAS-Dev/compass/pull/754
 
 
 # config options related to remapping topography to an MPAS-Ocean mesh

--- a/compass/ocean/tests/hurricane/hurricane.cfg
+++ b/compass/ocean/tests/hurricane/hurricane.cfg
@@ -4,3 +4,7 @@
 # Config options related to the step for culling land from the mesh
 # Whether to convert the culled mesh file to CDF5 format
 convert_culled_mesh_to_cdf5 = False
+# Minimum latitude, in degrees, for masking land-locked cells
+latitude_threshold = 43.0
+# Maximum number of sweeps to search for land-locked cells
+sweep_count = 20


### PR DESCRIPTION
<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->

Long name: RRSwISC6to18L80E3SMv3r4

This RRS (Rossby-radius scaled) mesh has:
* 6 km resolution near the poles
* 18 km resolution at the equator

Mesh, initial condition, dynamic adjustment and files for E3SM will be on Chrysalis at:
```
/lcrc/group/e3sm/ac.xylar/compass_1.2/chrysalis/e3smv3-meshes/rrswisc6to18e3r4
```

This mesh is similar to RRSwISC6to18E3r3 #747 but with #752 and some fixes to the metadata describing the mesh.

<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [ ] Document (in a comment titled `Testing` in this PR) any testing that was used to verify the changes

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->
