### PR TITLE
Update `e3sm_to_cmip_maps` step to create E3SMv3 maps

### DIFF
--- a/compass/ocean/tests/global_ocean/files_for_e3sm/scrip.py
+++ b/compass/ocean/tests/global_ocean/files_for_e3sm/scrip.py
@@ -54,8 +54,18 @@ class Scrip(FilesForE3SMStep):
 
         scrip_from_mpas('restart.nc', local_filename)
 
+        diagnostic_grids_dir = \
+            '../assembled_files/diagnostics/grids'
+        try:
+            os.makedirs(diagnostic_grids_dir)
+        except FileExistsError:
+            pass
+
         symlink(os.path.abspath(local_filename),
                 f'{self.ocean_inputdata_dir}/{scrip_filename}')
+
+        symlink(os.path.abspath(local_filename),
+                f'{diagnostic_grids_dir}/{scrip_filename}')
 
         if with_ice_shelf_cavities:
             local_filename = 'ocean.mask.scrip.nc'
@@ -65,4 +75,7 @@ class Scrip(FilesForE3SMStep):
                             useLandIceMask=True)
 
             symlink(os.path.abspath(local_filename),
-                    f'{self.ocean_inputdata_dir}//{scrip_mask_filename}')
+                    f'{self.ocean_inputdata_dir}/{scrip_mask_filename}')
+
+            symlink(os.path.abspath(local_filename),
+                    f'{diagnostic_grids_dir}/{scrip_mask_filename}')


### PR DESCRIPTION
<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->

E3SM v3 supports 8 new types of mapping files that we want to support for mapping from MPAS-Ocean and -Seaice meshes to CMIP6 grids.

This merge also copies MPAS-Ocean and -Seaice SCRIP files to `diagnostics/grids` in addition to `inputdata` so they area available for creating mapping files for diagnostics.

<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [x] Document (in a comment titled `Testing` in this PR) any testing that was used to verify the changes

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->
