### PR TITLE
Add ISMIP6 Greenland region masks that extend beyond ice edge

### DIFF
--- a/compass/landice/mesh.py
+++ b/compass/landice/mesh.py
@@ -772,7 +772,8 @@ def build_mali_mesh(self, cell_width, x1, y1, geom_points,
     check_call(args, logger=logger)
 
 
-def make_region_masks(self, mesh_filename, mask_filename, cores, tags):
+def make_region_masks(self, mesh_filename, mask_filename,
+                      cores, tags, component='landice', all_tags=True):
     """
     Create masks for ice-sheet subregions based on data
     in ``MPAS-Dev/geometric_fatures``.
@@ -797,10 +798,9 @@ def make_region_masks(self, mesh_filename, mask_filename, cores, tags):
     gf = GeometricFeatures()
     fcMask = FeatureCollection()
 
-    for tag in tags:
-        fc = gf.read(componentName='landice', objectType='region',
-                     tags=[tag])
-        fcMask.merge(fc)
+    fc = gf.read(componentName=component, objectType='region',
+                 tags=tags, allTags=all_tags)
+    fcMask.merge(fc)
 
     geojson_filename = 'regionMask.geojson'
     fcMask.to_geojson(geojson_filename)

--- a/compass/landice/tests/antarctica/mesh.py
+++ b/compass/landice/tests/antarctica/mesh.py
@@ -150,7 +150,8 @@ class Mesh(Step):
                           self.cpus_per_task,
                           tags=['EastAntarcticaIMBIE',
                                 'WestAntarcticaIMBIE',
-                                'AntarcticPeninsulaIMBIE'])
+                                'AntarcticPeninsulaIMBIE'],
+                          all_tags=False)
 
         mask_filename = f'{self.mesh_filename[:-3]}_ismip6_regionMasks.nc'
         make_region_masks(self, self.mesh_filename, mask_filename,

--- a/compass/landice/tests/greenland/mesh.py
+++ b/compass/landice/tests/greenland/mesh.py
@@ -184,7 +184,13 @@ class Mesh(Step):
         data.variables['observedSurfaceVelocityUncertainty'][0, mask[0, :]] = 1.0  # noqa
 
         # create region masks
-        mask_filename = f'{mesh_name[:-3]}_regionMasks.nc'
+        mask_filename = f'{mesh_name[:-3]}_ismip6_regionMasks.nc'
+        make_region_masks(self, mesh_name, mask_filename,
+                          self.cpus_per_task,
+                          tags=["Greenland", "ISMIP6", "Shelf"],
+                          component='ocean')
+
+        mask_filename = f'{mesh_name[:-3]}_zwally_regionMasks.nc'
         make_region_masks(self, mesh_name, mask_filename,
                           self.cpus_per_task,
                           tags=['eastCentralGreenland',
@@ -194,7 +200,8 @@ class Mesh(Step):
                                 'southEastGreenland',
                                 'southGreenland',
                                 'southWestGreenland',
-                                'westCentralGreenland'])
+                                'westCentralGreenland'],
+                          all_tags=False)
 
         # Ensure basalHeatFlux is positive
         data.variables['basalHeatFlux'][:] = np.abs(

--- a/compass/ocean/tests/global_ocean/files_for_e3sm/diagnostic_masks.py
+++ b/compass/ocean/tests/global_ocean/files_for_e3sm/diagnostic_masks.py
@@ -82,8 +82,8 @@ def make_diagnostics_files(logger, mesh_short_name, with_ice_shelf_cavities,
 
     gf = GeometricFeatures()
     region_groups = ['Antarctic Regions', 'Arctic Ocean Regions',
-                     'Arctic Sea Ice Regions', 'Ocean Basins',
-                     'Ocean Subbasins', 'ISMIP6 Regions']
+                     'Arctic Sea Ice Regions', 'Greenland Regions',
+                     'Ocean Basins', 'Ocean Subbasins', 'ISMIP6 Regions']
 
     if with_ice_shelf_cavities:
         region_groups.append('Ice Shelves')

--- a/compass/version.py
+++ b/compass/version.py
@@ -1,1 +1,1 @@
-__version__ = '1.4.0-alpha.1'
+__version__ = '1.4.0-alpha.2'

--- a/conda/compass_env/spec-file.template
+++ b/conda/compass_env/spec-file.template
@@ -8,7 +8,7 @@ cartopy_offlinedata
 cmocean
 esmf=8.6.1={{ mpi_prefix }}_*
 ffmpeg
-geometric_features=1.3.0
+geometric_features=1.4.0
 git
 gsw
 h5py


### PR DESCRIPTION
This merge adds ISMIP6 region masks to the Greenland mesh, which extend beyond ice edge and will be useful for regional stats. It also makes use of the `allTags` argument when calling `GeometricFeatures.read()` instead of looping over tags for greater flexibility.

Note: This requires geometric_features version 1.4.0, which is not yet in the latest version of compass.
<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->

<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [x] Document (in a comment titled `Testing` in this PR) any testing that was used to verify the changes

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->
