### PR TITLE
Set simulation length in the SLM namelist to 300 years 

### DIFF
--- a/compass/landice/tests/ismip6_run/ismip6_ais_proj2300/namelist.sealevel.template
+++ b/compass/landice/tests/ismip6_run/ismip6_ais_proj2300/namelist.sealevel.template
@@ -48,12 +48,12 @@
 
 /
 &timewindow_config
-    L_sim = 285
+    L_sim = 300
     dt1 = 5
     dt2 = 10
     dt3 = 10
     dt4 = 10
-    Ldt1 = 285
+    Ldt1 = 300
     Ldt2 = 0
     Ldt3 = 0
     Ldt4 = 0


### PR DESCRIPTION
In current setup, ISMIP6-2300 historical simulation is performed for 15 years between 2000-2015 CE, and the projection simulations start from year 2015 until 2301. Previously, the sea-level model namelist was set such that the total length of simulation covered by the SLM is 285 years to cover years between 2015-2300, but since we've decided to run the coupled MALI-SLM model for the historical period as well, the simulation length option in the SLM naemlist needs to be corrected to cover the whole 300 years (2000-2300). This PR includes the change.  
