### PR TITLE
Fixes to landlocked cells when culling global meshes 

### DIFF
--- a/compass/ocean/mesh/cull.py
+++ b/compass/ocean/mesh/cull.py
@@ -407,8 +407,9 @@ def _cull_mesh_with_logging(logger, with_cavities, with_critical_passages,
 
         # Alter critical passages to be at least two cells wide, to avoid sea
         # ice blockage
-        dsCritPassMask = widen_transect_edge_masks(dsCritPassMask, dsBaseMesh,
-                                                   latitude_threshold=43.0)
+        dsCritPassMask = widen_transect_edge_masks(
+            dsCritPassMask, dsBaseMesh,
+            latitude_threshold=latitude_threshold)
 
         dsPreserve.append(dsCritPassMask)
 

--- a/compass/ocean/mesh/cull.py
+++ b/compass/ocean/mesh/cull.py
@@ -336,10 +336,6 @@ def _cull_mesh_with_logging(logger, with_cavities, with_critical_passages,
 
     dsBaseMesh = xr.open_dataset('base_mesh.nc')
     dsLandMask = xr.open_dataset('land_mask.nc')
-    dsLandMask = add_land_locked_cells_to_mask(
-        dsLandMask, dsBaseMesh, latitude_threshold=latitude_threshold,
-        nSweeps=sweep_count)
-    write_netcdf(dsLandMask, 'land_mask_with_land_locked_cells.nc')
 
     # create seed points for a flood fill of the ocean
     # use all points in the ocean directory, on the assumption that they are,
@@ -415,6 +411,13 @@ def _cull_mesh_with_logging(logger, with_cavities, with_critical_passages,
 
     if preserve_floodplain:
         dsPreserve.append(dsBaseMesh)
+
+    # fix land locked cells after adding critical land blockages, as these
+    # can lead to new land-locked cells
+    dsLandMask = add_land_locked_cells_to_mask(
+        dsLandMask, dsBaseMesh, latitude_threshold=latitude_threshold,
+        nSweeps=sweep_count)
+    write_netcdf(dsLandMask, 'land_mask_with_land_locked_cells.nc')
 
     # cull the mesh based on the land mask
     dsCulledMesh = cull(dsBaseMesh, dsMask=dsLandMask,


### PR DESCRIPTION
<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->

Since critical land blockages can cause new cells to be landlocked, we need to remove landlocked cells only after we have added land blockages to the land mask.

This merge also fixes a small issue where the `latitude_threshold` parameter for widening critical passages is now supplied from the appropriate config option, whereas it had previously been hard coded by mistake.

<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [x] Document (in a comment titled `Testing` in this PR) any testing that was used to verify the changes

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->
