### PR TITLE
Update to 1.4.0-alpha.1

### DIFF
--- a/compass/version.py
+++ b/compass/version.py
@@ -1,1 +1,1 @@
-__version__ = '1.3.0-alpha.2'
+__version__ = '1.4.0-alpha.1'

--- a/conda/bootstrap.py
+++ b/conda/bootstrap.py
@@ -465,6 +465,7 @@ def build_spack_env(config, update_spack, machine, compiler, mpi,  # noqa: C901
     cmake = config.get('deploy', 'cmake')
     esmf = config.get('deploy', 'esmf')
     lapack = config.get('deploy', 'lapack')
+    metis = config.get('deploy', 'metis')
     moab = config.get('deploy', 'moab')
     petsc = config.get('deploy', 'petsc')
     scorpio = config.get('deploy', 'scorpio')
@@ -501,6 +502,9 @@ def build_spack_env(config, update_spack, machine, compiler, mpi,  # noqa: C901
         include_e3sm_lapack = False
     else:
         include_e3sm_lapack = True
+    if metis != 'None':
+        specs.append(
+            f'"metis@{metis}+int64+real64"')
     if moab != 'None':
         specs.append(
             f'"moab@{moab}+mpi+hdf5+netcdf+pnetcdf+metis+parmetis+tempest"')

--- a/conda/default.cfg
+++ b/conda/default.cfg
@@ -26,6 +26,7 @@ cmake = 3.23.0:
 esmf = 8.6.0
 hdf5 = 1.14.3
 lapack = 3.9.1
+metis = 5.1.0
 moab = 5.5.1
 netcdf_c = 4.9.2
 netcdf_fortran = 4.6.0


### PR DESCRIPTION
<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->

### Updates:
- 

### Other Changes:
- Add metis 5.1.0 built with `int64` and `real64` (needed for large partitions)

<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [ ] Document (in a comment titled `Testing` in this PR) any testing that was used to verify the changes

## Testing

MPAS-Ocean with `pr`:
- [ ] Anvil
  - [ ] intel and impi
  - [ ] gnu and openmpi
- [ ] Chicoma
  - [ ] gnu and mpich
- [ ] Chrysalis
  - [ ] intel and openmpi
  - [ ] gnu and openmpi
- [ ] Compy
  - [ ] intel and impi
- [ ] Perlmutter 
  - [ ] gnu and mpich

MALI with `full_integration`:
- [ ] Chicoma
  - [ ] gnu and mpich
- [ ] Chrysalis 
  - [ ] gnu and openmpi
- [ ] Perlmutter
  - [ ] gnu and mpich

## Deployed

MPAS-Ocean with `pr`:
- [ ] Anvil
  - [ ] intel and impi
  - [ ] intel and openmpi
  - [ ] gnu and openmpi
- [ ] Chicoma
  - [ ] gnu and mpich
- [ ] Chrysalis
  - [ ] intel and openmpi
  - [ ] gnu and openmpi
- [ ] Compy
  - [ ] intel and impi
- [ ] Perlmutter 
  - [ ] gnu and mpich

MALI with `full_integration`:
- [ ] Chicoma
  - [ ] gnu and mpich
- [ ] Chrysalis 
  - [ ] gnu and openmpi
- [ ] Perlmutter
  - [ ] gnu and mpich