### PR TITLE
Remove "Build Type: Tpetra" from Landice tests

### DIFF
--- a/compass/landice/tests/circular_shelf/albany_input.yaml
+++ b/compass/landice/tests/circular_shelf/albany_input.yaml
@@ -1,8 +1,6 @@
 %YAML 1.1
 ---
 ANONYMOUS:
-  Build Type: Tpetra
-
   Problem:
     LandIce Viscosity:
       Type: 'Glen''s Law'

--- a/compass/landice/tests/dome/albany_input.yaml
+++ b/compass/landice/tests/dome/albany_input.yaml
@@ -1,8 +1,6 @@
 %YAML 1.1
 ---
 ANONYMOUS:
-  Build Type: Tpetra
-
   Problem:
     LandIce Viscosity:
       Type: 'Glen''s Law'

--- a/compass/landice/tests/ensemble_generator/albany_input.yaml
+++ b/compass/landice/tests/ensemble_generator/albany_input.yaml
@@ -1,8 +1,6 @@
 %YAML 1.1
 ---
 ANONYMOUS:
-  Build Type: Tpetra
-
   Problem:
     LandIce Field Norm:
       sliding_velocity_basalside:

--- a/compass/landice/tests/greenland/albany_input.yaml
+++ b/compass/landice/tests/greenland/albany_input.yaml
@@ -1,8 +1,6 @@
 %YAML 1.1
 ---
 ANONYMOUS:
-  Build Type: Tpetra
-
 # Discretization Description
   Discretization:
     Exodus Output File Name: albany_output.exo

--- a/compass/landice/tests/humboldt/albany_input.yaml
+++ b/compass/landice/tests/humboldt/albany_input.yaml
@@ -1,8 +1,6 @@
 %YAML 1.1
 ---
 ANONYMOUS:
-  Build Type: Tpetra
-
   Problem:
     LandIce Field Norm:
       sliding_velocity_basalside:

--- a/compass/landice/tests/humboldt/albany_input_depthInt.yaml
+++ b/compass/landice/tests/humboldt/albany_input_depthInt.yaml
@@ -1,8 +1,6 @@
 %YAML 1.1
 ---
 ANONYMOUS:
-  Build Type: Tpetra
-
   Problem:
     LandIce Field Norm:
       sliding_velocity_basalside:

--- a/compass/landice/tests/ismip6_run/ismip6_ais_proj2300/albany_input.yaml
+++ b/compass/landice/tests/ismip6_run/ismip6_ais_proj2300/albany_input.yaml
@@ -1,10 +1,6 @@
 %YAML 1.1
 ---
 ANONYMOUS:
-# In order to use ML, change Tpetra to Epetra in the following line,
-# and "Preconditioner Type: MueLu" to " Preconditioner Type: ML" several lines below
-  Build Type: Tpetra
-
   Problem:
     LandIce Field Norm:
       sliding_velocity_basalside:

--- a/compass/landice/tests/mismipplus/albany_input.yaml
+++ b/compass/landice/tests/mismipplus/albany_input.yaml
@@ -1,8 +1,6 @@
 %YAML 1.1
 ---
 ANONYMOUS:
-  Build Type: Tpetra
-
   Problem:
     Dirichlet BCs:
       SDBC on NS dirichlet for DOF U1 prescribe Field: dirichlet_field

--- a/compass/landice/tests/thwaites/albany_input.yaml
+++ b/compass/landice/tests/thwaites/albany_input.yaml
@@ -1,8 +1,6 @@
 %YAML 1.1
 ---
 ANONYMOUS:
-  Build Type: Tpetra
-
 # Problem Description
   Problem:
     Cubature Degree: 4

--- a/compass/landice/tests/thwaites/albany_input_depthInt.yaml
+++ b/compass/landice/tests/thwaites/albany_input_depthInt.yaml
@@ -1,8 +1,6 @@
 %YAML 1.1
 ---
 ANONYMOUS:
-  Build Type: Tpetra
-
   Problem:
     Depth Integrated Model: true
 


### PR DESCRIPTION
Support for Epetra in Albany has been deprecated and therefore "Build Type:" is no longer a valid parameter for landice tests. This PR removes the option from all landice tests.

Checklist
* [x] Document (in a comment titled `Testing` in this PR) any testing that was used to verify the changes