### PR TITLE
Add wave mesh generation for global_ocean mesh test cases

### DIFF
--- a/compass/ocean/tests/global_ocean/__init__.py
+++ b/compass/ocean/tests/global_ocean/__init__.py
@@ -121,10 +121,10 @@ class GlobalOcean(TestGroup):
                 time_integrator=time_integrator)
             self.add_test_case(dynamic_adjustment_test)
 
-            self.add_test_case(
-                FilesForE3SM(
-                    test_group=self, mesh=mesh_test, init=init_test,
-                    dynamic_adjustment=dynamic_adjustment_test))
+            e3sm_files_test = FilesForE3SM(
+                test_group=self, mesh=mesh_test, init=init_test,
+                dynamic_adjustment=dynamic_adjustment_test)
+            self.add_test_case(e3sm_files_test)
 
             if include_rk4:
                 time_integrator = 'RK4'
@@ -176,4 +176,4 @@ class GlobalOcean(TestGroup):
             if include_wave_mesh:
                 self.add_test_case(
                     WaveMesh(test_group=self, ocean_mesh=mesh_test,
-                             ocean_init=init_test))
+                             ocean_init=init_test, ocean_e3sm=e3sm_files_test))

--- a/compass/ocean/tests/global_ocean/__init__.py
+++ b/compass/ocean/tests/global_ocean/__init__.py
@@ -1,5 +1,3 @@
-from comass.ocean.test.global_ocean.wave_mesh import WaveMesh
-
 from compass.ocean.tests.global_ocean.analysis_test import AnalysisTest
 from compass.ocean.tests.global_ocean.daily_output_test import DailyOutputTest
 from compass.ocean.tests.global_ocean.decomp_test import DecompTest
@@ -15,6 +13,7 @@ from compass.ocean.tests.global_ocean.monthly_output_test import (
 from compass.ocean.tests.global_ocean.performance_test import PerformanceTest
 from compass.ocean.tests.global_ocean.restart_test import RestartTest
 from compass.ocean.tests.global_ocean.threads_test import ThreadsTest
+from compass.ocean.tests.global_ocean.wave_mesh import WaveMesh
 from compass.testgroup import TestGroup
 
 
@@ -175,4 +174,5 @@ class GlobalOcean(TestGroup):
                         dynamic_adjustment=dynamic_adjustment_test))
 
             if include_wave_mesh:
-                self.add_test_case(WaveMesh(test_group=self, ocean_mesh=mest_test))
+                self.add_test_case(
+                    WaveMesh(test_group=self, ocean_mesh=mesh_test))

--- a/compass/ocean/tests/global_ocean/__init__.py
+++ b/compass/ocean/tests/global_ocean/__init__.py
@@ -1,3 +1,5 @@
+from comass.ocean.test.global_ocean.wave_mesh import WaveMesh
+
 from compass.ocean.tests.global_ocean.analysis_test import AnalysisTest
 from compass.ocean.tests.global_ocean.daily_output_test import DailyOutputTest
 from compass.ocean.tests.global_ocean.decomp_test import DecompTest
@@ -62,10 +64,14 @@ class GlobalOcean(TestGroup):
         # A test case for making E3SM support files from an existing mesh
         self.add_test_case(FilesForE3SM(test_group=self))
 
+        # Create waves mesh
+        self._add_tests(mesh_names=['Icos'], include_wave_mesh=True)
+
     def _add_tests(self, mesh_names, high_res_topography=True,
                    include_rk4=False,
                    include_regression=False, include_phc=False,
-                   include_en4_1900=False):
+                   include_en4_1900=False,
+                   include_wave_mesh=False):
         """ Add test cases for the given mesh(es) """
 
         default_ic = 'WOA23'
@@ -167,3 +173,6 @@ class GlobalOcean(TestGroup):
                     FilesForE3SM(
                         test_group=self, mesh=mesh_test, init=init_test,
                         dynamic_adjustment=dynamic_adjustment_test))
+
+            if include_wave_mesh:
+                self.add_test_case(WaveMesh(test_group=self, ocean_mesh=mest_test))

--- a/compass/ocean/tests/global_ocean/__init__.py
+++ b/compass/ocean/tests/global_ocean/__init__.py
@@ -175,4 +175,5 @@ class GlobalOcean(TestGroup):
 
             if include_wave_mesh:
                 self.add_test_case(
-                    WaveMesh(test_group=self, ocean_mesh=mesh_test))
+                    WaveMesh(test_group=self, ocean_mesh=mesh_test,
+                             ocean_init=init_test))

--- a/compass/ocean/tests/global_ocean/wave_mesh/__init__.py
+++ b/compass/ocean/tests/global_ocean/wave_mesh/__init__.py
@@ -52,7 +52,7 @@ class WaveMesh(TestCase):
         self.add_step(rotate_mesh_step)
 
         uost_file_step = WavesUostFiles(test_case=self,
-                                        ocean_mesh=ocean_mesh)
+                                        wave_culled_mesh=cull_mesh_step)
         self.add_step(uost_file_step)
 
     def configure(self, config=None):

--- a/compass/ocean/tests/global_ocean/wave_mesh/__init__.py
+++ b/compass/ocean/tests/global_ocean/wave_mesh/__init__.py
@@ -5,6 +5,7 @@ from compass.ocean.tests.global_ocean.wave_mesh.base_mesh import WavesBaseMesh
 from compass.ocean.tests.global_ocean.wave_mesh.uost_files import (
     WavesUostFiles,
 )
+from compass.ocean.tests.global_ocean.wave_mesh.cull_mesh import WavesCullMesh
 from compass.testcase import TestCase
 
 # from compass.validate import compare_variables
@@ -37,6 +38,11 @@ class WaveMesh(TestCase):
         base_mesh_step = WavesBaseMesh(test_case=self,
                                        ocean_mesh=ocean_mesh)
         self.add_step(base_mesh_step)
+
+        cull_mesh_step = WavesCullMesh(test_case=self,
+                                       ocean_mesh=ocean_mesh,
+                                       wave_base_mesh=base_mesh_step)
+        self.add_step(cull_mesh_step)
 
         uost_file_step = WavesUostFiles(test_case=self,
                                         ocean_mesh=ocean_mesh)

--- a/compass/ocean/tests/global_ocean/wave_mesh/__init__.py
+++ b/compass/ocean/tests/global_ocean/wave_mesh/__init__.py
@@ -37,8 +37,9 @@ class WaveMesh(TestCase):
         base_mesh_step = WavesBaseMesh(test_case=self,
                                        ocean_mesh=ocean_mesh)
         self.add_step(base_mesh_step)
-        
-        uost_file_step = WavesUostFiles(test_case=self)
+
+        uost_file_step = WavesUostFiles(test_case=self,
+                                        ocean_mesh=ocean_mesh)
         self.add_step(uost_file_step)
 
     def configure(self, config=None):

--- a/compass/ocean/tests/global_ocean/wave_mesh/__init__.py
+++ b/compass/ocean/tests/global_ocean/wave_mesh/__init__.py
@@ -1,8 +1,12 @@
 # from compass.ocean.tests.global_ocean.metadata import (
 #     get_author_and_email_from_git,
 # )
+from compass.ocean.tests.global_ocean.files_for_e3sm.scrip import Scrip
 from compass.ocean.tests.global_ocean.wave_mesh.base_mesh import WavesBaseMesh
 from compass.ocean.tests.global_ocean.wave_mesh.cull_mesh import WavesCullMesh
+from compass.ocean.tests.global_ocean.wave_mesh.remap_files import (
+    WavesRemapFiles,
+)
 from compass.ocean.tests.global_ocean.wave_mesh.rotate_mesh import (
     WavesRotateMesh,
 )
@@ -53,6 +57,11 @@ class WaveMesh(TestCase):
         scrip_file_step = WavesScripFile(test_case=self,
                                          wave_culled_mesh=cull_mesh_step)
         self.add_step(scrip_file_step)
+
+        remap_file_step = WavesRemapFiles(test_case=self,
+                                          wave_scrip=scrip_file_step,
+                                          ocean_scrip=Scrip)
+        self.add_step(remap_file_step)
 
         rotate_mesh_step = WavesRotateMesh(test_case=self,
                                            wave_culled_mesh=cull_mesh_step)

--- a/compass/ocean/tests/global_ocean/wave_mesh/__init__.py
+++ b/compass/ocean/tests/global_ocean/wave_mesh/__init__.py
@@ -28,25 +28,25 @@ class WaveMesh(TestCase):
         subdir = f'{ocean_mesh.mesh_name}/{name}'
         super().__init__(test_group=test_group, name=name, subdir=subdir)
 
