### PR TITLE
Reroute missing fluxes in data ice-shelf melt fluxes (DISMF)

### DIFF
--- a/compass/ocean/tests/global_ocean/files_for_e3sm/__init__.py
+++ b/compass/ocean/tests/global_ocean/files_for_e3sm/__init__.py
@@ -149,6 +149,13 @@ class FilesForE3SM(TestCase):
             graph_filename = os.path.abspath(graph_filename)
             config.set('files_for_e3sm', 'graph_filename', graph_filename)
 
+            base_mesh_filename = os.path.join(
+                self.base_work_dir, mesh.steps['base_mesh'].path,
+                'base_mesh.nc')
+            base_mesh_filename = os.path.abspath(base_mesh_filename)
+            config.set('files_for_e3sm', 'base_mesh_filename',
+                       base_mesh_filename)
+
         if init is not None:
             if mesh.with_ice_shelf_cavities:
                 initial_state_filename = \

--- a/compass/ocean/tests/global_ocean/files_for_e3sm/files_for_e3sm_step.py
+++ b/compass/ocean/tests/global_ocean/files_for_e3sm/files_for_e3sm_step.py
@@ -109,25 +109,20 @@ class FilesForE3SMStep(Step):
         """
         setup input files based on config options
         """
+        config = self.config
         self.add_input_file(filename='README', target='../README')
 
-        initial_state_filename = self.config.get(
-            'files_for_e3sm', 'ocean_initial_state_filename')
-        if initial_state_filename != 'autodetect':
-            initial_state_filename = os.path.normpath(os.path.join(
-                self.test_case.work_dir, initial_state_filename))
-            self.add_input_file(filename='initial_state.nc',
-                                target=initial_state_filename)
+        for prefix in ['base_mesh', 'initial_state', 'restart']:
+            filename = config.get('files_for_e3sm',
+                                  f'ocean_{prefix}_filename')
+            if filename != 'autodetect':
+                filename = os.path.normpath(os.path.join(
+                    self.test_case.work_dir, filename))
+                self.add_input_file(filename='base_mesh.nc',
+                                    target=filename)
 
-        restart_filename = self.config.get('files_for_e3sm',
-                                           'ocean_restart_filename')
-        if restart_filename != 'autodetect':
-            restart_filename = os.path.normpath(os.path.join(
-                self.test_case.work_dir, restart_filename))
-            self.add_input_file(filename='restart.nc', target=restart_filename)
-
-        with_ice_shelf_cavities = self.config.get('files_for_e3sm',
-                                                  'with_ice_shelf_cavities')
+        with_ice_shelf_cavities = config.get('files_for_e3sm',
+                                             'with_ice_shelf_cavities')
         if with_ice_shelf_cavities != 'autodetect':
             self.with_ice_shelf_cavities = \
                 (with_ice_shelf_cavities.lower() == 'true')
