### PR TITLE
Add optional support for `alphaBetaLab` package

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -7,3 +7,6 @@
 [submodule "jigsaw-python"]
 	path = jigsaw-python
 	url = git@github.com:dengwirda/jigsaw-python.git
+[submodule "alphaBetaLab"]
+	path = alphaBetaLab
+	url = git@github.com:xylar/alphaBetaLab.git

--- a/conda/bootstrap.py
+++ b/conda/bootstrap.py
@@ -244,7 +244,8 @@ def get_env_setup(args, config, machine, compiler, mpi, env_type, source_path,
 def build_conda_env(env_type, recreate, mpi, conda_mpi, version,
                     python, source_path, conda_template_path, conda_base,
                     env_name, env_path, activate_base, use_local,
-                    local_conda_build, logger, local_mache, update_jigsaw):
+                    local_conda_build, logger, local_mache, update_jigsaw,
+                    with_alphabetalab):
 
     if env_type != 'dev':
         install_miniforge(conda_base, activate_base, logger)
@@ -327,6 +328,17 @@ def build_conda_env(env_type, recreate, mpi, conda_mpi, version,
             print(f'{env_name} already exists')
 
     if env_type == 'dev':
+        if with_alphabetalab:
+            print('Installing AlphaBetaLab\n')
+            commands = \
+                f'{activate_env} && ' \
+                f'cd {source_path} && ' \
+                f'git submodule update --init alphaBetaLab &&' \
+                f'cd {source_path}/alphaBetaLab&& ' \
+                f'conda install -y --file dev-spec.txt && ' \
+                f'python -m pip install --no-deps -e .'
+            check_call(commands, logger=logger)
+
         if recreate or update_jigsaw:
             # remove conda jigsaw and jigsaw-python
             t0 = time.time()
@@ -1035,7 +1047,7 @@ def main():  # noqa: C901
                 python, source_path, conda_template_path, conda_base,
                 conda_env_name, conda_env_path, activate_base, args.use_local,
                 args.local_conda_build, logger, local_mache,
-                args.update_jigsaw)
+                args.update_jigsaw, args.with_alphabetalab)
 
             if local_mache:
                 print('Install local mache\n')

--- a/conda/shared.py
+++ b/conda/shared.py
@@ -69,6 +69,10 @@ def parse_args(bootstrap):
                         help="If this flag is included, OPENMP=false will "
                              "be added to the load script.  By default, MPAS "
                              "builds will be with OpenMP (OPENMP=true).")
+    parser.add_argument("--with_alphabetalab", dest="with_alphabetalab",
+                        action='store_true',
+                        help="Whether to install alphaBetaLab from its "
+                             "submodule.")
     parser.add_argument("--verbose", dest="verbose",
                         action='store_true',
                         help="Print all output to the terminal, rather than "


### PR DESCRIPTION
<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->

`alphaBetaLab` is needed to support WaveWatchIII mesh creation.  Since the original repo isn't in active development, we will use my fork for now.  This includes an improved list of dependencies and support for shapely 2.x, needed for compatibility with Compass.

`alphaBetaLab` will be installed from source since we cannot create a conda-forge package given that the original repo isn't in active development.

`alphaBetaLab` will only be installed if the `./conda/configure_compass_env.py` script is called with the `--with_alphabetalab` flag.

This feature will remain undocumented for now, but should be documented once WaveWatchIII mesh creation is added to Compass.

<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [x] Document (in a comment titled `Testing` in this PR) any testing that was used to verify the changes

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->
