### PR TITLE
Add a utility for combining GEBCO and BedMachine topo

### DIFF
--- a/compass/ocean/tests/utility/__init__.py
+++ b/compass/ocean/tests/utility/__init__.py
@@ -1,3 +1,4 @@
+from compass.ocean.tests.utility.combine_topo import CombineTopo
 from compass.ocean.tests.utility.cull_restarts import CullRestarts
 from compass.ocean.tests.utility.extrap_woa import ExtrapWoa
 from compass.testgroup import TestGroup
@@ -15,5 +16,6 @@ class Utility(TestGroup):
         """
         super().__init__(mpas_core=mpas_core, name='utility')
 
+        self.add_test_case(CombineTopo(test_group=self))
         self.add_test_case(CullRestarts(test_group=self))
         self.add_test_case(ExtrapWoa(test_group=self))

--- a/compass/ocean/tests/utility/combine_topo/__init__.py
+++ b/compass/ocean/tests/utility/combine_topo/__init__.py
@@ -1,0 +1,336 @@
+import numpy as np
+import progressbar
+import pyproj
+import xarray as xr
+from pyremap import LatLonGridDescriptor, ProjectionGridDescriptor, Remapper
+
+from compass.step import Step
+from compass.testcase import TestCase
+
+
+class CombineTopo(TestCase):
+    """
+    A test case for combining GEBCO 2023 with BedMachineAntarctica topography
+    datasets
+    """
+
+    def __init__(self, test_group):
+        """
+        Create the test case
+
+        Parameters
+        ----------
+        test_group : compass.ocean.tests.utility.Utility
+            The test group that this test case belongs to
+        """
+        super().__init__(test_group=test_group, name='combine_topo')
+
+        self.add_step(Combine(test_case=self))
+
+
+class Combine(Step):
+    """
+    A step for combining GEBCO 2023 with BedMachineAntarctica topography
+    datasets
+    """
+
+    def __init__(self, test_case):
+        """
+        Create a new step
+
+        Parameters
+        ----------
+        test_case : compass.ocean.tests.utility.extrap_woa.ExtraWoa
+            The test case this step belongs to
+        """
+        super().__init__(test_case, name='combine', ntasks=None,
+                         min_tasks=None)
+
+    def setup(self):
+        """
+        Set up the step in the work directory, including downloading any
+        dependencies.
+        """
+        super().setup()
+
+        config = self.config
+        section = config['combine_topo']
+        antarctic_filename = section.get('antarctic_filename')
+        self.add_input_file(filename=antarctic_filename,
+                            target=antarctic_filename,
+                            database='bathymetry_database')
+        global_filename = section.get('global_filename')
+        self.add_input_file(filename=global_filename,
+                            target=global_filename,
+                            database='bathymetry_database')
+
+        cobined_filename = section.get('cobined_filename')
+        self.add_output_file(filename=cobined_filename)
+
+        self.ntasks = section.getint('ntasks')
+        self.min_tasks = section.getint('min_tasks')
+
+    def run(self):
+        """
+        Run this step of the test case
+        """
+        self._downsample_gebco()
+        self._modify_bedmachine()
+        # we will work with bedmachine data at its original resolution
+        # self._downsample_bedmachine()
+        self._remap_bedmachine()
+        self._combine()
+
+    def _downsample_gebco(self):
+        """
+        Average GEBCO to 0.0125 degree grid. GEBCO is on 15" grid, so average
+        every 3x3 block of cells
+        """
+        config = self.config
+        logger = self.logger
+
+        section = config['combine_topo']
+        in_filename = section.get('global_filename')
+        out_filename = 'GEBCO_2023_0.0125_degree.nc'
+
+        gebco = xr.open_dataset(in_filename)
+
+        nlon = gebco.sizes['lon']
+        nlat = gebco.sizes['lat']
+
+        block = 3
+        norm = 1.0 / block**2
+
+        nx = nlon // block
+        ny = nlat // block
+
+        chunks = 2
+        nxchunk = nlon // chunks
+        nychunk = nlat // chunks
+
+        gebco = gebco.chunk({'lon': nxchunk, 'lat': nychunk})
+
+        bathymetry = np.zeros((ny, nx))
+
+        logger.info('Averaging GEBCO to 0.0125 degree grid')
+        widgets = [progressbar.Percentage(), ' ',
+                   progressbar.Bar(), ' ', progressbar.ETA()]
+        bar = progressbar.ProgressBar(widgets=widgets,
+                                      maxval=chunks**2).start()
+        for ychunk in range(chunks):
+            for xchunk in range(chunks):
+                gebco_chunk = gebco.isel(
+                    lon=slice(nxchunk * xchunk, nxchunk * (xchunk + 1)),
+                    lat=slice(nychunk * ychunk, nychunk * (ychunk + 1)))
+                elevation = gebco_chunk.elevation.values
+                nxblock = nxchunk // block
+                nyblock = nychunk // block
+                bathy_block = np.zeros((nyblock, nxblock))
+                for y in range(block):
+                    for x in range(block):
+                        bathy_block += elevation[y::block, x::block]
+                bathy_block *= norm
+                xmin = xchunk * nxblock
+                xmax = (xchunk + 1) * nxblock
+                ymin = ychunk * nyblock
+                ymax = (ychunk + 1) * nyblock
+                bathymetry[ymin:ymax, xmin:xmax] = bathy_block
+                bar.update(ychunk * chunks + xchunk + 1)
+        bar.finish()
+
+        lon_corner = np.linspace(-180., 180., bathymetry.shape[1] + 1)
+        lat_corner = np.linspace(-90., 90., bathymetry.shape[0] + 1)
+        lon = 0.5 * (lon_corner[0:-1] + lon_corner[1:])
+        lat = 0.5 * (lat_corner[0:-1] + lat_corner[1:])
+        gebco_low = xr.Dataset({'bathymetry': (['lat', 'lon'], bathymetry)},
+                               coords={'lon': (['lon',], lon),
+                                       'lat': (['lat',], lat)})
+        gebco_low.attrs = gebco.attrs
+        gebco_low.lon.attrs = gebco.lon.attrs
+        gebco_low.lat.attrs = gebco.lat.attrs
+        gebco_low.bathymetry.attrs = gebco.elevation.attrs
+        gebco_low.to_netcdf(out_filename)
+
+    def _modify_bedmachine(self):
+        """
+        Modify BedMachineAntarctica to compute the fields needed by MPAS-Ocean
+        """
+        logger = self.logger
+        logger.info('Modifying BedMachineAntarctica with MPAS-Ocean names')
+
+        config = self.config
+
+        section = config['combine_topo']
+        in_filename = section.get('antarctic_filename')
+        out_filename = 'BedMachineAntarctica-v3_mod.nc'
+        bedmachine = xr.open_dataset(in_filename)
+        mask = bedmachine.mask
+        ice_mask = (mask != 0).astype(float)
+        ocean_mask = (np.logical_or(mask == 0, mask == 3)).astype(float)
+        grounded_mask = np.logical_or(np.logical_or(mask == 1, mask == 2),
+                                      mask == 4).astype(float)
+
+        bedmachine['bathymetry'] = bedmachine.bed.where(ocean_mask, 0.)
+        bedmachine['ice_draft'] = \
+            (bedmachine.surface -
+                bedmachine.thickness).where(ocean_mask, 0.)
+        bedmachine.ice_draft.attrs['units'] = 'meters'
+        bedmachine['thickness'] = \
+            bedmachine.thickness.where(ocean_mask, 0.)
+
+        bedmachine['ice_mask'] = ice_mask
+        bedmachine['grounded_mask'] = grounded_mask
+        bedmachine['ocean_mask'] = ocean_mask
+
+        varlist = ['bathymetry', 'ice_draft', 'thickness', 'ice_mask',
+                   'grounded_mask', 'ocean_mask']
+
+        bedmachine = bedmachine[varlist]
+
+        bedmachine.to_netcdf(out_filename)
+        logger.info('  Done.')
+
+    def _downsample_bedmachine(self):
+        """
+        Downsample bedmachine from 0.5 to 1 km grid
+        """
+        logger = self.logger
+        logger.info('Downsample BedMachineAntarctica from 500 m to 1 km')
+
+        in_filename = 'BedMachineAntarctica-v3_mod.nc'
+        out_filename = 'BedMachineAntarctica-v3_1k.nc'
+        bedmachine = xr.open_dataset(in_filename)
+        x = bedmachine.x.values
+        y = bedmachine.y.values
+
+        nx = len(x) // 2
+        ny = len(y) // 2
+        x = 0.5 * (x[0:2 * nx:2] + x[1:2 * nx:2])
+        y = 0.5 * (y[0:2 * ny:2] + y[1:2 * ny:2])
+        bedmachine1k = xr.Dataset()
+        for field in bedmachine.data_vars:
+            in_array = bedmachine[field].values
+            out_array = np.zeros((ny, nx))
+            for yoffset in range(2):
+                for xoffset in range(2):
+                    out_array += 0.25 * \
+                        in_array[yoffset:2 * ny:2, xoffset:2 * nx:2]
+            da = xr.DataArray(out_array, dims=('y', 'x'),
+                              coords={'x': (('x',), x),
+                                      'y': (('y',), y)})
+            bedmachine1k[field] = da
+            bedmachine1k[field].attrs = bedmachine[field].attrs
+
+        bedmachine1k.to_netcdf(out_filename)
+        logger.info('  Done.')
+
+    def _remap_bedmachine(self):
+        """
+        Remap BedMachine Antarctica to GEBCO lat-lon grid
+        """
+        logger = self.logger
+        logger.info('Remap BedMachineAntarctica to GEBCO 1/80 deg grid')
+
+        config = self.config
+
+        section = config['combine_topo']
+        renorm_thresh = section.getfloat('renorm_thresh')
+
+        in_filename = 'BedMachineAntarctica-v3_mod.nc'
+        out_filename = 'BedMachineAntarctica_on_GEBCO_low.nc'
+        gebco_filename = 'GEBCO_2023_0.0125_degree.nc'
+
+        projection = pyproj.Proj('+proj=stere +lat_ts=-71.0 +lat_0=-90 '
+                                 '+lon_0=0.0 +k_0=1.0 +x_0=0.0 +y_0=0.0 '
+                                 '+ellps=WGS84')
+
+        bedmachine = xr.open_dataset(in_filename)
+        x = bedmachine.x.values
+        y = bedmachine.y.values
+
+        in_descriptor = ProjectionGridDescriptor.create(
+            projection, x, y, 'BedMachineAntarctica_500m')
+
+        out_descriptor = LatLonGridDescriptor.read(fileName=gebco_filename)
+
+        mapping_filename = \
+            'map_BedMachineAntarctica_500m_to_GEBCO_0.0125deg_bilinear.nc'
+
+        remapper = Remapper(in_descriptor, out_descriptor, mapping_filename)
+        remapper.build_mapping_file(method='bilinear', mpiTasks=self.ntasks,
+                                    esmf_parallel_exec='srun', tempdir='.')
+        bedmachine = xr.open_dataset(in_filename)
+        bedmachine_on_gebco_low = remapper.remap(bedmachine)
+
+        for field in ['bathymetry', 'ice_draft', 'thickness']:
+            bedmachine_on_gebco_low[field].attrs['unit'] = 'meters'
+
+        # renormalize the fields based on the ocean masks
+        ocean_mask = bedmachine_on_gebco_low.ocean_mask
+
+        valid = ocean_mask > renorm_thresh
+        norm = ocean_mask.where(valid, 1.)
+        norm = 1. / norm
+        for field in ['bathymetry', 'ice_draft', 'thickness']:
+            bedmachine_on_gebco_low[field] = \
+                norm * bedmachine_on_gebco_low[field].where(valid, 0.)
+
+        bedmachine_on_gebco_low.to_netcdf(out_filename)
+        logger.info('  Done.')
+
+    def _combine(self):
+        """
+        Combine GEBCO with BedMachine Antarctica
+        """
+        logger = self.logger
+        logger.info('Combine BedMachineAntarctica and GEBCO')
+
+        config = self.config
+        section = config['combine_topo']
+
+        latmin = section.getfloat('latmin')
+        latmax = section.getfloat('latmax')
+        cobined_filename = section.get('cobined_filename')
+
+        gebco_filename = 'GEBCO_2023_0.0125_degree.nc'
+        gebco = xr.open_dataset(gebco_filename)
+
+        bedmachine_filename = 'BedMachineAntarctica_on_GEBCO_low.nc'
+        bedmachine = xr.open_dataset(bedmachine_filename)
+
+        combined = xr.Dataset()
+        alpha = (gebco.lat - latmin) / (latmax - latmin)
+        alpha = np.maximum(np.minimum(alpha, 1.0), 0.0)
+
+        bedmachine_bathy = bedmachine.bathymetry
+        valid = bedmachine_bathy.notnull()
+        bedmachine_bathy = bedmachine_bathy.where(valid, 0.)
+
+        combined['bathymetry'] = \
+            alpha * gebco.bathymetry.where(gebco.bathymetry < 0, 0.) + \
+            (1.0 - alpha) * bedmachine_bathy
+        for field in ['ice_draft', 'thickness']:
+            combined[field] = bedmachine[field]
+        for field in ['bathymetry', 'ice_draft', 'thickness']:
+            combined[field].attrs['unit'] = 'meters'
+
+        fill = {'ice_mask': 0., 'grounded_mask': 0.,
+                'ocean_mask': combined['bathymetry'] < 0.}
+
+        for field, fill_val in fill.items():
+            valid = bedmachine[field].notnull()
+            combined[field] = bedmachine[field].where(valid, fill_val)
+
+        combined['water_column'] = \
+            combined['ice_draft'] - combined['bathymetry']
+        combined.water_column.attrs['units'] = 'meters'
+
+        combined.to_netcdf(cobined_filename)
+        logger.info('  Done.')
+
+        diff = xr.Dataset()
+
+        diff['bathymetry'] = \
+            gebco.bathymetry.where(gebco.bathymetry < 0, 0.) - \
+            bedmachine.bathymetry
+        diff.to_netcdf('gebco_minus_bedmachine.nc')

--- a/compass/ocean/tests/utility/combine_topo/combine_topo.cfg
+++ b/compass/ocean/tests/utility/combine_topo/combine_topo.cfg
@@ -1,0 +1,21 @@
+# config options related combining Antarctic and global topograph datasets
+[combine_topo]
+
+# the names of the input topography files in the bathymetry database
+antarctic_filename = BedMachineAntarctica-v3.nc
+global_filename = GEBCO_2023.nc
+
+# the name of the output topography file, to be copied to the bathymetry database
+cobined_filename = BedMachineAntarctica_v3_and_GEBCO_2023_0.0125_degree_20240323.nc
+
+# the target and minimum number of MPI tasks to use in remapping
+ntasks = 512
+min_tasks = 128
+
+# latitudes between which the topography datasets get blended
+latmin = -62.
+latmax = -60.
+
+# the threshold for masks below which interpolated variables are not
+# renormalized
+renorm_thresh = 1e-3

--- a/docs/developers_guide/ocean/api.rst
+++ b/docs/developers_guide/ocean/api.rst
@@ -907,6 +907,11 @@ utility
 
    Utility
 
+   combine_topo.CombineTopo
+   combine_topo.Combine
+   combine_topo.Combine.setup
+   combine_topo.Combine.run
+
    cull_restarts.CullRestarts
    cull_restarts.Cull
    cull_restarts.Cull.run

--- a/docs/developers_guide/ocean/test_groups/utility.rst
+++ b/docs/developers_guide/ocean/test_groups/utility.rst
@@ -8,6 +8,22 @@ may create datasets for other test groups to use.  It is partly designed to
 provide provenance for data processing that may be more complex than a single,
 short script.
 
+combine_topo
+------------
+The class :py:class:`compass.ocean.tests.utility.combine_topo.CombineTopo`
+defines a test case for combining the
+`BedMachine Antarctica v3 <https://nsidc.org/data/nsidc-0756/versions/3>`_
+dataset with the `GEBCO 2023 <https://www.gebco.net/data_and_products/gridded_bathymetry_data/>`_
+dataset.
+
+combine
+~~~~~~~
+The class :py:class:`compass.ocean.tests.utility.combine_topo.Combine`
+defines a step for combining the datasets above.  The GEBCO data is downsampled
+to a 1/80 degree latitude-longitude grid to make later remapping to MPAS meshes
+more manageable.  The BedMachine data is remapped to this same mesh and the
+two datasets are blended between 60 and 62 degrees south latitude.
+
 cull_restarts
 -------------
 The class :py:class:`compass.ocean.tests.utility.cull_restarts.CullRestarts`

--- a/docs/users_guide/ocean/test_groups/utility.rst
+++ b/docs/users_guide/ocean/test_groups/utility.rst
@@ -8,6 +8,15 @@ may create datasets for other test groups to use.  It is partly designed to
 provide provenance for data processing that may be more complex than a single,
 short script.
 
+combine_topo
+------------
+The ``ocean/utility/combine_topo`` test case is used to combine the
+`BedMachine Antarctica v3 <https://nsidc.org/data/nsidc-0756/versions/3>`_
+dataset with the `GEBCO 2023 <https://www.gebco.net/data_and_products/gridded_bathymetry_data/>`_
+dataset.  The result is on a 1/80 degree latitude-longitude grid.  This utility
+is intended for provenance.  It is intended to doucment the process for
+producing the topography dataset used for E3SM ocean meshes.
+
 cull_restarts
 -------------
 The ``ocean/utility/cull_restarts`` test case is used to cull ice-shelf


### PR DESCRIPTION
<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->
This is nearly identical to the script used to produce the current bathymetry at:
https://web.lcrc.anl.gov/public/e3sm/mpas_standalonedata/mpas-ocean/provenance/combine_bedmachine_v3_gebco_2023.py
The major difference is that this utility doesn't downsample the BedMachine dataset to at 1 km grid (instead remapping the 500 m dataset to a 1/80 degree lat-lon grid).

<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [x] User's Guide has been updated
* [x] Developer's Guide has been updated
* [x] API documentation in the Developer's Guide (`api.rst`) has any new or modified class, method and/or functions listed
* [x] Documentation has been [built locally](https://mpas-dev.github.io/compass/latest/developers_guide/building_docs.html) and changes look as expected
* [x] Document (in a comment titled `Testing` in this PR) any testing that was used to verify the changes

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->