-        mesh_lower = ocean_mesh.mesh_name.lower()
-        self.package = f'compass.ocean.tests.global_ocean.mesh.{mesh_lower}'
-        self.mesh_config_filename = f'{mesh_lower}.cfg'
+        self.package = 'compass.ocean.tests.global_ocean.wave_mesh'
+        self.mesh_config_filename = 'wave_mesh.cfg'
 
-        base_mesh_step = WavesBaseMesh(test_case=self)
+        base_mesh_step = WavesBaseMesh(test_case=self,
+                                       ocean_mesh=ocean_mesh)
         self.add_step(base_mesh_step)
 
-#    def configure(self, config=None):
-#        """
-#        Modify the configuration options for this test case
-#
-#        config : compass.config.CompassConfigParser, optional
-#            Configuration options to update if not those for this test case
-#        """
-#        if config is None:
-#            config = self.config
-#        config.add_from_package('compass.mesh', 'mesh.cfg', exception=True)
-#
-#        get_author_and_email_from_git(config)
+    def configure(self, config=None):
+        """
+        Modify the configuration options for this test case
+
+        config : compass.config.CompassConfigParser, optional
+            Configuration options to update if not those for this test case
+        """
+        if config is None:
+            config = self.config
+        config.add_from_package('compass.mesh', 'mesh.cfg', exception=True)
+
+        # get_author_and_email_from_git(config)
 
 #    def validate(self):
 #        """

--- a/compass/ocean/tests/global_ocean/wave_mesh/__init__.py
+++ b/compass/ocean/tests/global_ocean/wave_mesh/__init__.py
@@ -1,7 +1,6 @@
 # from compass.ocean.tests.global_ocean.metadata import (
 #     get_author_and_email_from_git,
 # )
-from compass.ocean.tests.global_ocean.files_for_e3sm.scrip import Scrip
 from compass.ocean.tests.global_ocean.wave_mesh.base_mesh import WavesBaseMesh
 from compass.ocean.tests.global_ocean.wave_mesh.cull_mesh import WavesCullMesh
 from compass.ocean.tests.global_ocean.wave_mesh.remap_files import (
@@ -28,7 +27,7 @@ class WaveMesh(TestCase):
     Attributes
     ----------
     """
-    def __init__(self, test_group, ocean_mesh, ocean_init):
+    def __init__(self, test_group, ocean_mesh, ocean_init, ocean_e3sm):
         """
         Create test case for creating a global MPAS-Ocean mesh
 
@@ -60,7 +59,7 @@ class WaveMesh(TestCase):
 
         remap_file_step = WavesRemapFiles(test_case=self,
                                           wave_scrip=scrip_file_step,
-                                          ocean_scrip=Scrip)
+                                          ocean_e3sm=ocean_e3sm)
         self.add_step(remap_file_step)
 
         rotate_mesh_step = WavesRotateMesh(test_case=self,

--- a/compass/ocean/tests/global_ocean/wave_mesh/__init__.py
+++ b/compass/ocean/tests/global_ocean/wave_mesh/__init__.py
@@ -6,6 +6,9 @@ from compass.ocean.tests.global_ocean.wave_mesh.cull_mesh import WavesCullMesh
 from compass.ocean.tests.global_ocean.wave_mesh.rotate_mesh import (
     WavesRotateMesh,
 )
+from compass.ocean.tests.global_ocean.wave_mesh.scrip_file import (
+    WavesScripFile,
+)
 from compass.ocean.tests.global_ocean.wave_mesh.uost_files import (
     WavesUostFiles,
 )
@@ -46,6 +49,10 @@ class WaveMesh(TestCase):
                                        ocean_mesh=ocean_init,
                                        wave_base_mesh=base_mesh_step)
         self.add_step(cull_mesh_step)
+
+        scrip_file_step = WavesScripFile(test_case=self,
+                                         wave_culled_mesh=cull_mesh_step)
+        self.add_step(scrip_file_step)
 
         rotate_mesh_step = WavesRotateMesh(test_case=self,
                                            wave_culled_mesh=cull_mesh_step)

--- a/compass/ocean/tests/global_ocean/wave_mesh/__init__.py
+++ b/compass/ocean/tests/global_ocean/wave_mesh/__init__.py
@@ -2,6 +2,9 @@
 #     get_author_and_email_from_git,
 # )
 from compass.ocean.tests.global_ocean.wave_mesh.base_mesh import WavesBaseMesh
+from compass.ocean.tests.global_ocean.wave_mesh.uost_files import (
+    WavesUostFiles,
+)
 from compass.testcase import TestCase
 
 # from compass.validate import compare_variables
@@ -34,6 +37,9 @@ class WaveMesh(TestCase):
         base_mesh_step = WavesBaseMesh(test_case=self,
                                        ocean_mesh=ocean_mesh)
         self.add_step(base_mesh_step)
+        
+        uost_file_step = WavesUostFiles(test_case=self)
+        self.add_step(uost_file_step)
 
     def configure(self, config=None):
         """

--- a/compass/ocean/tests/global_ocean/wave_mesh/__init__.py
+++ b/compass/ocean/tests/global_ocean/wave_mesh/__init__.py
@@ -1,9 +1,10 @@
-#from compass.ocean.tests.global_ocean.metadata import (
-#    get_author_and_email_from_git,
-#)
+# from compass.ocean.tests.global_ocean.metadata import (
+#     get_author_and_email_from_git,
+# )
+from compass.ocean.tests.global_ocean.wave_mesh.base_mesh import WavesBaseMesh
 from compass.testcase import TestCase
 
-#from compass.validate import compare_variables
+# from compass.validate import compare_variables
 
 
 class WaveMesh(TestCase):
@@ -24,12 +25,14 @@ class WaveMesh(TestCase):
 
         """
         name = 'wave_mesh'
-        subdir = f'{mesh_name}/{name}'
+        subdir = f'{ocean_mesh.mesh_name}/{name}'
         super().__init__(test_group=test_group, name=name, subdir=subdir)
 
+        mesh_lower = ocean_mesh.mesh_name.lower()
         self.package = f'compass.ocean.tests.global_ocean.mesh.{mesh_lower}'
         self.mesh_config_filename = f'{mesh_lower}.cfg'
 
+        base_mesh_step = WavesBaseMesh(test_case=self)
         self.add_step(base_mesh_step)
 
 #    def configure(self, config=None):

--- a/compass/ocean/tests/global_ocean/wave_mesh/__init__.py
+++ b/compass/ocean/tests/global_ocean/wave_mesh/__init__.py
@@ -1,0 +1,55 @@
+#from compass.ocean.tests.global_ocean.metadata import (
+#    get_author_and_email_from_git,
+#)
+from compass.testcase import TestCase
+
+#from compass.validate import compare_variables
+
+
+class WaveMesh(TestCase):
+    """
+    A test case for creating a global MPAS-Ocean mesh
+
+    Attributes
+    ----------
+    """
+    def __init__(self, test_group, ocean_mesh):
+        """
+        Create test case for creating a global MPAS-Ocean mesh
+
+        Parameters
+        ----------
+        test_group : compass.ocean.tests.global_ocean.GlobalOcean
+            The global ocean test group that this test case belongs to
+
+        """
+        name = 'wave_mesh'
+        subdir = f'{mesh_name}/{name}'
+        super().__init__(test_group=test_group, name=name, subdir=subdir)
+
+        self.package = f'compass.ocean.tests.global_ocean.mesh.{mesh_lower}'
+        self.mesh_config_filename = f'{mesh_lower}.cfg'
+
+        self.add_step(base_mesh_step)
+
+#    def configure(self, config=None):
+#        """
+#        Modify the configuration options for this test case
+#
+#        config : compass.config.CompassConfigParser, optional
+#            Configuration options to update if not those for this test case
+#        """
+#        if config is None:
+#            config = self.config
+#        config.add_from_package('compass.mesh', 'mesh.cfg', exception=True)
+#
+#        get_author_and_email_from_git(config)
+
+#    def validate(self):
+#        """
+#        Test cases can override this method to perform validation of variables
+#        and timers
+#        """
+#        variables = ['xCell', 'yCell', 'zCell']
+#        compare_variables(test_case=self, variables=variables,
+#                          filename1='cull_mesh/culled_mesh.nc')

--- a/compass/ocean/tests/global_ocean/wave_mesh/__init__.py
+++ b/compass/ocean/tests/global_ocean/wave_mesh/__init__.py
@@ -2,10 +2,13 @@
 #     get_author_and_email_from_git,
 # )
 from compass.ocean.tests.global_ocean.wave_mesh.base_mesh import WavesBaseMesh
