### PR TITLE
Fix label for landice mesh_modifications test group in dev guide

### DIFF
--- a/docs/developers_guide/landice/test_groups/mesh_modifications.rst
+++ b/docs/developers_guide/landice/test_groups/mesh_modifications.rst
@@ -1,4 +1,4 @@
-.. _mesh_modifications:
+.. _dev_mesh_modifications:
 
 mesh_modifications
 ==================


### PR DESCRIPTION
<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->
This PR fixes the label for the landice mesh_modifications test group in the devevlopers guide so it does not conflict with the section in the users guide with the same name.
<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [x] Developer's Guide has been updated
* [x] Documentation has been [built locally](https://mpas-dev.github.io/compass/latest/developers_guide/building_docs.html) and changes look as expected

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->
