### PR TITLE
Fix jigsaw build

### DIFF
--- a/conda/bootstrap.py
+++ b/conda/bootstrap.py
@@ -409,11 +409,6 @@ def get_env_vars(machine, compiler, mpilib):
                    f'export I_MPI_F77=ifort\n' \
                    f'export I_MPI_F90=ifort\n'
 
-    if machine == 'anvil':
-        # Anvil seems to need libs from here to build successfully
-        env_vars = f'{env_vars}' \
-                   f'export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/lib64\n'
-
     if machine.startswith('conda'):
         # we're using parallelio so we don't have ADIOS support
         env_vars = \

--- a/conda/bootstrap.py
+++ b/conda/bootstrap.py
@@ -354,8 +354,8 @@ def build_conda_env(env_type, recreate, mpi, conda_mpi, version,
             check_call(commands, logger=logger)
 
             print('Building JIGSAW\n')
+            # add build tools to deployment env, not compass env
             commands = \
-                f'{activate_env} && ' \
                 f'conda install -y cmake cxx-compiler && ' \
                 f'cd {source_path}/jigsaw-python && ' \
                 f'python setup.py build_external'
@@ -371,7 +371,7 @@ def build_conda_env(env_type, recreate, mpi, conda_mpi, version,
 
             t1 = time.time()
             total = t1 - t0
-            message = f'JIGSAW install took {total} s.'
+            message = f'JIGSAW install took {total:.1f} s.'
             if logger is None:
                 print(message)
             else:


### PR DESCRIPTION
<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->

This merge switches to installing `cmake` and `cxx-compiler` in the deployment environment (not the final compass environment) and use them to build Jigsaw.  This prevents build tools from being left in the compass conda environment that later interfere with system tools and/or the spack environment.

This merge also removes a temporary fix from #757 on Anvil that is not needed after this "real" fix.

<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [ ] Document (in a comment titled `Testing` in this PR) any testing that was used to verify the changes

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->

closes #759 