+from compass.ocean.tests.global_ocean.wave_mesh.cull_mesh import WavesCullMesh
+from compass.ocean.tests.global_ocean.wave_mesh.rotate_mesh import (
+    WavesRotateMesh,
+)
 from compass.ocean.tests.global_ocean.wave_mesh.uost_files import (
     WavesUostFiles,
 )
-from compass.ocean.tests.global_ocean.wave_mesh.cull_mesh import WavesCullMesh
 from compass.testcase import TestCase
 
 # from compass.validate import compare_variables
@@ -43,6 +46,10 @@ class WaveMesh(TestCase):
                                        ocean_mesh=ocean_mesh,
                                        wave_base_mesh=base_mesh_step)
         self.add_step(cull_mesh_step)
+
+        rotate_mesh_step = WavesRotateMesh(test_case=self,
+                                           wave_culled_mesh=cull_mesh_step)
+        self.add_step(rotate_mesh_step)
 
         uost_file_step = WavesUostFiles(test_case=self,
                                         ocean_mesh=ocean_mesh)

--- a/compass/ocean/tests/global_ocean/wave_mesh/__init__.py
+++ b/compass/ocean/tests/global_ocean/wave_mesh/__init__.py
@@ -21,7 +21,7 @@ class WaveMesh(TestCase):
     Attributes
     ----------
     """
-    def __init__(self, test_group, ocean_mesh):
+    def __init__(self, test_group, ocean_mesh, ocean_init):
         """
         Create test case for creating a global MPAS-Ocean mesh
 
@@ -39,11 +39,11 @@ class WaveMesh(TestCase):
         self.mesh_config_filename = 'wave_mesh.cfg'
 
         base_mesh_step = WavesBaseMesh(test_case=self,
-                                       ocean_mesh=ocean_mesh)
+                                       ocean_mesh=ocean_init)
         self.add_step(base_mesh_step)
 
         cull_mesh_step = WavesCullMesh(test_case=self,
-                                       ocean_mesh=ocean_mesh,
+                                       ocean_mesh=ocean_init,
                                        wave_base_mesh=base_mesh_step)
         self.add_step(cull_mesh_step)
 

--- a/compass/ocean/tests/global_ocean/wave_mesh/base_mesh.py
+++ b/compass/ocean/tests/global_ocean/wave_mesh/base_mesh.py
@@ -1,0 +1,38 @@
+import numpy as np
+
+from compass.mesh import QuasiUniformSphericalMeshStep
+
+
+class WavesBaseMesh(QuasiUniformSphericalMeshStep):
+    """
+    A step for creating wave mesh based on an ocean mesh
+    """
+    pass
+    #def build_cell_width_lat_lon(self):
+    #    """
+    #    Create cell width array for this mesh on a regular latitude-longitude
+    #    grid
+
+    #    Returns
+    #    -------
+    #    cellWidth : numpy.array
+    #        m x n array of cell width in km
+
+    #    lon : numpy.array
+    #        longitude in degrees (length n and between -180 and 180)
+
+    #    lat : numpy.array
+    #        longitude in degrees (length m and between -90 and 90)
+    #    """
+
+    #    dlon = 10.
+    #    dlat = 0.1
+    #    nlon = int(360. / dlon) + 1
+    #    nlat = int(180. / dlat) + 1
+    #    lon = np.linspace(-180., 180., nlon)
+    #    lat = np.linspace(-90., 90., nlat)
+
+    #    cellWidthVsLat = mdt.EC_CellWidthVsLat(lat)
+    #    cellWidth = np.outer(cellWidthVsLat, np.ones([1, lon.size]))
+
+    #    return cellWidth, lon, lat

--- a/compass/ocean/tests/global_ocean/wave_mesh/base_mesh.py
+++ b/compass/ocean/tests/global_ocean/wave_mesh/base_mesh.py
@@ -1,4 +1,15 @@
+import timeit
+
+import cartopy  # noqa: F401
+import cartopy.crs as ccrs  # noqa: F401
+import cartopy.feature as cfeature  # noqa: F401
+import jigsawpy
+import matplotlib.pyplot as plt
 import numpy as np
+import shapefile
+from mpas_tools.cime.constants import constants
+from netCDF4 import Dataset
+from scipy import interpolate, spatial
 
 from compass.mesh import QuasiUniformSphericalMeshStep
 
@@ -7,32 +18,329 @@ class WavesBaseMesh(QuasiUniformSphericalMeshStep):
     """
     A step for creating wave mesh based on an ocean mesh
     """
-    pass
-    #def build_cell_width_lat_lon(self):
-    #    """
-    #    Create cell width array for this mesh on a regular latitude-longitude
-    #    grid
+    def __init__(self, test_case, ocean_mesh, name='base_mesh', subdir=None):
 
-    #    Returns
-    #    -------
-    #    cellWidth : numpy.array
-    #        m x n array of cell width in km
+        super().__init__(test_case=test_case, name=name, subdir=subdir,
+                         cell_width=None)
 
-    #    lon : numpy.array
-    #        longitude in degrees (length n and between -180 and 180)
+        base_mesh_path = ocean_mesh.steps['base_mesh'].path
+        self.add_input_file(
+            filename='ocean_mesh.nc',
+            work_dir_target=f'{base_mesh_path}/base_mesh.nc')
 
-    #    lat : numpy.array
-    #        longitude in degrees (length m and between -90 and 90)
-    #    """
+    def setup(self):
 
-    #    dlon = 10.
-    #    dlat = 0.1
-    #    nlon = int(360. / dlon) + 1
-    #    nlat = int(180. / dlat) + 1
-    #    lon = np.linspace(-180., 180., nlon)
-    #    lat = np.linspace(-90., 90., nlat)
+        super().setup()
+        self.opts.init_file = 'init.msh'
 