@@ -138,7 +133,7 @@ class FilesForE3SMStep(Step):
         Run this step of the testcase
         """
         config = self.config
-        for prefix in ['initial_state', 'restart']:
+        for prefix in ['base_mesh', 'initial_state', 'restart']:
             if not os.path.exists(f'{prefix}.nc'):
                 filename = config.get('files_for_e3sm',
                                       f'ocean_{prefix}_filename')

--- a/compass/ocean/tests/global_ocean/files_for_e3sm/ocean_mesh.py
+++ b/compass/ocean/tests/global_ocean/files_for_e3sm/ocean_mesh.py
@@ -120,3 +120,8 @@ class OceanMesh(FilesForE3SMStep):
 
         symlink(os.path.abspath(dest_filename),
                 f'{self.ocean_mesh_dir}/{dest_filename}')
+
+        dest_filename = f'{self.mesh_short_name}_base.{self.creation_date}.nc'
+
+        symlink(os.path.abspath('base_mesh.nc'),
+                f'{self.ocean_mesh_dir}/{dest_filename}')

--- a/compass/ocean/tests/global_ocean/files_for_e3sm/remap_ice_shelf_melt.py
+++ b/compass/ocean/tests/global_ocean/files_for_e3sm/remap_ice_shelf_melt.py
@@ -81,11 +81,13 @@ class RemapIceShelfMelt(FilesForE3SMStep):
 
             parallel_executable = config.get('parallel', 'parallel_executable')
 
-            mesh_filename = 'initial_state.nc'
+            base_mesh_filename = 'base_mesh.nc'
+            culled_mesh_filename = 'initial_state.nc'
             mesh_name = self.mesh_short_name
             land_ice_mask_filename = 'initial_state.nc'
 
-            remap_adusumilli(in_filename, mesh_filename, mesh_name,
+            remap_adusumilli(in_filename, base_mesh_filename,
+                             culled_mesh_filename, mesh_name,
                              land_ice_mask_filename, remapped_filename,
                              logger=logger, mpi_tasks=ntasks,
                              parallel_executable=parallel_executable)

--- a/compass/ocean/tests/global_ocean/global_ocean.cfg
+++ b/compass/ocean/tests/global_ocean/global_ocean.cfg
@@ -181,6 +181,10 @@ mesh_short_name = autodetect
 # directory of an ocean restart file on the given mesh
 ocean_restart_filename = autodetect
 
+# the base mesh before culling for remapping and rerouting data ice-shelf melt
+# fluxes
+ocean_base_mesh_filename = autodetect
+
 # the initial state used to extract the ocean and sea-ice meshes
 ocean_initial_state_filename = ${ocean_restart_filename}
 

--- a/compass/ocean/tests/global_ocean/init/remap_ice_shelf_melt.py
+++ b/compass/ocean/tests/global_ocean/init/remap_ice_shelf_melt.py
@@ -5,7 +5,9 @@ import xarray as xr
 from mpas_tools.cime.constants import constants
 from mpas_tools.io import write_netcdf
 from pyremap import MpasCellMeshDescriptor, ProjectionGridDescriptor, Remapper
+from scipy.spatial import KDTree
 
+from compass.ocean.mesh.cull import write_map_culled_to_base
 from compass.step import Step
 
 
@@ -33,15 +35,24 @@ class RemapIceShelfMelt(Step):
         super().__init__(test_case, name='remap_ice_shelf_melt', ntasks=512,
                          min_tasks=1)
 
-        mesh_path = mesh.get_cull_mesh_path()
+        base_mesh_path = mesh.steps['base_mesh'].path
+        culled_mesh_path = mesh.steps['cull_mesh'].path
 
         self.add_input_file(
-            filename='mesh.nc',
-            work_dir_target=f'{mesh_path}/culled_mesh.nc')
+            filename='base_mesh.nc',
+            work_dir_target=f'{base_mesh_path}/base_mesh.nc')
+
+        self.add_input_file(
+            filename='culled_mesh.nc',
+            work_dir_target=f'{culled_mesh_path}/culled_mesh.nc')
+
+        self.add_input_file(
+            filename='map_culled_to_base.nc',
+            work_dir_target=f'{culled_mesh_path}/map_culled_to_base.nc')
 
         self.add_input_file(
             filename='land_ice_mask.nc',
-            work_dir_target=f'{mesh_path}/land_ice_mask.nc')
+            work_dir_target=f'{culled_mesh_path}/land_ice_mask.nc')
 
         self.add_input_file(
             filename='Adusumilli_2020_iceshelf_melt_rates_2010-2018_v0.h5',
@@ -67,21 +78,26 @@ class RemapIceShelfMelt(Step):
 
         parallel_executable = config.get('parallel', 'parallel_executable')
 
-        mesh_filename = 'mesh.nc'
+        base_mesh_filename = 'base_mesh.nc'
+        culled_mesh_filename = 'culled_mesh.nc'
         land_ice_mask_filename = 'land_ice_mask.nc'
+        map_culled_to_base_filename = 'map_culled_to_base.nc'
         mesh_name = self.mesh.mesh_name
 
-        remap_adusumilli(in_filename, mesh_filename, mesh_name,
-                         land_ice_mask_filename, out_filename,
-                         logger=logger, mpi_tasks=ntasks,
-                         parallel_executable=parallel_executable)
+        remap_adusumilli(
+            in_filename, base_mesh_filename, culled_mesh_filename,
+            mesh_name, land_ice_mask_filename, out_filename,
+            logger=logger, mpi_tasks=ntasks,
+            parallel_executable=parallel_executable,
+            map_culled_to_base_filename=map_culled_to_base_filename)
 
 
-def remap_adusumilli(in_filename, mesh_filename, mesh_name,
-                     land_ice_mask_filename, out_filename, logger,
+def remap_adusumilli(in_filename, base_mesh_filename, culled_mesh_filename,
+                     mesh_name, land_ice_mask_filename, out_filename, logger,
                      mapping_directory='.', method='conserve',
                      renormalization_threshold=None, mpi_tasks=1,
-                     parallel_executable=None):
+                     parallel_executable=None,
+                     map_culled_to_base_filename=None):
     """
     Remap the Adusumilli et al. (2020) melt rates at 1 km resolution to an MPAS
     mesh
