### PR TITLE
Add config options for min levels

### DIFF
--- a/compass/ocean/tests/global_ocean/global_ocean.cfg
+++ b/compass/ocean/tests/global_ocean/global_ocean.cfg
@@ -49,8 +49,17 @@ btr_dt_per_km = 1.5
 
 ## config options related to the initial_state step
 
+# minimum number of vertical levels, both in the open ocean and in ice-shelf
+# cavities
+min_levels = 3
+cavity_min_levels = ${min_levels}
+
+# minimum thickness of layers in ice-shelf cavities
+cavity_min_layer_thickness = 1.0
+
 # Maximum allowed Haney number for configurations with ice-shelf cavities
-rx1_max = 20
+rx1_max = 20.0
+
 # the number of iterations of topography smoothing (0 means no smoothing)
 topo_smooth_num_passes = 0
 # The distance in km over which the Gaussian filter is applied

--- a/compass/ocean/tests/global_ocean/init/initial_state.py
+++ b/compass/ocean/tests/global_ocean/init/initial_state.py
@@ -176,6 +176,25 @@ class InitialState(Step):
         plot_vertical_grid(grid_filename='vertical_grid.nc', config=config,
                            out_filename='vertical_grid.png')
 
+        min_levels = config.getint('global_ocean', 'min_levels')
+        # minimum depth will be the depth of the middle of the minimum layer
+        # so that MPAS-Ocean init mode will convert it back to the same
+        # minimm number of levels
+        min_depth = 0.5 * (interfaces[min_levels - 1] +
+                           interfaces[min_levels])
+        namelist = {'config_global_ocean_minimum_depth': f'{min_depth}'}
+
+        if self.mesh.with_ice_shelf_cavities:
+            cavity_min_levels = \
+                config.getint('global_ocean', 'cavity_min_levels')
+            cavity_min_layer_thickness = \
+                config.getfloat('global_ocean', 'cavity_min_layer_thickness')
+            namelist['config_rx1_min_levels'] = f'{cavity_min_levels}'
+            namelist['config_rx1_min_layer_thickness'] = \
+                f'{cavity_min_layer_thickness}'
+
+        self.update_namelist_at_runtime(namelist)
+
         update_pio = config.getboolean('global_ocean', 'init_update_pio')
         run_model(self, update_pio=update_pio)
 

--- a/compass/ocean/tests/global_ocean/init/namelist.init
+++ b/compass/ocean/tests/global_ocean/init/namelist.init
@@ -50,7 +50,6 @@ config_global_ocean_depth_file = 'vertical_grid.nc'
 config_global_ocean_depth_dimname = 'nVertLevels'
 config_global_ocean_depth_varname = 'refMidDepth'
 config_global_ocean_depth_conversion_factor = 1.0
-config_global_ocean_minimum_depth = 10
 config_global_ocean_deepen_critical_passages = .false.
 config_block_decomp_file_prefix = 'graph.info.part.'
 config_global_ocean_topography_smooth_iterations = 0

--- a/compass/ocean/tests/global_ocean/mesh/arrm10to60/arrm10to60.cfg
+++ b/compass/ocean/tests/global_ocean/mesh/arrm10to60/arrm10to60.cfg
@@ -21,6 +21,14 @@ max_layer_thickness = 150.0
 [global_ocean]
 
 ## config options related to the initial_state step
+
+# minimum number of vertical levels, both in the open ocean and in ice-shelf
+# cavities
+min_levels = 5
+
+# minimum thickness of layers in ice-shelf cavities
+cavity_min_layer_thickness = 2.0
+
 # number of cores to use
 init_ntasks = 256
 # minimum of cores, below which the step fails

--- a/compass/ocean/tests/global_ocean/mesh/arrm10to60/namelist.init
+++ b/compass/ocean/tests/global_ocean/mesh/arrm10to60/namelist.init
@@ -1,1 +1,0 @@
-config_global_ocean_minimum_depth = 10

--- a/compass/ocean/tests/global_ocean/mesh/rrs6to18/rrs6to18.cfg
+++ b/compass/ocean/tests/global_ocean/mesh/rrs6to18/rrs6to18.cfg
@@ -24,6 +24,13 @@ convert_to_cdf5 = True
 # options for global ocean testcases
 [global_ocean]
 
+# minimum number of vertical levels, both in the open ocean and in ice-shelf
+# cavities
+min_levels = 8
+
+# minimum thickness of layers in ice-shelf cavities
+cavity_min_layer_thickness = 2.5
+
 ## config options related to the initial_state step
 # number of cores to use
 init_ntasks = 512

--- a/docs/developers_guide/ocean/test_groups/global_ocean.rst
+++ b/docs/developers_guide/ocean/test_groups/global_ocean.rst
@@ -664,6 +664,13 @@ The default config options for these meshes are:
     grid_type = 80layerE3SMv1
 
 
+    # options for spherical meshes
+    [spherical_mesh]
+
+    # Whether to convert the culled mesh file to CDF5 format
+    convert_culled_mesh_to_cdf5 = True
+
+
     # Options relate to adjusting the sea-surface height or land-ice pressure
     # below ice shelves to they are dynamically consistent with one another
     [ssh_adjustment]
@@ -675,6 +682,13 @@ The default config options for these meshes are:
 
     # options for global ocean testcases
     [global_ocean]
+
+    # minimum number of vertical levels, both in the open ocean and in ice-shelf
+    # cavities
+    min_levels = 8
+
+    # minimum thickness of layers in ice-shelf cavities
+    cavity_min_layer_thickness = 2.5
 
     ## config options related to the initial_state step
     # number of cores to use
@@ -691,16 +705,16 @@ The default config options for these meshes are:
     forward_update_pio = False
 
     # the approximate number of cells in the mesh
