### PR TITLE
Fix incorrect creation dates for e3sm_to_cmip maps

### DIFF
--- a/compass/ocean/tests/global_ocean/files_for_e3sm/e3sm_to_cmip_maps.py
+++ b/compass/ocean/tests/global_ocean/files_for_e3sm/e3sm_to_cmip_maps.py
@@ -49,8 +49,7 @@ class E3smToCmipMaps(FilesForE3SMStep):
         Run this step of the testcase
         """
         super().run()
-        # more verbose creation date for clarity
-        creation_date = f'20{self.creation_date}'
+        creation_date = self.creation_date
         make_e3sm_to_cmip_maps(self.config, self.logger, self.mesh_short_name,
                                creation_date, self.ntasks)
 


### PR DESCRIPTION
Compass was prepending `20` to the creation date but our creation dates already include the full 4-digit year.

<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->

<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [x] Document (in a comment titled `Testing` in this PR) any testing that was used to verify the changes

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->