@@ -91,8 +107,11 @@ def remap_adusumilli(in_filename, mesh_filename, mesh_name,
     in_filename : str
         The original Adusumilli et al. (2020) melt rates
 
-    mesh_filename : str
-        The MPAS mesh
+    base_mesh_filename : str
+        The base MPAS mesh before land is culled
+
+    culled_mesh_filename : str
+        The MPAS mesh after land has been culled
 
     mesh_name : str
         The name of the mesh (e.g. oEC60to30wISC), used in the name of the
@@ -127,6 +146,10 @@ def remap_adusumilli(in_filename, mesh_filename, mesh_name,
     parallel_executable : {'srun', 'mpirun'}, optional
         The name of the parallel executable to use to launch ESMF tools.
         But default, 'mpirun' from the conda environment is used
+
+    map_culled_to_base_filename : str, optional
+        A file with indices that map from the culled to the base MPAS mesh. If
+        not provided, they will be computed
     """
 
     logger.info(f'Reading {in_filename}...')
@@ -172,10 +195,10 @@ def remap_adusumilli(in_filename, mesh_filename, mesh_name,
     write_netcdf(ds, 'Adusumilli_2020_ismf_2010-2018_v0.nc')
     logger.info('done.')
 
-    out_descriptor = MpasCellMeshDescriptor(mesh_filename, mesh_name)
+    out_descriptor = MpasCellMeshDescriptor(base_mesh_filename, mesh_name)
 
     mapping_filename = \
-        f'{mapping_directory}/map_{in_grid_name}_to_{mesh_name}.nc'
+        f'{mapping_directory}/map_{in_grid_name}_to_{mesh_name}_base.nc'
 
     logger.info(f'Creating the mapping file {mapping_filename}...')
     remapper = Remapper(in_descriptor, out_descriptor, mapping_filename)
@@ -190,22 +213,126 @@ def remap_adusumilli(in_filename, mesh_filename, mesh_name,
         ds, renormalizationThreshold=renormalization_threshold)
     logger.info('done.')
 
-    ds_mask = xr.open_dataset(land_ice_mask_filename)
-    mask = ds_mask.landIceMask
+    if map_culled_to_base_filename is None:
+        map_culled_to_base_filename = 'map_culled_to_base.nc'
+        write_map_culled_to_base(base_mesh_filename=base_mesh_filename,
+                                 culled_mesh_filename=culled_mesh_filename,
+                                 out_filename=map_culled_to_base_filename)
 
-    for field in ['dataLandIceFreshwaterFlux',
-                  'dataLandIceHeatFlux']:
-        # zero out the field where it's currently NaN, and mask only to
-        # regions with land ice
-        ds_remap[field] = \
-            mask * ds_remap[field].where(ds_remap[field].notnull(), 0.)
+    _land_ice_mask_on_base_mesh(
+        base_mesh_filename=base_mesh_filename,
+        land_ice_mask_filename=land_ice_mask_filename,
+        map_culled_to_base_filename=map_culled_to_base_filename)
 
-        # add a time dimension
-        if 'Time' not in ds_remap[field].dims:
-            ds_remap[field] = ds_remap[field].expand_dims(dim='Time', axis=0)
-
-    # deal with melting beyond the land-ice mask
-
+    ds_mask = xr.open_dataset('land_ice_mask_on_base.nc')
+    mask = ds_mask.landIceFloatingMask
+    ds_remap['landIceFloatingMask'] = mask
     ds_remap.attrs.pop('history')
 
-    write_netcdf(ds_remap, out_filename)
+    write_netcdf(ds_remap, 'ismf_remapped_to_base.nc')
+
+    # deal with melting beyond the land-ice mask
+    _reroute_missing_flux(base_mesh_filename, map_culled_to_base_filename,
+                          out_filename, logger)
+
+
+def _land_ice_mask_on_base_mesh(base_mesh_filename, land_ice_mask_filename,
+                                map_culled_to_base_filename):
+    """ Map the land-ice mask back to the base mesh """
+
+    ds_map = xr.open_dataset(map_culled_to_base_filename)
+    map_culled_to_base = ds_map.mapCulledToBase.values
+
+    ds_base = xr.open_dataset(base_mesh_filename)
+    ncells_base = ds_base.sizes['nCells']
+
+    ds_culled_mask = xr.open_dataset(land_ice_mask_filename)
+    culled_land_ice_mask = ds_culled_mask.landIceFloatingMask.values
+    base_land_ice_mask = np.zeros(ncells_base, dtype=int)
+    base_land_ice_mask[map_culled_to_base] = culled_land_ice_mask
+    ds_base_mask = xr.Dataset()
+    ds_base_mask['landIceFloatingMask'] = ('nCells', base_land_ice_mask)
+
+    write_netcdf(ds_base_mask, 'land_ice_mask_on_base.nc')
+
+
+def _reroute_missing_flux(base_mesh_filename, map_culled_to_base_filename,
+                          out_filename, logger):
+    """
+    For each flux cell not within an ice shelf, find the closest ice-shelf cell
+    """
+    ds_ismf_base = xr.open_dataset('ismf_remapped_to_base.nc')
+    land_ice_mask = ds_ismf_base.landIceFloatingMask
+    fwf = ds_ismf_base.dataLandIceFreshwaterFlux
+    fwf = fwf.where(fwf.notnull(), 0.)
+    hf = ds_ismf_base.dataLandIceHeatFlux
+    hf = hf.where(hf.notnull(), 0.)
+    flux_mask = fwf != 0.
+    fluxes_to_reroute = np.logical_and(flux_mask,
+                                       land_ice_mask != 1)
+
+    ds_base = xr.open_dataset(base_mesh_filename)
+    ncells_base = ds_base.sizes['nCells']
+    base_xyz = np.zeros((ncells_base, 3))
+    base_xyz[:, 0] = ds_base.xCell.values
+    base_xyz[:, 1] = ds_base.yCell.values
+    base_xyz[:, 2] = ds_base.zCell.values
+    area = ds_base.areaCell
+
+    land_ice_xyz = base_xyz[land_ice_mask.values == 1, :]
+    land_ice_cell_indices = np.arange(ncells_base)[land_ice_mask.values == 1]
+
+    reroute_mask = fluxes_to_reroute.astype(int)
+
+    fw_mass_rerouted = (fwf * area).isel(nCells=fluxes_to_reroute.values)
+    heat_rerouted = (hf * area).isel(nCells=fluxes_to_reroute.values)
+
+    count = np.sum(reroute_mask.values)
+    logger.info(f'Rerouting fluxes from {count} cells')
+    fwf_land_ice = (land_ice_mask * fwf * area).sum().values
+    logger.info(f'Captured flux (kg/s):         {fwf_land_ice:.1f}')
+    fwf_rerouted = fw_mass_rerouted.sum().values
+    logger.info(f'Rerouted flux (kg/s):         {fwf_rerouted:.1f}')
+    fwf_total = (fwf * area).sum().values
+    logger.info(f'Total flux (kg/s):            {fwf_total:.1f}')
+    ds_to_route = xr.Dataset()
+    ds_to_route['rerouteMask'] = reroute_mask
+    write_netcdf(ds_to_route, 'route_mask.nc')
+
+    reroute_xyz = base_xyz[fluxes_to_reroute.values, :]
+
+    # we want to find closest land-ice cell to a given reroute cell
+    tree = KDTree(land_ice_xyz)
+
+    # todo: may need to be more sophisticated with workers based on ntasks,
+    # etc.
+    _, indices = tree.query(reroute_xyz, workers=-1)
+
+    ds_map = xr.open_dataset(map_culled_to_base_filename)
+    map_culled_to_base = ds_map.mapCulledToBase.values
+
+    fwf_rerouted = land_ice_mask.values * fwf.where(fwf.notnull(), 0.).values
+    hf_rerouted = land_ice_mask.values * hf.where(hf.notnull(), 0.).values
+    for rerouted_index, land_ice_index in enumerate(indices):
+        icell = land_ice_cell_indices[land_ice_index]
+        fwf_rerouted[icell] += fw_mass_rerouted[rerouted_index] / area[icell]
+        hf_rerouted[icell] += heat_rerouted[rerouted_index] / area[icell]
+
+    # now, go from base to culled mesh
+    fwf_rerouted = fwf_rerouted[map_culled_to_base]
+    hf_rerouted = hf_rerouted[map_culled_to_base]
+
+    ds_out = xr.Dataset()
+    field = 'dataLandIceFreshwaterFlux'
+    ds_out[field] = ('nCells', fwf_rerouted)
+    ds_out[field] = ds_out[field].expand_dims(dim='Time', axis=0)
+    ds_out[field].attrs['units'] = 'kg m^-2 s^-1'
+    field = 'dataLandIceHeatFlux'
+    ds_out[field] = ('nCells', hf_rerouted)
+    ds_out[field] = ds_out[field].expand_dims(dim='Time', axis=0)
+    ds_out[field].attrs['units'] = 'W m^-2'
+    write_netcdf(ds_out, out_filename)
+
+    fwf_total = (ds_out.dataLandIceFreshwaterFlux *
+                 area.isel(nCells=map_culled_to_base)).sum().values
+    logger.info(f'Total after rerouting (kg/s): {fwf_total:.1f}')

--- a/docs/users_guide/ocean/test_groups/global_ocean.rst
+++ b/docs/users_guide/ocean/test_groups/global_ocean.rst
@@ -200,6 +200,10 @@ Note that meshes and test cases may modify these options, as noted below.
     # directory of an ocean restart file on the given mesh
     ocean_restart_filename = autodetect
 
+   # the base mesh before culling for remapping and rerouting data ice-shelf melt
+   # fluxes
+   base_mesh_filename = autodetect
+
     # the initial state used to extract the ocean and sea-ice meshes
     ocean_initial_state_filename = ${ocean_restart_filename}
 
@@ -882,14 +886,17 @@ graph partition files for MPAS-Seaice, either weren't created with the initial
 condition or they are out of date.  The ``ocean/global_ocean/files_for_e3sm``
 test case is useful for creating these files.
 
-The user should create a local symlink to an E3SM initial condition for
-MPAS-Ocean for the desired mesh.  Then, the config options in
-``files_for_e3sm.cfg`` should be edited.  In this example, we have
-created a local link to the ``ocean.EC30to60E2r3.210210.nc`` initial
-condition and the ``mpas-o.graph.info.200904`` graph file in the test case
-directory.  The mesh name has also been set to the E3SM short name for this
-mesh ``EC30to60E2r3``.  We indicate that the mesh does not include ice-shelf
-cavities, which means we don't compute masks for ice-shelf melt rates.
+The user should create local symlinks to an E3SM initial condition, a graph
+file, and a base-mesh file for MPAS-Ocean for the desired mesh.  Then, the
+config options in ``files_for_e3sm.cfg`` should be edited.  In this example,
+we have created a local link to the ``mpaso.IcoswISC30E3r5.20231120.nc``
+initial condition and the ``mpas-o.graph.info.20231120`` graph file in the
+test case directory.  We also created a symlink to the base mesh (found in the
+``share/meshes/mpas/ocean`` subdirectory within the ``inputdata`` diretory on
+a given E3SM supported machine). The mesh name has also been set to the E3SM
+short name for this mesh ``IcoswISC30E3r5``.  We indicate that the mesh
+includes ice-shelf cavities, which means we include processing related to
+ice-shelf melt rates.
 
 We also need to provide several options in the ``[global_ocean]`` section of
 the config file so the metadata added to the initial conditions will be
@@ -899,33 +906,33 @@ correct.
 
     [global_ocean]
 
-    prefix = EC
+    prefix = Icos
 
-    mesh_description = MPAS Eddy Closure mesh for E3SM version ${e3sm_version} with
-                       enhanced resolution around the equator (30 km), South pole
-                       (35 km), Greenland (${min_res} km), ${max_res}-km resolution
-                       at mid latitudes, and <<<levels>>> vertical levels
+   mesh_description = MPAS subdivided icosahedral mesh for E3SM version
+                     ${e3sm_version} at ${min_res}-km global resolution with
+                     <<<levels>>> vertical level
 
-    bathy_description = Bathymetry is from GEBCO 2022, combined with BedMachine
-                        Antarctica v2 around Antarctica.
+    bathy_description = Bathymetry is from GEBCO 2023, combined with
+                        BedMachine Antarctica v3 around Antarctica.
 
-    init_description = Polar science center Hydrographic Climatology (PHC)
+    init_description = World Ocean Atlas 2023 climatology 1991-2020
 
-    e3sm_version = 2
-    mesh_revision = 3
+    e3sm_version = 3
+    mesh_revision = 5
     min_res = 30
-    max_res = 60
-    pull_request = https://github.com/MPAS-Dev/MPAS-Model/pull/669
-    creation_date = 230311
+    max_res = 30
+    pull_request = https://github.com/MPAS-Dev/compass/pull/735
+    creation_date = 20240219
     author = Xylar Asay-Davis
     email = xylar@lanl.gov
 
     [files_for_e3sm]
 
-    mesh_short_name = EC30to60E2r3
-    ocean_restart_filename = ocean.EC30to60E2r3.210210.nc
-    graph_filename = mpas-o.graph.info.200904
-    with_ice_shelf_cavities = False
+    mesh_short_name = IcoswISC30E3r5
+    ocean_restart_filename = mpaso.IcoswISC30E3r5.20231120.nc
+    ocean_base_mesh_filename = IcoswISC30E3r5_base.20240219.nc
+    graph_filename = mpas-o.graph.info.20231120
+    with_ice_shelf_cavities = True
 
 The resulting files are symlinked in a subdirectory of the test case called
 ``assembled_files``.  This directory contains subdirectories with the same


### PR DESCRIPTION
<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->
This merge adds the ability to reroute data melt fluxes remapped from the Adusumilli et al. (2020) dataset that were previously removed completely instead to the nearest sub-ice-shelf cell.

This requires first remapping to the base mesh, then rerouting, then culling land and masking land ice in the result.

In order to facilitate making DISMF datasets for existing meshes, the base mesh is also written out as part of `files_for_e3sm` and placed in `share/meshes/mpas/ocean`.

<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [x] User's Guide has been updated
* [x] Documentation has been [built locally](https://mpas-dev.github.io/compass/latest/developers_guide/building_docs.html) and changes look as expected
* [x] Document (in a comment titled `Testing` in this PR) any testing that was used to verify the changes

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->