-    #    cellWidthVsLat = mdt.EC_CellWidthVsLat(lat)
-    #    cellWidth = np.outer(cellWidthVsLat, np.ones([1, lon.size]))
+    def build_cell_width_lat_lon(self):
+        """
+        Create cell width array for this mesh on a regular latitude-longitude
+        grid
 
-    #    return cellWidth, lon, lat
+        Returns
+        -------
+        cellWidth : numpy.array
+            m x n array of cell width in km
+
+        lon : numpy.array
+            longitude in degrees (length n and between -180 and 180)
+
+        lat : numpy.array
+            longitude in degrees (length m and between -90 and 90)
+        """
+        km = 1000.0
+
+        lon_min = -180.0
+        lon_max = 180.0
+        dlon = self.config.getfloat('wave_mesh', 'hfun_grid_spacing')
+        nlon = int((lon_max - lon_min) / dlon) + 1
+        lat_min = -90.0
+        lat_max = 90.0
+        nlat = int((lat_max - lat_min) / dlon) + 1
+
+        xlon = np.linspace(lon_min, lon_max, nlon)
+        ylat = np.linspace(lat_min, lat_max, nlat)
+
+        earth_radius = constants['SHR_CONST_REARTH'] / km
+        shapefiles = ['GSHHS_l_L1.shp', 'GSHHS_l_L6.shp']
+        cell_width = self.cell_widthVsLatLon(xlon, ylat, shapefiles,
+                                             earth_radius, 'ocean_mesh.nc')
+        cell_width = cell_width / km
+
+        self.create_initial_points('ocean_mesh.nc', xlon, ylat, cell_width,
+                                   earth_radius, self.opts.init_file)
+
+        return cell_width, xlon, ylat
+
+    def cell_widthVsLatLon(self, lon, lat, coast_shapefiles,
+                           sphere_radius, ocean_mesh):
+
+        config = self.config
+
+        depth_threshold_refined = config.getfloat('wave_mesh',
+                                                  'depth_threshold_refined')
+        dist_threshold_refined = config.getfloat('wave_mesh',
+                                                 'distance_threshold_refined')
+        depth_threshold_global = config.getfloat('wave_mesh',
+                                                 'depth_threshold_global')
+        dist_threshold_global = config.getfloat('wave_mesh',
+                                                'distance_threshold_global')
+        refined_res = config.getfloat('wave_mesh', 'refined_res')
+        maxres = config.getfloat('wave_mesh', 'maxres')
+
+        # Create structrued grid points
+        nlon = lon.size
+        nlat = lat.size
+        Lon_grd, Lat_grd = np.meshgrid(np.radians(lon), np.radians(lat))
+        xy_pts = np.vstack((Lon_grd.ravel(), Lat_grd.ravel())).T
+
+        # Create structured grid points and background cell_with array
+        cell_width = np.zeros(Lon_grd.shape) + maxres
+
+        # Get ocean mesh variables
+        nc_file = Dataset(ocean_mesh, 'r')
+        areaCell = nc_file.variables['areaCell'][:]
+        lonCell = nc_file.variables['lonCell'][:]
+        latCell = nc_file.variables['latCell'][:]
+        bottomDepth = nc_file.variables['bottomDepth'][:]
+
+        # Transform 0,360 range to -180,180
+        idx, = np.where(lonCell > np.pi)
+        lonCell[idx] = lonCell[idx] - 2.0 * np.pi
+        idx, = np.where(lonCell < -np.pi)
+        lonCell[idx] = lonCell[idx] + 2.0 * np.pi
+
+        # Interpolate cellWidth onto background grid
+        cellWidth = 2.0 * np.sqrt(areaCell / np.pi)
+        hfun = interpolate.NearestNDInterpolator((lonCell, latCell), cellWidth)
+        hfun_interp = hfun(xy_pts)
+        hfun_grd = np.reshape(hfun_interp, (nlat, nlon))
+
+        # Interpolate bathymetry onto background grid
+        bathy = interpolate.NearestNDInterpolator((lonCell, latCell),
+                                                  bottomDepth)
+        bathy_interp = bathy(xy_pts)
+        bathy_grd = np.reshape(bathy_interp, (nlat, nlon))
+
+        # Get distance to coasts
+        D = self.distance_to_shapefile_points(coast_shapefiles, lon, lat,
+                                              sphere_radius, reggrid=True)
+
+        # Apply refined region criteria
+        idxx, idxy = np.where((bathy_grd < depth_threshold_refined) &
+                              (bathy_grd > 0.0) &
+                              (D < dist_threshold_refined) &
+                              (hfun_grd < refined_res))
+        cell_width[idxx, idxy] = hfun_grd[idxx, idxy]
+
+        # Apply global region criteria
+        idxx, idxy = np.where((bathy_grd < depth_threshold_global) &
+                              (bathy_grd > 0.0) &
+                              (D < dist_threshold_global))
+        cell_width[idxx, idxy] = hfun_grd[idxx, idxy]
+
+        hfun_slope_lim = config.getfloat('wave_mesh', 'hfun_slope_lim')
+        self.limit_spacing_gradient(lon, lat, cell_width, hfun_slope_lim)
+
+        # Plot
+        fig = plt.figure(figsize=(16, 8))
+
+        ax1 = fig.add_subplot(4, 1, 1, projection=ccrs.PlateCarree())
+        plt1 = ax1.contourf(lon, lat, cell_width, transform=ccrs.PlateCarree())
+        ax1.set_title('waves mesh cell width')
+        fig.colorbar(plt1, ax=ax1)
+
+        ax2 = fig.add_subplot(4, 1, 2, projection=ccrs.PlateCarree())
+        plt2 = ax2.contourf(lon, lat, hfun_grd, transform=ccrs.PlateCarree())
+        ax2.set_title('ocean cell width')
+        fig.colorbar(plt2, ax=ax2)
+
+        ax3 = fig.add_subplot(4, 1, 3, projection=ccrs.PlateCarree())
+        plt3 = ax3.contourf(lon, lat, bathy_grd, transform=ccrs.PlateCarree())
+        ax3.set_title('bathymetry')
+        fig.colorbar(plt3, ax=ax3)
+
+        ax4 = fig.add_subplot(4, 1, 4, projection=ccrs.PlateCarree())
+        plt4 = ax4.contourf(lon, lat, D, transform=ccrs.PlateCarree())
+        ax4.set_title('distance to coast')
+        fig.colorbar(plt4, ax=ax4)
+
+        fig.savefig('cell_width.png', bbox_inches='tight', dpi=400)
+        plt.close()
+
+        return cell_width
+
+    def limit_spacing_gradient(self, lon, lat, cell_width, dhdx):
+
+        print("Smoothing h(x) via |dh/dx| limits...")
+
+        opts = jigsawpy.jigsaw_jig_t()
+        opts.hfun_file = "spac_pre_smooth.msh"
+        opts.jcfg_file = "opts_pre_smooth.jig"
+        opts.verbosity = +1
+
+        spac = jigsawpy.jigsaw_msh_t()
+        spac.mshID = "ellipsoid-grid"
+        spac.xgrid = lon
+        spac.ygrid = lat
+        spac.value = cell_width
+        spac.slope = np.full(spac.value.shape, dhdx)
+        jigsawpy.savemsh(opts.hfun_file, spac)
+
+        jigsawpy.cmd.marche(opts, spac)
+
+        return spac.value
+
+    def distance_to_shapefile_points(self, shpfiles, lon, lat,
+                                     sphere_radius, reggrid=False):
+
+        # Get coastline coordinates from shapefile
+        pt_list = []
+        for shpfile in shpfiles:
+
+            sf = shapefile.Reader(shpfile)
+            shapes = sf.shapes()
+            # records = sf.records()
+            n = len(sf.shapes())
+
+            for i in range(n):
+
+                points = shapes[i].points
+
+                if len(points) < 20:
+                    continue
+
+                for pt in points:
+                    pt_list.append([pt[0], pt[1]])
+
+        coast_pts = np.radians(np.array(pt_list))
+
+        # Convert coastline points to x,y,z and create kd-tree
+        npts = coast_pts.shape[0]
+        coast_pts_xyz = np.zeros((npts, 3))
+        x, y, z = self.lonlat2xyz(coast_pts[:, 0], coast_pts[:, 1],
+                                  sphere_radius)
+        coast_pts_xyz[:, 0] = x
+        coast_pts_xyz[:, 1] = y
+        coast_pts_xyz[:, 2] = z
+        tree = spatial.KDTree(coast_pts_xyz)
+
+        # Make sure longitude and latitude are in radians
+        if np.amax(lon) < 2.1 * np.pi:
+            lonr = lon
+            latr = lat
+        else:
+            lonr = np.radians(lon)
+            latr = np.radians(lat)
+
+        # Convert  backgound grid coordinates to x,y,z
+        # and put in a nx x 3 array for kd-tree query
+        if reggrid:
+            Lon, Lat = np.meshgrid(lonr, latr)
+        else:
+            Lon = lonr
+            Lat = latr
+        X, Y, Z = self.lonlat2xyz(Lon, Lat, sphere_radius)
+        pts = np.vstack([X.ravel(), Y.ravel(), Z.ravel()]).T
+
+        # Find distances of background grid coordinates to the coast
+        print("   Finding distance")
+        start = timeit.default_timer()
+        d, idx = tree.query(pts)
+        end = timeit.default_timer()
+        print("   Done")
+        print("   " + str(end - start) + " seconds")
+
+        D = np.reshape(d, Lon.shape)
+
+        return D
+
+    def create_initial_points(self, meshfile, lon, lat, hfunction,
+                              sphere_radius, outfile):
+
+        # Open MPAS mesh and get cell variables
+        nc_file = Dataset(meshfile, 'r')
+        lonCell = nc_file.variables['lonCell'][:]
+        latCell = nc_file.variables['latCell'][:]
+        nCells = lonCell.shape[0]
+
+        # Transform 0,360 range to -180,180
+        idx, = np.where(lonCell > np.pi)
+        lonCell[idx] = lonCell[idx] - 2.0 * np.pi
+
+        # Interpolate hfunction onto mesh cell centers
+        hfun = interpolate.RegularGridInterpolator(
+            (np.radians(lon), np.radians(lat)),
+            hfunction.T)
+        mesh_pts = np.vstack((lonCell, latCell)).T
+        hfun_interp = hfun(mesh_pts)
+
+        # Find cells in refined region of waves mesh
+        max_res = np.amax(hfunction)
+        idx, = np.where(hfun_interp < 0.5 * max_res)
+
+        # Find boundary cells
+        #   some meshes have non-zero values
+        #   in the extra columns of cellsOnCell
+        #   in this case, these must be zeroed out
+        #   to correctly identify boundary cells
+        nEdgesOnCell = nc_file.variables['nEdgesOnCell'][:]
+        cellsOnCell = nc_file.variables['cellsOnCell'][:]
+        nz = np.zeros(cellsOnCell.shape, dtype=bool)
+        for i in range(nCells):
+            nz[i, 0:nEdgesOnCell[i]] = True
+        cellsOnCell[~nz] = 0
+        nCellsOnCell = np.count_nonzero(cellsOnCell, axis=1)
+        is_boundary_cell = np.equal(nCellsOnCell, nEdgesOnCell)
+        idx_bnd, = np.where(is_boundary_cell == False)  # noqa: E712
+
+        # Force inclusion of all boundary cells
+        idx = np.union1d(idx, idx_bnd)
+
+        # Get coordinates of points
+        lon = lonCell[idx]
+        lat = latCell[idx]
+
+        lon = np.append(lon, 0.0)
+        lat = np.append(lat, 0.5 * np.pi)
+
+        npt = lon.size
+        print(npt)
+
+        # Change to Cartesian coordinates
+        x, y, z = self.lonlat2xyz(lon, lat, sphere_radius)
+
+        # Get coordinates and ID into structured array
+        #   (for use with np.savetxt)
+        pt_list = []
+        for i in range(npt):
+            # ID of -1 specifies that node is fixed
+            pt_list.append((x[i], y[i], z[i], -1))
+        pt_type = np.dtype({'names': ['x', 'y', 'z', 'id'],
+                           'formats': [np.float64, np.float64,
+                                       np.float64, np.int32]})
+        pts = np.array(pt_list, dtype=pt_type)
+
+        # Write initial conditions file
+        f = open(outfile, 'w')
+        f.write('# Initial coordinates \n')
+        f.write('MSHID=3;EUCLIDEAN-MESH\n')
+        f.write('NDIMS=3\n')
+        f.write(f'POINT={npt}\n')
+        np.savetxt(f, pts, fmt='%.12e;%.12e;%.12e;%2i')
+        f.close()
+
+        init = jigsawpy.jigsaw_msh_t()
+        jigsawpy.loadmsh(self.opts.init_file, init)
+        jigsawpy.savevtk("init.vtk", init)
+
+        return
+
+    def lonlat2xyz(self, lon, lat, R):
+
+        x = R * np.multiply(np.cos(lon), np.cos(lat))
+        y = R * np.multiply(np.sin(lon), np.cos(lat))
+        z = R * np.sin(lat)
+
+        return x, y, z