-    approx_cell_count = 3700000
+    approx_cell_count = 4000000
 
     ## metadata related to the mesh
     # the prefix (e.g. QU, EC, WC, SO)
     prefix = RRS
     # a description of the mesh and initial condition
     mesh_description = MPAS Eddy Closure mesh for E3SM version ${e3sm_version} with
-                       enhanced resolution around the equator (30 km), South pole
-                       (35 km), Greenland (${min_res} km), ${max_res}-km resolution
-                       at mid latitudes, and ${levels} vertical levels
+                    enhanced resolution around the equator (30 km), South pole
+                    (35 km), Greenland (${min_res} km), ${max_res}-km resolution
+                    at mid latitudes, and ${levels} vertical levels
     # E3SM version that the mesh is intended for
     e3sm_version = 3
     # The revision number of the mesh, which should be incremented each time the
@@ -730,6 +744,15 @@ The default config options for these meshes are:
 
     # the NetCDF output engine: netcdf4 or scipy
     engine = netcdf4
+
+    # config options related to initial condition and diagnostics support files
+    # for E3SM
+    [files_for_e3sm]
+
+    # The minimum and maximum cells per core for creating graph partitions
+    max_cells_per_core = 30000
+    # We're seeing gpmetis failures for more than 750,000 tasks so we'll stay under
+    min_cells_per_core = 6
 
 The vertical grid is a ``80LayerE3SMv1`` profile (see
 :ref:`dev_ocean_framework_vertical`) with 80 vertical levels ranging in

--- a/docs/users_guide/ocean/test_groups/global_ocean.rst
+++ b/docs/users_guide/ocean/test_groups/global_ocean.rst
@@ -43,6 +43,12 @@ Note that meshes and test cases may modify these options, as noted below.
     cull_mesh_min_cpus_per_task = 1
     # maximum memory usage allowed (in MB)
     cull_mesh_max_memory = 1000
+    # Whether to convert the culled mesh file to CDF5 format
+    convert_culled_mesh_to_cdf5 = False
+    # Minimum latitude, in degrees, for masking land-locked cells
+    latitude_threshold = 43.0
+    # Maximum number of sweeps to search for land-locked cells
+    sweep_count = 20
 
 
     # Options relate to adjusting the sea-surface height or land-ice pressure
@@ -78,8 +84,23 @@ Note that meshes and test cases may modify these options, as noted below.
 
     ## config options related to the initial_state step
 
+    # minimum number of vertical levels, both in the open ocean and in ice-shelf
+    # cavities
+    min_levels = 3
+    cavity_min_levels = ${min_levels}
+
+    # minimum thickness of layers in ice-shelf cavities
+    cavity_min_layer_thickness = 1.0
+
     # Maximum allowed Haney number for configurations with ice-shelf cavities
-    rx1_max = 20
+    rx1_max = 20.0
+
+    # the number of iterations of topography smoothing (0 means no smoothing)
+    topo_smooth_num_passes = 0
+    # The distance in km over which the Gaussian filter is applied
+    topo_smooth_distance_limit = 200.0
+    # The standard deviation in km of the Gaussian filter
+    topo_smooth_std_deviation = 100.0
 
     # number of cores to use
     init_ntasks = 36
@@ -124,7 +145,7 @@ Note that meshes and test cases may modify these options, as noted below.
     # the number of vertical levels, always detected automatically
     levels = autodetect
 
-    # the date the mesh was created as YYMMDD, typically detected automatically
+    # the date the mesh was created as YYYYMMDD, typically detected automatically
     creation_date = autodetect
     # The following options are detected from .gitconfig if not explicitly entered
     author = autodetect
@@ -146,6 +167,10 @@ Note that meshes and test cases may modify these options, as noted below.
     # config options related to initial condition and diagnostics support files
     # for E3SM
     [files_for_e3sm]
+
+    # The minimum and maximum cells per core for creating graph partitions
+    max_cells_per_core = 30000
+    min_cells_per_core = 2
 
     ## the following relate to the comparison grids in MPAS-Analysis to generate
     ## mapping files for.  The default values are also the defaults in
@@ -200,9 +225,9 @@ Note that meshes and test cases may modify these options, as noted below.
     # directory of an ocean restart file on the given mesh
     ocean_restart_filename = autodetect
 
-   # the base mesh before culling for remapping and rerouting data ice-shelf melt
-   # fluxes
-   base_mesh_filename = autodetect
+    # the base mesh before culling for remapping and rerouting data ice-shelf melt
+    # fluxes
+    ocean_base_mesh_filename = autodetect
 
     # the initial state used to extract the ocean and sea-ice meshes
     ocean_initial_state_filename = ${ocean_restart_filename}


### PR DESCRIPTION
Previously, we specified the minimum thickness of the global ocean, which was set to 10 m.

This is not a good approach with different vertical coordinates.  If we want to use the same settings across various vertical coordinates, it is more useful to require a minimum number of levels.

This merge changes the global ocean `initial_state` step to use config options to set the number of vertical levels both in the open ocean and in ice-shelf cavities.  Relatedly, we also add a config option to set the minimum layer thickness in cavities.

This change will affect the vertical 3D vertical cooridinate in all meshes (hopefully for the better).

For meshes that use variants of the 80-layer vertical coordinate, we set the minimum number of layers that sets the column thickness to either 10 or 20 m.

<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->

<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [x] User's Guide has been updated
* [x] Developer's Guide has been updated
* [x] Documentation has been [built locally](https://mpas-dev.github.io/compass/latest/developers_guide/building_docs.html) and changes look as expected
* [x] Document (in a comment titled `Testing` in this PR) any testing that was used to verify the changes

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->
