### PR TITLE
Only make tidal mixing files for meshes with cavities

### DIFF
--- a/compass/ocean/tests/global_ocean/files_for_e3sm/remap_tidal_mixing.py
+++ b/compass/ocean/tests/global_ocean/files_for_e3sm/remap_tidal_mixing.py
@@ -34,13 +34,22 @@ class RemapTidalMixing(FilesForE3SMStep):
             target='ustar_CATS2008_S71W70.nc',
             database='tidal_mixing')
 
-        self.add_output_file(filename='velocityTidalRMS_CATS2008.nc')
+    def setup(self):
+        """
+        setup input and output files based on config options
+        """
+        super().setup()
+        if self.with_ice_shelf_cavities:
+            self.add_output_file(filename='velocityTidalRMS_CATS2008.nc')
 
     def run(self):
         """
         Run this step of the test case
         """
         super().run()
+        if not self.with_ice_shelf_cavities:
+            return
+
         logger = self.logger
         config = self.config
         ntasks = self.ntasks


### PR DESCRIPTION
Since the tidal model used to produce the dataset only covers the Southern Ocean, there is not much value in having the reampped dataset for meshes without cavities.  If we want to make a more general mixing parameterization that uses tidal information, we would need to use data from a global tidal model for the input dataset in the future.

<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->

<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [x] Document (in a comment titled `Testing` in this PR) any testing that was used to verify the changes

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->