--- a/compass/ocean/tests/global_ocean/wave_mesh/base_mesh.py
+++ b/compass/ocean/tests/global_ocean/wave_mesh/base_mesh.py
@@ -23,10 +23,10 @@ class WavesBaseMesh(QuasiUniformSphericalMeshStep):
         super().__init__(test_case=test_case, name=name, subdir=subdir,
                          cell_width=None)
 
-        base_mesh_path = ocean_mesh.steps['base_mesh'].path
+        mesh_path = ocean_mesh.steps['initial_state'].path
         self.add_input_file(
             filename='ocean_mesh.nc',
-            work_dir_target=f'{base_mesh_path}/base_mesh.nc')
+            work_dir_target=f'{mesh_path}/initial_state.nc')
 
     def setup(self):
 
@@ -182,8 +182,8 @@ class WavesBaseMesh(QuasiUniformSphericalMeshStep):
 
         spac = jigsawpy.jigsaw_msh_t()
         spac.mshID = "ellipsoid-grid"
-        spac.xgrid = lon
-        spac.ygrid = lat
+        spac.xgrid = np.radians(lon)
+        spac.ygrid = np.radians(lat)
         spac.value = cell_width
         spac.slope = np.full(spac.value.shape, dhdx)
         jigsawpy.savemsh(opts.hfun_file, spac)

--- a/compass/ocean/tests/global_ocean/wave_mesh/cull_mesh.py
+++ b/compass/ocean/tests/global_ocean/wave_mesh/cull_mesh.py
@@ -1,3 +1,6 @@
+from importlib.resources import read_text
+
+from jinja2 import Template
 from mpas_tools.logging import check_call
 
 from compass import Step
@@ -26,16 +29,15 @@ class WavesCullMesh(Step):
 
         super().setup()
 
-        f = open(f'{self.work_dir}/cull_waves_mesh.nml', 'w')
-        f.write('&inputs\n')
-        f.write("    waves_mesh_file = 'wave_base_mesh.nc'\n")
-        f.write("    ocean_mesh_file = 'ocean_culled_mesh.nc'\n")
-        f.write("/\n")
-        f.write("&output\n")
-        f.write("    waves_mesh_culled_vtk = 'wave_mesh_culled.vtk'\n")
-        f.write("    waves_mesh_culled_gmsh = 'wave_mesh_culled.msh'\n")
-        f.write("/\n")
-        f.close()
+        template = Template(read_text(
+            'compass.ocean.tests.global_ocean.wave_mesh',
+            'cull_mesh.template'))
+
+        text = template.render()
+        text = f'{text}\n'
+
+        with open(f'{self.work_dir}/cull_waves_mesh.nml', 'w') as file:
+            file.write(text)
 
     def run(self):
 

--- a/compass/ocean/tests/global_ocean/wave_mesh/cull_mesh.py
+++ b/compass/ocean/tests/global_ocean/wave_mesh/cull_mesh.py
@@ -12,15 +12,15 @@ class WavesCullMesh(Step):
 
         super().__init__(test_case=test_case, name=name, subdir=subdir)
 
-        culled_mesh_path = ocean_mesh.steps['cull_mesh'].path
+        culled_mesh_path = ocean_mesh.steps['initial_state'].path
         self.add_input_file(
             filename='ocean_culled_mesh.nc',
-            work_dir_target=f'{culled_mesh_path}/culled_mesh.nc')
+            work_dir_target=f'{culled_mesh_path}/initial_state.nc')
 
         wave_base_mesh_path = wave_base_mesh.path
         self.add_input_file(
             filename='wave_base_mesh.nc',
-            work_dir_target=f'{wave_base_mesh_path}/wave_base_mesh.nc')
+            work_dir_target=f'{wave_base_mesh_path}/base_mesh.nc')
 
     def setup(self):
 

--- a/compass/ocean/tests/global_ocean/wave_mesh/cull_mesh.py
+++ b/compass/ocean/tests/global_ocean/wave_mesh/cull_mesh.py
@@ -1,0 +1,42 @@
+from mpas_tools.logging import check_call
+
+from compass import Step
+
+
+class WavesCullMesh(Step):
+    """
+    A step for creating wave mesh based on an ocean mesh
+    """
+    def __init__(self, test_case, ocean_mesh, wave_base_mesh,
+                 name='cull_mesh', subdir=None):
+
+        super().__init__(test_case=test_case, name=name, subdir=subdir)
+
+        culled_mesh_path = ocean_mesh.steps['cull_mesh'].path
+        self.add_input_file(
+            filename='ocean_culled_mesh.nc',
+            work_dir_target=f'{culled_mesh_path}/culled_mesh.nc')
+
+        wave_base_mesh_path = wave_base_mesh.path
+        self.add_input_file(
+            filename='wave_base_mesh.nc',
+            work_dir_target=f'{wave_base_mesh_path}/wave_base_mesh.nc')
+
+    def setup(self):
+
+        super().setup()
+
+        f = open(f'{self.work_dir}/cull_waves_mesh.nml', 'w')
+        f.write('&inputs\n')
+        f.write("    waves_mesh_file = 'wave_base_mesh.nc'\n")
+        f.write("    ocean_mesh_file = 'ocean_culled_mesh.nc'\n")
+        f.write("/\n")
+        f.write("&output\n")
+        f.write("    waves_mesh_culled_vtk = 'wave_mesh_culled.vtk'\n")
+        f.write("    waves_mesh_culled_gmsh = 'wave_mesh_culled.msh'\n")
+        f.write("/\n")
+        f.close()
+
+    def run(self):
+
+        check_call('ocean_cull_wave_mesh', logger=self.logger)

--- a/compass/ocean/tests/global_ocean/wave_mesh/cull_mesh.template
+++ b/compass/ocean/tests/global_ocean/wave_mesh/cull_mesh.template
@@ -1,0 +1,8 @@
+&inputs
+    waves_mesh_file = 'wave_base_mesh.nc'
+    ocean_mesh_file = 'ocean_culled_mesh.nc'
+/
+&output
+    waves_mesh_culled_vtk = 'wave_mesh_culled.vtk'
+    waves_mesh_culled_gmsh = 'wave_mesh_culled.msh'
+/

