### PR TITLE
Add edge masks to default arguments of `make_region_masks` landice framework function

### DIFF
--- a/compass/landice/mesh.py
+++ b/compass/landice/mesh.py
@@ -815,7 +815,7 @@ def make_region_masks(self, mesh_filename, mask_filename, cores, tags):
             '-m', mesh_filename,
             '-g', geojson_filename,
             '-o', mask_filename,
-            '-t', 'cell',
+            '-t', 'cell', 'edge', 'vertex',
             '--process_count', f'{cores}',
             '--format', mpas_tools.io.default_format,
             '--engine', mpas_tools.io.default_engine]

--- a/compass/landice/mesh.py
+++ b/compass/landice/mesh.py
@@ -815,7 +815,7 @@ def make_region_masks(self, mesh_filename, mask_filename, cores, tags):
             '-m', mesh_filename,
             '-g', geojson_filename,
             '-o', mask_filename,
-            '-t', 'cell', 'edge', 'vertex',
+            '-t', 'cell', 'edge',
             '--process_count', f'{cores}',
             '--format', mpas_tools.io.default_format,
             '--engine', mpas_tools.io.default_engine]


### PR DESCRIPTION
__Description__: 
This PR adds `edge` region masks to the default options of the `make_region_masks` function within the mesh module of the landice framework. 

The addition of `edge` masks for regions is needed the by the recent addition of SGH quantities to regional stats analysis member in `MALI-Dev` (https://github.com/MALI-Dev/E3SM/pull/105). 

Originally, we planned on adding `vertex` masks aswell, to forestall future problems. But after some experimentation with the [antarctic/mesh_gen](https://mpas-dev.github.io/compass/latest/users_guide/landice/test_groups/antarctica.html) testcase, the additional masks slow down testcase execution considerably (~50%). As _very_ few variables are defined on vertices, we've opted to leave them out of the defaults for now. 
<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->

<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
__Checklist__
* [x] Document (in a comment titled `Testing` in this PR) any testing that was used to verify the changes

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->
