### PR TITLE
Turn off topographic wave drag in global ocean cases

### DIFF
--- a/compass/ocean/tests/global_ocean/mesh/qu240/namelist.rk4
+++ b/compass/ocean/tests/global_ocean/mesh/qu240/namelist.rk4
@@ -8,6 +8,5 @@ config_tracer_del4 = 1.2e11
 config_use_Leith_del2 = .true.
 config_use_GM = .true.
 config_use_frazil_ice_formation = .true.
-config_use_topographic_wave_drag = .true.
 config_write_output_on_startup = .false.
 config_use_debugTracers = .true.

--- a/compass/ocean/tests/global_ocean/mesh/qu240/namelist.split_explicit_ab2
+++ b/compass/ocean/tests/global_ocean/mesh/qu240/namelist.split_explicit_ab2
@@ -9,6 +9,5 @@ config_tracer_del4 = 1.2e11
 config_use_Leith_del2 = .true.
 config_use_GM = .true.
 config_use_frazil_ice_formation = .true.
-config_use_topographic_wave_drag = .true.
 config_write_output_on_startup = .false.
 config_use_debugTracers = .true.


### PR DESCRIPTION
Following https://github.com/E3SM-Project/E3SM/pull/6310, using `config_use_topographic_wave_drag=.true.` in global ocean test cases causes a segfault in the init routine for teh topographic wave drag tendency, since the input streams required to calculate the wave drag coefficient is not available. Going forward, testing for this term should be restricted to barotropic tides cases.