--- a/compass/ocean/tests/global_ocean/wave_mesh/remap_files.py
+++ b/compass/ocean/tests/global_ocean/wave_mesh/remap_files.py
@@ -1,0 +1,106 @@
+import os
+import pprint
+import subprocess
+
+import yaml
+
+from compass import Step
+
+
+class WavesRemapFiles(Step):
+    """
+    A step for creating remapping files for wave mesh
+    """
+    def __init__(self, test_case, wave_scrip, ocean_scrip,
+                 name='remap_files', subdir=None):
+
+        super().__init__(test_case=test_case, name=name, subdir=subdir)
+
+        wave_scrip_file_path = wave_scrip.path
+        self.add_input_file(
+            filename='wave_scrip.nc',
+            work_dir_target=f'{wave_scrip_file_path}/wave_scrip.nc')
+
+        ocean_scrip_file_path = ocean_scrip.path
+        self.add_input_file(
+            filename='ocean_scrip.nc',
+            work_dir_target=f'{ocean_scrip_file_path}/ocean_scrip.nc')
+
+    def setup(self):
+
+        super().setup()
+        # TO DO: mesh names should be flexible not hard-coded.
+        f = open(f'{self.work_dir}/make_remapping_files.config', 'w')
+        f.write("grid1 : 'scrip.nc'\n")
+        f.write("grid1_shortname : 'wQU225IcoswISC30E3r5'\n")
+        f.write("reg1 : True\n")
+        f.write("\n")
+        f.write("grid2 : 'ocean.IcoswISC30E3r5.mask.scrip.20231120.nc'\n")
+        f.write("grid2_shortname : 'IcoswISC30E3r5'\n")
+        f.write("reg2 : True\n")
+        f.write("\n")
+        f.write("datestamp : 20240411\n")
+        f.write("\n")
+        f.write("map_types : ['conserve','bilinear','neareststod']\n")
+        f.close()
+
+    def make_remapping_files(grid1, grid2,
+                             grid1_shortname, grid2_shortname,
+                             datestamp, reg1, reg2, map_type, nprocs=1):
+        if map_type == 'conserve':
+            map_abbrev = 'aave'
+        elif map_type == 'bilinear':
+            map_abbrev = 'blin'
+        elif map_type == 'patch':
+            map_abbrev = 'patc'
+        elif map_type == 'neareststod':
+            map_abbrev = 'nstod'
+        elif map_type == 'nearsetdtos':
+            map_abbrev = 'ndtos'
+        else:
+            print('map type not recognized')
+            raise SystemExit(0)
+
+        flags = ' --ignore_unmapped --ignore_degenerate'
+        if reg1:
+            flags += ' --src_regional'
+        if reg2:
+            flags += ' --dst_regional'
+
+        map_name = 'map_' + grid1_shortname + '_TO_' + grid2_shortname +\
+                   '_' + map_abbrev + '.' + str(datestamp) + '.nc'
+        subprocess.call('srun -n ' + str(nprocs) +
+                        ' ESMF_RegridWeightGen --source ' + grid1 +
+                        ' --destination ' + grid2 +
+                        ' --method ' + map_type +
+                        ' --weight ' + map_name +
+                        flags, shell=True)
+
+        flags = ' --ignore_unmapped --ignore_degenerate'
+        if reg1:
+            flags += ' --dst_regional'
+        if reg2:
+            flags += ' --src_regional'
+
+        map_name = 'map_' + grid2_shortname + '_TO_' + grid1_shortname +\
+                   '_' + map_abbrev + '.' + str(datestamp) + '.nc'
+        subprocess.call('srun -n ' + str(nprocs) +
+                        ' ESMF_RegridWeightGen --source ' + grid2 +
+                        ' --destination ' + grid1 +
+                        ' --method ' + map_type +
+                        ' --weight ' + map_name +
+                        flags, shell=True)
+
+    def run(self):
+        pwd = os.getcwd()
+        f = open(pwd + '/make_remapping_files.config')
+        cfg = yaml.load(f, Loader=yaml.Loader)
+        pprint.pprint(cfg)
+        for map_type in cfg['map_types']:
+            self.make_remapping_files(cfg['grid1'],
+                                      cfg['grid2'],
+                                      cfg['grid1_shortname'],
+                                      cfg['grid2_shortname'],
+                                      cfg['datestamp'],
+                                      cfg['reg1'], cfg['reg2'],
+                                      map_type)

--- a/compass/ocean/tests/global_ocean/wave_mesh/rotate_mesh.py
+++ b/compass/ocean/tests/global_ocean/wave_mesh/rotate_mesh.py
@@ -28,7 +28,7 @@ class WavesRotateMesh(Step):
         f.write("    wind_file = 'null'\n")
         f.write("    mesh_file = 'wave_mesh_culled.msh'\n")
         f.write("    mesh_file_out = 'wave_culled_mesh_RTD.msh'\n")
-        f.write("/")
+        f.write("/\n")
         f.close()
 
     def run(self):

--- a/compass/ocean/tests/global_ocean/wave_mesh/rotate_mesh.py
+++ b/compass/ocean/tests/global_ocean/wave_mesh/rotate_mesh.py
@@ -23,11 +23,11 @@ class WavesRotateMesh(Step):
 
         f = open(f'{self.work_dir}/rotate.nml', 'w')
         f.write('&inputs\n')
-        f.write("   LON_POLE = -42.8906d0\n")
-        f.write("   LAT_POLE = 72.3200d0\n")
-        f.write("   wind_file = 'null'\n")
-        f.write("   mesh_file = 'wave_mesh_culled.msh'\n")
-        f.write("   mesh_file_out = 'wave_culled_mesh_RTD.msh'\n")
+        f.write("    LON_POLE = -42.8906d0\n")
+        f.write("    LAT_POLE = 72.3200d0\n")
+        f.write("    wind_file = 'null'\n")
+        f.write("    mesh_file = 'wave_mesh_culled.msh'\n")
+        f.write("    mesh_file_out = 'wave_culled_mesh_RTD.msh'\n")
         f.write("/")
         f.close()
 

--- a/compass/ocean/tests/global_ocean/wave_mesh/rotate_mesh.py
+++ b/compass/ocean/tests/global_ocean/wave_mesh/rotate_mesh.py
@@ -1,0 +1,36 @@
+from mpas_tools.logging import check_call
+
+from compass import Step
+
+
+class WavesRotateMesh(Step):
+    """
+    A step for creating wave mesh based on an ocean mesh
+    """
+    def __init__(self, test_case, wave_culled_mesh,
+                 name='rotate_mesh', subdir=None):
+
+        super().__init__(test_case=test_case, name=name, subdir=subdir)
+
+        wave_culled_mesh_path = wave_culled_mesh.path
+        self.add_input_file(
+            filename='wave_mesh_culled.msh',
+            work_dir_target=f'{wave_culled_mesh_path}/wave_mesh_culled.msh')
+
+    def setup(self):
+
+        super().setup()
+
+        f = open(f'{self.work_dir}/rotate.nml', 'w')
+        f.write('&inputs\n')
+        f.write("   LON_POLE = -42.8906d0\n")
+        f.write("   LAT_POLE = 72.3200d0\n")
+        f.write("   wind_file = 'null'\n")
+        f.write("   mesh_file = 'wave_mesh_culled.msh'\n")
+        f.write("   mesh_file_out = 'wave_culled_mesh_RTD.msh'\n")
+        f.write("/")
+        f.close()
+
+    def run(self):
+
+        check_call('ocean_rotate_wave_mesh', logger=self.logger)

--- a/compass/ocean/tests/global_ocean/wave_mesh/rotate_mesh.py
+++ b/compass/ocean/tests/global_ocean/wave_mesh/rotate_mesh.py
@@ -1,3 +1,6 @@
+from importlib.resources import read_text
+
+from jinja2 import Template
 from mpas_tools.logging import check_call
 
 from compass import Step
@@ -21,15 +24,15 @@ class WavesRotateMesh(Step):
 
         super().setup()
 
-        f = open(f'{self.work_dir}/rotate.nml', 'w')
-        f.write('&inputs\n')
-        f.write("    LON_POLE = -42.8906d0\n")
-        f.write("    LAT_POLE = 72.3200d0\n")
-        f.write("    wind_file = 'null'\n")
-        f.write("    mesh_file = 'wave_mesh_culled.msh'\n")
-        f.write("    mesh_file_out = 'wave_culled_mesh_RTD.msh'\n")
-        f.write("/\n")
-        f.close()
+        template = Template(read_text(
+            'compass.ocean.tests.global_ocean.wave_mesh',
+            'rotate_mesh.template'))
+
+        text = template.render()
+        text = f'{text}\n'
+
+        with open(f'{self.work_dir}/rotate.nml', 'w') as file:
+            file.write(text)
 
     def run(self):
 

