### PR TITLE
Allow decimal time steps in `isomip_plus`

### DIFF
--- a/compass/ocean/tests/isomip_plus/forward.py
+++ b/compass/ocean/tests/isomip_plus/forward.py
@@ -1,6 +1,5 @@
 import os
 import shutil
-import time
 
 import numpy as np
 import xarray
@@ -8,6 +7,7 @@ import xarray
 from compass.model import run_model
 from compass.ocean.tests.isomip_plus.evap import update_evaporation_flux
 from compass.ocean.tests.isomip_plus.viz.plot import MoviePlotter
+from compass.ocean.time import get_time_interval_string
 from compass.step import Step
 
 
@@ -148,11 +148,8 @@ class Forward(Step):
         dt_per_km = config.getfloat('isomip_plus', 'dt_per_km')
         dt_btr_per_km = config.getfloat('isomip_plus', 'dt_btr_per_km')
 
-        # https://stackoverflow.com/a/1384565/7728169
-        # Note: this will drop any fractional seconds, which is usually okay
-        dt = time.strftime('%H:%M:%S', time.gmtime(dt_per_km * resolution))
-        btr_dt = time.strftime(
-            '%H:%M:%S', time.gmtime(dt_btr_per_km * resolution))
+        dt = get_time_interval_string(seconds=dt_per_km * resolution)
+        btr_dt = get_time_interval_string(seconds=dt_btr_per_km * resolution)
 
         options = dict(config_dt=f"'{dt}'",
                        config_btr_dt=f"'{btr_dt}'")

--- a/compass/ocean/tests/isomip_plus/ssh_adjustment.py
+++ b/compass/ocean/tests/isomip_plus/ssh_adjustment.py
@@ -1,6 +1,5 @@
-import time
-
 from compass.ocean.iceshelf import adjust_ssh
+from compass.ocean.time import get_time_interval_string
 from compass.step import Step
 
 
@@ -86,14 +85,11 @@ class SshAdjustment(Step):
         dt_per_km = config.getfloat('isomip_plus', 'dt_per_km')
         dt_btr_per_km = config.getfloat('isomip_plus', 'dt_btr_per_km')
 
-        # https://stackoverflow.com/a/1384565/7728169
-        # Note: this will drop any fractional seconds, which is usually okay
-        dt = time.strftime('%H:%M:%S', time.gmtime(dt_per_km * resolution))
-        btr_dt = time.strftime(
-            '%H:%M:%S', time.gmtime(dt_btr_per_km * resolution))
+        dt = get_time_interval_string(seconds=dt_per_km * resolution)
+        btr_dt = get_time_interval_string(seconds=dt_btr_per_km * resolution)
 
-        options = dict(config_dt="'{}'".format(dt),
-                       config_btr_dt="'{}'".format(btr_dt))
+        options = dict(config_dt=f"'{dt}'",
+                       config_btr_dt=f"'{btr_dt}'")
         self.update_namelist_at_runtime(options)
 
         iteration_count = config.getint('ssh_adjustment', 'iterations')

--- a/compass/ocean/time.py
+++ b/compass/ocean/time.py
@@ -1,0 +1,38 @@
+import time
+
+import numpy as np
+
+
+def get_time_interval_string(days=None, seconds=None):
+    """
+    Convert a time interval in days and/or seconds to a string for use in a
+    model config option.  If both are provided, they will be added
+
+    Parameters
+    ----------
+    days : float, optional
+        A time interval in days
+
+    seconds : float, optional
+        A time interval in seconds
+
+    Returns
+    -------
+    time_str : str
+        The time as a string in the format "DDDD_HH:MM:SS.SS"
+
+    """
+    sec_per_day = 86400
+    total = 0.
+    if seconds is not None:
+        total += seconds
+    if days is not None:
+        total += sec_per_day * days
+
+    day_part = int(total / sec_per_day)
+    sec_part = total - day_part * sec_per_day
+    sec_decimal = sec_part - np.floor(sec_part)
+    # https://stackoverflow.com/a/1384565/7728169
+    seconds_str = time.strftime('%H:%M:%S', time.gmtime(sec_part))
+    time_str = f'{day_part:04d}_{seconds_str}.{int(sec_decimal * 1e3):03d}'
+    return time_str


### PR DESCRIPTION
<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->
This merge adds an ocean framework module `time` with a function `get_time_interval_string()` that can be used to make a time string from a number of days or seconds (taking into account fractions of a second).  This is a back-port of https://github.com/E3SM-Project/polaris/pull/158/files#diff-25e5a0739b2dea91e8c71a47f173206923d2572571b9b84a98a01fa58db876cd

The `isomip_plus` test group has been updated to use this functionality so fractional time steps can be used.

<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [ ] Developer's Guide has been updated
* [ ] API documentation in the Developer's Guide (`api.rst`) has any new or modified class, method and/or functions listed
* [ ] Documentation has been [built locally](https://mpas-dev.github.io/compass/latest/developers_guide/building_docs.html) and changes look as expected
* [ ] Document (in a comment titled `Testing` in this PR) any testing that was used to verify the changes

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->
