### PR TITLE
Add dependabot for github actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+
+updates:
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    assignees:
+      - "xylar"
+    reviewers:
+      - "xylar"


### PR DESCRIPTION
With this merge, dependabot will perform dependency checks on the dependencies of our GitHub Actions on a weekly basis.

Following the example of E3SM-Project/E3SM#6163 (Thanks @mahf708!).