--- a/compass/ocean/tests/global_ocean/wave_mesh/rotate_mesh.template
+++ b/compass/ocean/tests/global_ocean/wave_mesh/rotate_mesh.template
@@ -1,0 +1,7 @@
+&inputs
+    LON_POLE = -42.8906d0
+    LAT_POLE = 72.3200d0
+    wind_file = 'null'
+    mesh_file = 'wave_mesh_culled.msh'
+    mesh_file_out = 'wave_culled_mesh_RTD.msh'
+/

--- a/compass/ocean/tests/global_ocean/wave_mesh/scrip_file.py
+++ b/compass/ocean/tests/global_ocean/wave_mesh/scrip_file.py
@@ -23,10 +23,10 @@ class WavesScripFile(Step):
 
         f = open(f'{self.work_dir}/scrip.nml', 'w')
         f.write('&inputs\n')
-        f.write("   waves_mesh_file = 'wave_mesh_culled.msh'\n")
+        f.write("    waves_mesh_file = 'wave_mesh_culled.msh'\n")
         f.write("/\n")
         f.write('&outputs\n')
-        f.write("   waves_scrip_file = 'wave_mesh_scrip.nc'\n")
+        f.write("    waves_scrip_file = 'wave_mesh_scrip.nc'\n")
         f.write("/")
         f.close()
 

--- a/compass/ocean/tests/global_ocean/wave_mesh/scrip_file.py
+++ b/compass/ocean/tests/global_ocean/wave_mesh/scrip_file.py
@@ -23,10 +23,10 @@ class WavesScripFile(Step):
 
         f = open(f'{self.work_dir}/scrip.nml', 'w')
         f.write('&inputs\n')
-        f.write("   waves_mesh_file = 'waves_mesh_culled.msh'\n")
-        f.write("/")
+        f.write("   waves_mesh_file = 'wave_mesh_culled.msh'\n")
+        f.write("/\n")
         f.write('&outputs\n')
-        f.write("   waves_scrip_file = 'waves_mesh_scrip.nc'\n")
+        f.write("   waves_scrip_file = 'wave_mesh_scrip.nc'\n")
         f.write("/")
         f.close()
 

--- a/compass/ocean/tests/global_ocean/wave_mesh/scrip_file.py
+++ b/compass/ocean/tests/global_ocean/wave_mesh/scrip_file.py
@@ -27,7 +27,7 @@ class WavesScripFile(Step):
         f.write("/\n")
         f.write('&outputs\n')
         f.write("    waves_scrip_file = 'wave_mesh_scrip.nc'\n")
-        f.write("/")
+        f.write("/\n")
         f.close()
 
     def run(self):

--- a/compass/ocean/tests/global_ocean/wave_mesh/scrip_file.py
+++ b/compass/ocean/tests/global_ocean/wave_mesh/scrip_file.py
@@ -1,0 +1,37 @@
+from mpas_tools.logging import check_call
+
+from compass import Step
+
+
+class WavesScripFile(Step):
+    """
+    A step for creating the scrip file for the wave mesh
+    """
+    def __init__(self, test_case, wave_culled_mesh,
+                 name='scrip_file', subdir=None):
+
+        super().__init__(test_case=test_case, name=name, subdir=subdir)
+
+        wave_culled_mesh_path = wave_culled_mesh.path
+        self.add_input_file(
+            filename='wave_mesh_culled.msh',
+            work_dir_target=f'{wave_culled_mesh_path}/wave_mesh_culled.msh')
+
+    def setup(self):
+
+        super().setup()
+
+        f = open(f'{self.work_dir}/scrip.nml', 'w')
+        f.write('&inputs\n')
+        f.write("   waves_mesh_file = 'waves_mesh_culled.msh'\n")
+        f.write("/")
+        f.write('&outputs\n')
+        f.write("   waves_scrip_file = 'waves_mesh_scrip.nc'\n")
+        f.write("/")
+        f.close()
+
+    def run(self):
+        """
+        Create scrip files for wave mesh
+        """
+        check_call('ocean_scrip_wave_mesh', logger=self.logger)

--- a/compass/ocean/tests/global_ocean/wave_mesh/scrip_file.py
+++ b/compass/ocean/tests/global_ocean/wave_mesh/scrip_file.py
@@ -1,3 +1,6 @@
+from importlib.resources import read_text
+
+from jinja2 import Template
 from mpas_tools.logging import check_call
 
 from compass import Step
@@ -21,14 +24,15 @@ class WavesScripFile(Step):
 
         super().setup()
 
-        f = open(f'{self.work_dir}/scrip.nml', 'w')
-        f.write('&inputs\n')
-        f.write("    waves_mesh_file = 'wave_mesh_culled.msh'\n")
-        f.write("/\n")
-        f.write('&outputs\n')
-        f.write("    waves_scrip_file = 'wave_mesh_scrip.nc'\n")
-        f.write("/\n")
-        f.close()
+        template = Template(read_text(
+            'compass.ocean.tests.global_ocean.wave_mesh',
+            'scrip_file.template'))
+
+        text = template.render()
+        text = f'{text}\n'
+
+        with open(f'{self.work_dir}/scrip.nml', 'w') as file:
+            file.write(text)
 
     def run(self):
         """

--- a/compass/ocean/tests/global_ocean/wave_mesh/scrip_file.template
+++ b/compass/ocean/tests/global_ocean/wave_mesh/scrip_file.template
@@ -1,0 +1,6 @@
+&inputs
+    waves_mesh_file = 'wave_mesh_culled.msh'
+/
+&outputs
+    waves_scrip_file = 'wave_mesh_scrip.nc'
+/

--- a/compass/ocean/tests/global_ocean/wave_mesh/uost_files.py
+++ b/compass/ocean/tests/global_ocean/wave_mesh/uost_files.py
@@ -63,7 +63,7 @@ class WavesUostFiles(Step):
         outputDestDir = 'output/'
 
         # number of cores for parallel computing
-        nParWorker = 1
+        nParWorker = 1  # SB NOTE: we should set this to the of cores on a node
 
         # this option indicates that the computation
         # should be skipped for cells smaller than 3 km

--- a/compass/ocean/tests/global_ocean/wave_mesh/uost_files.py
+++ b/compass/ocean/tests/global_ocean/wave_mesh/uost_files.py
@@ -6,23 +6,23 @@ from alphaBetaLab.alphaBetaLab.abEstimateAndSave import (
 )
 # importing from alphaBetaLab the needed components
 from alphaBetaLab.alphaBetaLab.abOptionManager import abOptions
-from compass.mesh import QuasiUniformSphericalMeshStep
+from compass import Step
 
 
-class WavesUostFiles(QuasiUniformSphericalMeshStep):
+class WavesUostFiles(Step):
     """
     A step for creating the unresolved obstacles file for wave mesh
     """
-    def __init__(self, test_case, ocean_mesh, name='uost_files', subdir=None):
+    def __init__(self, test_case, wave_culled_mesh,
+                 name='uost_files', subdir=None):
 
-        super().__init__(test_case=test_case, name=name, subdir=subdir,
-                         cell_width=None)
+        super().__init__(test_case=test_case, name=name, subdir=subdir)
 
         # other things INIT should do?
-        base_mesh_path = ocean_mesh.steps['base_mesh'].path
+        culled_mesh_path = wave_culled_mesh.path
         self.add_input_file(
-            filename='ocean_mesh.nc',
-            work_dir_target=f'{base_mesh_path}/base_mesh.nc')
+            filename='wave_mesh_culled.msh',
+            work_dir_target=f'{culled_mesh_path}/wave_mesh_culled.msh')
 
         self.add_input_file(
             filename='etopo1_180.nc',
@@ -50,17 +50,17 @@ class WavesUostFiles(QuasiUniformSphericalMeshStep):
         freqs = [minfrq * (frqfactor ** i) for i in range(1, nfreq + 1)]
 
         # definition of the spatial mesh
-        gridname = 'glo_unst'
-        mshfile = 'global.msh'
+        gridname = 'glo_unst'  # SB NOTE: should be flexible
+        mshfile = 'wave_mesh_culled.msh'
         triMeshSpec = triMeshSpecFromMshFile(mshfile)
 
         # path of the etopo1 bathymetry
         # etopoFilePath = '/users/sbrus/scratch4/ \
         # WW3_unstructured/GEBCO_2019.nc'
-        etopoFilePath = './etopo1_180.nc'
+        etopoFilePath = 'etopo1_180.nc'
 
         # output directory
-        outputDestDir = './output/'
+        outputDestDir = 'output/'
 
         # number of cores for parallel computing
         nParWorker = 1

--- a/compass/ocean/tests/global_ocean/wave_mesh/uost_files.py
+++ b/compass/ocean/tests/global_ocean/wave_mesh/uost_files.py
@@ -1,0 +1,100 @@
+import numpy as np
+
+from alphaBetaLab.alphaBetaLab.abEstimateAndSave import (
+    abEstimateAndSaveTriangularEtopo1,
+    triMeshSpecFromMshFile,
+)
+# importing from alphaBetaLab the needed components
+from alphaBetaLab.alphaBetaLab.abOptionManager import abOptions
+
+# from compass.mesh import QuasiUniformSphericalMeshStep
+
+
+class WavesUostFiles():
+    """
+    A step for creating the unresolved obstacles file for wave mesh
+    """
+    # pass
+
+    def __init__(self, test_case):
+        """
+        Create a new step
+        """
+        super().__init__(test_case, name='uost_files')
+
+    def run(self):
+        """
+        Run this step
+        """
+        super().run()
+
+        dirs = np.linspace(0, 2 * np.pi, 36)
+        nfreq = 50   # ET NOTE: this should be flexible
+        minfrq = .035
+        if (nfreq == 50):
+            frqfactor = 1.07
+        elif (nfreq == 36):
+            frqfactor = 1.10
+        elif (nfreq == 25):
+            frqfactor = 1.147
+            # PRINT SOME ERROR MESSAGE FOR NON-supoorted spectral reslution
+
+        freqs = [minfrq * (frqfactor ** i) for i in range(1, nfreq + 1)]
+
+        # definition of the spatial mesh
+        gridname = 'glo_unst'
+        mshfile = 'global.msh'
+        triMeshSpec = triMeshSpecFromMshFile(mshfile)
+
+        # path of the etopo1 bathymetry
+        # etopoFilePath = '/users/sbrus/scratch4/ \
+        # WW3_unstructured/GEBCO_2019.nc'
+        etopoFilePath = './etopo1_180.nc'
+
+        # output directory
+        outputDestDir = './output/'
+
+        # number of cores for parallel computing
+        nParWorker = 1
+
+        # this option indicates that the computation
+        # should be skipped for cells smaller than 3 km
+        minSizeKm = 3
+        opt = abOptions(minSizeKm=minSizeKm)
+
+        # instruction to do the computation and save the output
+        # abEstimateAndSaveTriangularGebco(
+        # dirs, freqs, gridname, triMeshSpec,
+        # etopoFilePath, outputDestDir, nParWorker, abOptions=opt)
+        abEstimateAndSaveTriangularEtopo1(
+            dirs, freqs, gridname, triMeshSpec, etopoFilePath,
+            outputDestDir, nParWorker, abOptions=opt)
+
+    # def build_cell_width_lat_lon(self):
+    #    """
+    #    Create cell width array for this mesh on a regular latitude-longitude
+    #    grid
+
+    #    Returns
+    #    -------
+    #    cellWidth : numpy.array
+    #        m x n array of cell width in km
+
+    #    lon : numpy.array
+    #        longitude in degrees (length n and between -180 and 180)
+
+    #    lat : numpy.array
+    #        longitude in degrees (length m and between -90 and 90)
+    #    """
+
+    #    dlon = 10.
+    #    dlat = 0.1
+    #    nlon = int(360. / dlon) + 1
+    #    nlat = int(180. / dlat) + 1
+    #    lon = np.linspace(-180., 180., nlon)
+    #    lat = np.linspace(-90., 90., nlat)
+
+    #    cellWidthVsLat = mdt.EC_CellWidthVsLat(lat)
+    #    cellWidth = np.outer(cellWidthVsLat, np.ones([1, lon.size]))
+
+    #    return cellWidth, lon, lat

