### PR TITLE
New Mesh: RRS6to18E3r6

### DIFF
--- a/compass/ocean/tests/global_ocean/mesh/rrs6to18/dynamic_adjustment.yaml
+++ b/compass/ocean/tests/global_ocean/mesh/rrs6to18/dynamic_adjustment.yaml
@@ -63,6 +63,6 @@ dynamic_adjustment:
       run_duration: 18_00:00:00
       output_interval: 10_00:00:00
       restart_interval: 06_00:00:00
-      dt: 00:06:00
-      btr_dt: 00:00:12
+      dt: 00:05:00
+      btr_dt: 00:00:10
       Rayleigh_damping_coeff: None

--- a/compass/ocean/tests/global_ocean/mesh/rrs6to18/namelist.init
+++ b/compass/ocean/tests/global_ocean/mesh/rrs6to18/namelist.init
@@ -4,4 +4,6 @@ config_rx1_vert_smooth_weight = 10.0
 config_rx1_slope_weight = 1e-1
 config_rx1_zstar_weight = 10.0
 config_rx1_horiz_smooth_open_ocean_cells = 40
-config_rx1_min_layer_thickness = 0.1
+config_rx1_min_levels = 8
+config_rx1_min_layer_thickness = 2.5
+config_global_ocean_minimum_depth = 20.0

--- a/compass/ocean/tests/global_ocean/mesh/rrs6to18/rrs6to18.cfg
+++ b/compass/ocean/tests/global_ocean/mesh/rrs6to18/rrs6to18.cfg
@@ -45,21 +45,22 @@ approx_cell_count = 4000000
 # the prefix (e.g. QU, EC, WC, SO)
 prefix = RRS
 # a description of the mesh and initial condition
-mesh_description = MPAS Eddy Closure mesh for E3SM version ${e3sm_version} with
-                   enhanced resolution around the equator (30 km), South pole
-                   (35 km), Greenland (${min_res} km), ${max_res}-km resolution
-                   at mid latitudes, and ${levels} vertical levels
+mesh_description = MPAS Rossby-radius scaled (RRS) mesh for E3SM version
+                   ${e3sm_version} with ${min_res}-km resolution at the poles,
+                   ${max_res}-km resolution at the equator, and <<<levels>>>
+                   vertical levels. This mesh includes cavities under the ice
+                   shelves around Antarctica.
 # E3SM version that the mesh is intended for
 e3sm_version = 3
 # The revision number of the mesh, which should be incremented each time the
 # mesh is revised
-mesh_revision = 1
+mesh_revision = 5
 # the minimum (finest) resolution in the mesh
 min_res = 6
 # the maximum (coarsest) resolution in the mesh, can be the same as min_res
 max_res = 18
 # The URL of the pull request documenting the creation of the mesh
-pull_request = <<<Missing>>>
+pull_request = https://github.com/MPAS-Dev/compass/pull/801
 
 
 # config options related to remapping topography to an MPAS-Ocean mesh

--- a/compass/ocean/tests/global_ocean/mesh/rrs6to18/rrs6to18.cfg
+++ b/compass/ocean/tests/global_ocean/mesh/rrs6to18/rrs6to18.cfg
@@ -54,13 +54,13 @@ mesh_description = MPAS Rossby-radius scaled (RRS) mesh for E3SM version
 e3sm_version = 3
 # The revision number of the mesh, which should be incremented each time the
 # mesh is revised
-mesh_revision = 5
+mesh_revision = 6
 # the minimum (finest) resolution in the mesh
 min_res = 6
 # the maximum (coarsest) resolution in the mesh, can be the same as min_res
 max_res = 18
 # The URL of the pull request documenting the creation of the mesh
-pull_request = https://github.com/MPAS-Dev/compass/pull/801
+pull_request = https://github.com/MPAS-Dev/compass/pull/809
 
 
 # config options related to remapping topography to an MPAS-Ocean mesh


### PR DESCRIPTION
<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->

Long name: RRS6to18L80E3SMv3r6

This RRS (Rossby-radius scaled) mesh has:
* 6 km resolution near the poles
* 18 km resolution at the equator

Mesh, initial condition, dynamic adjustment and files for E3SM will be on Chrysalis at:
```
/lcrc/group/e3sm/ac.xylar/compass_1.3/chrysalis/e3smv3-meshes/rrs6to18e3r6
```

This mesh is similar to RRSwISC6to18E3r5 #801 but without ice-shelf cavities.

<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [ ] Document (in a comment titled `Testing` in this PR) any testing that was used to verify the changes

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->
