### PR TITLE
Fix bug in limiting cull distance

### DIFF
--- a/compass/landice/mesh.py
+++ b/compass/landice/mesh.py
@@ -369,7 +369,7 @@ def set_cell_width(self, section_name, thk, bed=None, vx=None, vy=None,
     # cell size in the final mesh. There may be a more rigorous way to set
     # that distance.
     if dist_to_edge is not None:
-        assert (3. * cull_distance < max(high_dist, high_dist_bed)), \
+        assert (cull_distance < 3. * max(high_dist, high_dist_bed)), \
             ('cull_distance is set to be larger than 3x the max of high_dist '
              'and high_dist_bed, which means max_spac is not being applied to '
              'the regions of the mesh that will be culled, which means the '

--- a/compass/landice/mesh.py
+++ b/compass/landice/mesh.py
@@ -369,12 +369,6 @@ def set_cell_width(self, section_name, thk, bed=None, vx=None, vy=None,
     # cell size in the final mesh. There may be a more rigorous way to set
     # that distance.
     if dist_to_edge is not None:
-        assert (cull_distance < 3. * max(high_dist, high_dist_bed)), \
-            ('cull_distance is set to be larger than 3x the max of high_dist '
-             'and high_dist_bed, which means max_spac is not being applied to '
-             'the regions of the mesh that will be culled, which means the '
-             'mesh generation is likely to be substantially slower '
-             'than necessary.  Please fix or relax this constraint.')
         mask = np.logical_and(
             thk == 0.0, dist_to_edge > (3. * cull_distance))
         logger.info('Setting cell_width in outer regions to max_spac '


### PR DESCRIPTION
This merge removes an unnecessary assertion about the value of `cull_distance`, since it is handled by other logic.

<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->

<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->
