### PR TITLE
Update to mache v1.22.0

### DIFF
--- a/compass/version.py
+++ b/compass/version.py
@@ -1,1 +1,1 @@
-__version__ = '1.3.0-alpha.2'
+__version__ = '1.3.0-alpha.3'

--- a/conda/compass_env/spec-file.template
+++ b/conda/compass_env/spec-file.template
@@ -16,7 +16,7 @@ ipython
 jupyter
 lxml
 {% if include_mache %}
-mache=1.20.0
+mache=1.22.0
 {% endif %}
 matplotlib-base
 metis

--- a/conda/configure_compass_env.py
+++ b/conda/configure_compass_env.py
@@ -100,7 +100,7 @@ def main():
     if local_mache:
         mache = ''
     else:
-        mache = '"mache=1.20.0"'
+        mache = '"mache=1.22.0"'
 
     setup_install_env(env_name, activate_base, args.use_local, logger,
                       args.recreate, conda_base, mache)

--- a/conda/recipe/meta.yaml
+++ b/conda/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "compass" %}
-{% set version = "1.3.0alpha.2" %}
+{% set version = "1.3.0alpha.3" %}
 {% set build = 0 %}
 
 {% if mpi == "nompi" %}
@@ -54,7 +54,7 @@ requirements:
     - jigsawpy 0.3.3
     - jupyter
     - lxml
-    - mache 1.17.0
+    - mache 1.22.0
     - matplotlib-base
     - metis
     - mpas_tools 0.33.0


### PR DESCRIPTION
<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->
This version of mache uses newer OpenMPI libraries for Intel, needed to prevent jobs from hanging during cancellation, blocking nodes.

* [x] Document (in a comment titled `Testing` in this PR) any testing that was used to verify the changes

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->