--- a/compass/ocean/tests/global_ocean/wave_mesh/uost_files.py
+++ b/compass/ocean/tests/global_ocean/wave_mesh/uost_files.py
@@ -6,27 +6,33 @@ from alphaBetaLab.alphaBetaLab.abEstimateAndSave import (
 )
 # importing from alphaBetaLab the needed components
 from alphaBetaLab.alphaBetaLab.abOptionManager import abOptions
+from compass.mesh import QuasiUniformSphericalMeshStep
 
-# from compass.mesh import QuasiUniformSphericalMeshStep
 
-
-class WavesUostFiles():
+class WavesUostFiles(QuasiUniformSphericalMeshStep):
     """
     A step for creating the unresolved obstacles file for wave mesh
     """
-    # pass
+    def __init__(self, test_case, ocean_mesh, name='uost_files', subdir=None):
 
-    def __init__(self, test_case):
-        """
-        Create a new step
-        """
-        super().__init__(test_case, name='uost_files')
+        super().__init__(test_case=test_case, name=name, subdir=subdir,
+                         cell_width=None)
+
+        # other things INIT should do?
+        base_mesh_path = ocean_mesh.steps['base_mesh'].path
+        self.add_input_file(
+            filename='ocean_mesh.nc',
+            work_dir_target=f'{base_mesh_path}/base_mesh.nc')
+
+        self.add_input_file(
+            filename='etopo1_180.nc',
+            target='etopo1_180.nc',
+            database='bathymetry_database')
 
     def run(self):
         """
-        Run this step
+        Create unresolved obstacles for wave mesh and spectral resolution
         """
-        super().run()
 
         dirs = np.linspace(0, 2 * np.pi, 36)
         nfreq = 50   # ET NOTE: this should be flexible
@@ -37,7 +43,9 @@ class WavesUostFiles():
             frqfactor = 1.10
         elif (nfreq == 25):
             frqfactor = 1.147
-            # PRINT SOME ERROR MESSAGE FOR NON-supoorted spectral reslution
+        else:
+            print("ERROR: Spectral resolution not supported.")
+            print("Number of wave freqencies must be 25, 36, or 50.")
 
         freqs = [minfrq * (frqfactor ** i) for i in range(1, nfreq + 1)]
 
@@ -69,32 +77,3 @@ class WavesUostFiles():
         abEstimateAndSaveTriangularEtopo1(
             dirs, freqs, gridname, triMeshSpec, etopoFilePath,
             outputDestDir, nParWorker, abOptions=opt)
-
-    # def build_cell_width_lat_lon(self):
-    #    """
-    #    Create cell width array for this mesh on a regular latitude-longitude
-    #    grid
-
-    #    Returns
-    #    -------
-    #    cellWidth : numpy.array
-    #        m x n array of cell width in km
-
-    #    lon : numpy.array
-    #        longitude in degrees (length n and between -180 and 180)
-
-    #    lat : numpy.array
-    #        longitude in degrees (length m and between -90 and 90)
-    #    """
-
-    #    dlon = 10.
-    #    dlat = 0.1
-    #    nlon = int(360. / dlon) + 1
-    #    nlat = int(180. / dlat) + 1
-    #    lon = np.linspace(-180., 180., nlon)
-    #    lat = np.linspace(-90., 90., nlat)
-
-    #    cellWidthVsLat = mdt.EC_CellWidthVsLat(lat)
-    #    cellWidth = np.outer(cellWidthVsLat, np.ones([1, lon.size]))
-
-    #    return cellWidth, lon, lat

--- a/compass/ocean/tests/global_ocean/wave_mesh/wave_mesh.cfg
+++ b/compass/ocean/tests/global_ocean/wave_mesh/wave_mesh.cfg
@@ -1,0 +1,10 @@
+[wave_mesh]
+
+hfun_grid_spacing = 0.5
+hfun_slope_lim = 0.15
+depth_threshold_refined = 1000.0
+distance_threshold_refined = 300.0
+depth_threshold_global = 1000.0
+distance_threshold_global = 300.0
+refined_res = 20000.0
+maxres = 225000.0


### PR DESCRIPTION
<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->
This PR is a collaboration with @erinethomas that adds the workflow used to create coastal-refined wave mesh that conforms to the coastlines for a given ocean mesh. It includes several steps to:
 - build the base mesh
 - cull the base mesh
 - create the wave mesh scrip file 
 - generate remapping files between the wave and ocean mesh
 - rotate the mesh 
 - generate the files for the unresolved obstacle source term (uost) in WAVEWATCH III

This work depends on a MPAS-Tools PR which will be linked here when opened.


<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [ ] User's Guide has been updated
* [ ] Developer's Guide has been updated
* [ ] API documentation in the Developer's Guide (`api.rst`) has any new or modified class, method and/or functions listed
* [ ] Documentation has been [built locally](https://mpas-dev.github.io/compass/latest/developers_guide/building_docs.html) and changes look as expected
* [ ] Document (in a comment titled `Testing` in this PR) any testing that was used to verify the changes
* [ ] New tests have been added to a test suite

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->
