### PR TITLE
Fix DISMF dataset name in global ocean forward runs

### DIFF
--- a/compass/ocean/tests/global_ocean/forward.py
+++ b/compass/ocean/tests/global_ocean/forward.py
@@ -113,7 +113,7 @@ class ForwardStep(Step):
                            config_land_ice_flux_mode=f"'{land_ice_flux_mode}'")
             self.add_namelist_options(options)
             if land_ice_flux_mode == 'data':
-                filename = 'prescribed_ismf_adusumilli2020.nc'
+                filename = 'prescribed_ismf_paolo2023.nc'
                 target = f'{init.path}/remap_ice_shelf_melt/{filename}'
                 self.add_input_file(filename=filename, work_dir_target=target)
                 self.add_streams_file(

--- a/compass/ocean/tests/global_ocean/streams.dismf
+++ b/compass/ocean/tests/global_ocean/streams.dismf
@@ -1,7 +1,7 @@
 <streams>
 
 <stream name="data_land_ice_fluxes"
-        filename_template="prescribed_ismf_adusumilli2020.nc"
+        filename_template="prescribed_ismf_paolo2023.nc"
         input_interval="initial_only"
         type="input">
 


### PR DESCRIPTION
This got missed in the pull request (#778) that switched to Paolo et al. (2023) melt rates.

<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->

<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [x] Document (in a comment titled `Testing` in this PR) any testing that was used to verify the changes

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->
