### PR TITLE
New Mesh: SOwISC12to30E3r4

### DIFF
--- a/compass/ocean/tests/global_ocean/__init__.py
+++ b/compass/ocean/tests/global_ocean/__init__.py
@@ -45,6 +45,8 @@ class GlobalOcean(TestGroup):
         self._add_tests(mesh_names=['ARRM10to60', 'ARRMwISC10to60'])
 
         self._add_tests(mesh_names=['SO12to30', 'SOwISC12to30'])
+        self._add_tests(mesh_names=['SOwISC12to30'],
+                        mali_ais_topo='AIS_4to20km')
 
         self._add_tests(mesh_names=['WC14', 'WCwISC14'])
 
@@ -65,7 +67,7 @@ class GlobalOcean(TestGroup):
     def _add_tests(self, mesh_names, high_res_topography=True,
                    include_rk4=False,
                    include_regression=False, include_phc=False,
-                   include_en4_1900=False):
+                   include_en4_1900=False, mali_ais_topo=None):
         """ Add test cases for the given mesh(es) """
 
         default_ic = 'WOA23'
@@ -73,7 +75,8 @@ class GlobalOcean(TestGroup):
 
         for mesh_name in mesh_names:
             mesh_test = Mesh(test_group=self, mesh_name=mesh_name,
-                             high_res_topography=high_res_topography)
+                             high_res_topography=high_res_topography,
+                             mali_ais_topo=mali_ais_topo)
             self.add_test_case(mesh_test)
 
             init_test = Init(test_group=self, mesh=mesh_test,

--- a/compass/ocean/tests/global_ocean/__init__.py
+++ b/compass/ocean/tests/global_ocean/__init__.py
@@ -46,7 +46,7 @@ class GlobalOcean(TestGroup):
 
         self._add_tests(mesh_names=['SO12to30', 'SOwISC12to30'])
         self._add_tests(mesh_names=['SOwISC12to30'],
-                        mali_ais_topo='AIS_4to20km')
+                        mali_ais_topo='AIS_2to10km')
 
         self._add_tests(mesh_names=['WC14', 'WCwISC14'])
 

--- a/compass/ocean/tests/global_ocean/__init__.py
+++ b/compass/ocean/tests/global_ocean/__init__.py
@@ -46,7 +46,7 @@ class GlobalOcean(TestGroup):
 
         self._add_tests(mesh_names=['SO12to30', 'SOwISC12to30'])
         self._add_tests(mesh_names=['SOwISC12to30'],
-                        mali_ais_topo='AIS_2to10km')
+                        mali_ais_topo='AIS_4to20km')
 
         self._add_tests(mesh_names=['WC14', 'WCwISC14'])
 

--- a/compass/ocean/tests/global_ocean/init/__init__.py
+++ b/compass/ocean/tests/global_ocean/init/__init__.py
@@ -44,9 +44,8 @@ class Init(TestCase):
             The initial condition dataset to use
         """
         name = 'init'
-        mesh_name = mesh.mesh_name
         ic_dir = initial_condition
-        self.init_subdir = os.path.join(mesh_name, ic_dir)
+        self.init_subdir = os.path.join(mesh.mesh_subdir, ic_dir)
         subdir = os.path.join(self.init_subdir, name)
         super().__init__(test_group=test_group, name=name, subdir=subdir)
 

--- a/compass/ocean/tests/global_ocean/mesh/__init__.py
+++ b/compass/ocean/tests/global_ocean/mesh/__init__.py
@@ -154,7 +154,8 @@ class Mesh(TestCase):
         else:
             remap_step = RemapMaliTopography(
                 test_case=self, base_mesh_step=base_mesh_step,
-                mesh_name=mesh_name, mali_ais_topo=mali_ais_topo)
+                mesh_name=mesh_name, mali_ais_topo=mali_ais_topo,
+                ocean_includes_grounded=True)
 
         self.add_step(remap_step)
 

--- a/compass/ocean/tests/global_ocean/mesh/__init__.py
+++ b/compass/ocean/tests/global_ocean/mesh/__init__.py
@@ -155,7 +155,7 @@ class Mesh(TestCase):
             remap_step = RemapMaliTopography(
                 test_case=self, base_mesh_step=base_mesh_step,
                 mesh_name=mesh_name, mali_ais_topo=mali_ais_topo,
-                ocean_includes_grounded=True)
+                ocean_includes_grounded=False)
 
         self.add_step(remap_step)
 

--- a/compass/ocean/tests/global_ocean/mesh/remap_mali_topography/__init__.py
+++ b/compass/ocean/tests/global_ocean/mesh/remap_mali_topography/__init__.py
@@ -43,7 +43,7 @@ class RemapMaliTopography(RemapTopography):
         mesh_name : str
             The name of the MPAS mesh to include in the mapping file
 
-                    mali_ais_topo : str, optional
+        mali_ais_topo : str, optional
             Short name for the MALI dataset to use for Antarctic Ice Sheet
             topography
         """
@@ -230,27 +230,27 @@ class RemapMaliTopography(RemapTopography):
                     'landIceThkObserved']:
             ds_out[var] = ds_mali[var]
 
-        ds_out['landIceFracObserved'] = ds_mali['landIceFracConserve']
+        ds_out['landIceFracObserved'] = ds_mali['landIceFrac']
 
         ds_out['landIceFloatingFracObserved'] = (
             ds_mali['landIceFrac'] -
             ds_mali['landIceGroundedFrac'])
 
-        for var in ['maliFracBilinear', 'maliFracConserve']:
+        for var in ['maliFrac']:
             mali_field = ds_mali[var]
             mali_field = xr.where(mali_field.notnull(), mali_field, 0.)
             ds_out[var] = mali_field
 
         # for now, blend topography at calving fronts, but we may want a
         # smoother blend in the future
-        alpha = ds_mali.landIceFracBilinear
+        alpha = ds_mali.landIceFrac
         ds_out['bed_elevation'] = (
             alpha * ds_mali.bed_elevation +
             (1.0 - alpha) * ds_bedmachine.bed_elevation)
 
-        alpha = ds_out.maliFracConserve
+        alpha = ds_out.maliFrac
         ds_out['oceanFracObserved'] = (
-            alpha * ds_mali.oceanFracConserve +
+            alpha * ds_mali.oceanFrac +
             (1.0 - alpha) * ds_bedmachine.oceanFracObserved)
 
         ds_out['ssh'] = ds_out.landIceDraftObserved

--- a/compass/ocean/tests/global_ocean/mesh/remap_mali_topography/__init__.py
+++ b/compass/ocean/tests/global_ocean/mesh/remap_mali_topography/__init__.py
@@ -1,0 +1,252 @@
+import os
+
+import numpy as np
+import xarray as xr
+from mpas_tools.cime.constants import constants
+from mpas_tools.io import write_netcdf
+from mpas_tools.logging import check_call
+from pyremap import MpasCellMeshDescriptor
+
+from compass.ocean.mesh.remap_topography import RemapTopography
+from compass.parallel import run_command
+
+
+class RemapMaliTopography(RemapTopography):
+    """
+    A step for remapping bathymetry and ice-shelf topography from a MALI
+    datase to a global MPAS-Ocean mesh and combining it with a global
+    topography dataset
+
+    Attributes
+    ----------
+    mali_ais_topo : str
+        Short name for the MALI dataset to use for Antarctic Ice Sheet
+        topography
+    """
+
+    def __init__(self, test_case, base_mesh_step, mesh_name, mali_ais_topo):
+        """
+        Create a new step
+
+        Parameters
+        ----------
+        test_case : compass.ocean.tests.global_ocean.mesh.Mesh
+            The test case this step belongs to
+
+        base_mesh_step : compass.mesh.spherical.SphericalBaseStep
+            The base mesh step containing input files to this step
+
+        remap_topography : compass.ocean.mesh.remap_topography.RemapTopography
+            A step for remapping topography. If provided, the remapped
+            topography is used to determine the land mask
+
+        mesh_name : str
+            The name of the MPAS mesh to include in the mapping file
+
+                    mali_ais_topo : str, optional
+            Short name for the MALI dataset to use for Antarctic Ice Sheet
+            topography
+        """
+        super().__init__(test_case=test_case, base_mesh_step=base_mesh_step,
+                         mesh_name=mesh_name)
+        self.mali_ais_topo = mali_ais_topo
+
+        self.add_output_file(filename='mali_topography_remapped.nc')
+
+    def setup(self):
+        """
+        Set up the step in the work directory, including downloading any
+        dependencies.
+        """
+        super().setup()
+
+        mali_filename = self.config.get('remap_mali_topography',
+                                        'mali_filename')
+        self.add_input_file(
+            filename='mali_topography.nc',
+            target=mali_filename,
+            database='mali_topo')
+
+    def run(self):
+        """
+        Run this step of the test case
+        """
+        super().run()
+        self._remap_mali_topo()
+        self._combine_topo()
+
+    def _remap_mali_topo(self):
+        config = self.config
+        logger = self.logger
+
+        in_mesh_name = self.mali_ais_topo
+        in_descriptor = MpasCellMeshDescriptor(fileName='mali_topography.nc',
+                                               meshName=in_mesh_name)
+        in_descriptor.format = 'NETCDF3_64BIT'
+        in_descriptor.to_scrip('mali_scrip.nc')
+
+        out_mesh_name = self.mesh_name
+        out_descriptor = MpasCellMeshDescriptor(fileName='base_mesh.nc',
+                                                meshName=out_mesh_name)
+        out_descriptor.format = 'NETCDF3_64BIT'
+        out_descriptor.to_scrip('mpaso_scrip.nc')
+
+        args = ['mbtempest',
+                '--type', '5',
+                '--load', 'mali_scrip.nc',
+                '--load', 'mpaso_scrip.nc',
+                '--intx', 'moab_intx_mali_mpaso.h5m',
+                '--rrmgrids']
+
+        run_command(args=args, cpus_per_task=self.cpus_per_task,
+                    ntasks=self.ntasks, openmp_threads=self.openmp_threads,
+                    config=config, logger=logger)
+
+        ds_mali = xr.open_dataset('mali_topography.nc')
+        if 'Time' in ds_mali.dims:
+            ds_mali = ds_mali.isel(Time=0)
+        bed = ds_mali.bedTopography
+        thickness = ds_mali.thickness
+
+        ice_density = config.getfloat('remap_topography', 'ice_density')
+
+        mali_ice_density = ds_mali.attrs['config_ice_density']
+        mali_ocean_density = ds_mali.attrs['config_ocean_density']
+        sea_level = ds_mali.attrs['config_sea_level']
+
+        g = constants['SHR_CONST_G']
+        ocean_density = constants['SHR_CONST_RHOSW']
+
+        if ice_density != mali_ice_density:
+            raise ValueError('Ice density from the config option in '
+                             '[remap_topography] does not match the value '
+                             'from MALI config_ice_density')
+        if ocean_density != mali_ocean_density:
+            logger.warn('\nWARNING: Ocean density from SHR_CONST_RHOSW does '
+                        'not match the value from MALI config_ocean_density\n')
+
+        draft = - (ice_density / ocean_density) * thickness
+
+        ice_mask = ds_mali.thickness > 0
+        floating_mask = np.logical_and(
+            ice_mask,
+            ice_density / mali_ocean_density * thickness <= sea_level - bed)
+        grounded_mask = np.logical_and(ice_mask, np.logical_not(floating_mask))
+        ocean_mask = np.logical_and(np.logical_not(ice_mask), bed < sea_level)
+
+        lithop = ice_density * g * thickness
+        ice_frac = xr.where(ice_mask, 1., 0.)
+        grounded_frac = xr.where(grounded_mask, 1., 0.)
+        ocean_frac = xr.where(ocean_mask, 1., 0.)
+        mali_frac = xr.DataArray(data=np.ones(ds_mali.sizes['nCells']),
+                                 dims='nCells')
+
+        ds_in = {}
+        # we will remap topography bilinearly
+        ds_in['bilinear'] = xr.Dataset()
+        ds_in['bilinear']['bed_elevation'] = bed
+        ds_in['bilinear']['landIceThkObserved'] = thickness
+        ds_in['bilinear']['landIcePressureObserved'] = lithop
+        ds_in['bilinear']['landIceDraftObserved'] = draft
+        ds_in['bilinear']['landIceFracBilinear'] = ice_frac
+        ds_in['bilinear']['landIceGroundedFracBilinear'] = grounded_frac
+        ds_in['bilinear']['oceanFracBilinear'] = ocean_frac
+        ds_in['bilinear']['maliFracBilinear'] = mali_frac
+        # we will remap masks conservatively
+        ds_in['conserve'] = xr.Dataset()
+        ds_in['conserve']['landIceFracConserve'] = ice_frac
+        ds_in['conserve']['landIceGroundedFracConserve'] = grounded_frac
+        ds_in['conserve']['oceanFracConserve'] = ocean_frac
+        ds_in['conserve']['maliFracConserve'] = mali_frac
+
+        mbtempest_args = {'conserve': ['--order', '1',
+                                       '--order', '1',
+                                       '--fvmethod', 'none',
+                                       '--rrmgrids'],
+                          'bilinear': ['--order', '1',
+                                       '--order', '1',
+                                       '--fvmethod', 'bilin']}
+
+        suffix = {'conserve': 'mbtraave',
+                  'bilinear': 'mbtrbilin'}
+
+        ds_out = xr.Dataset()
+        for method in ['conserve', 'bilinear']:
+            mapping_file_name = \
+                f'map_{in_mesh_name}_to_{out_mesh_name}_{suffix[method]}.nc'
+
+            # split the parallel executable into constituents in case it
+            # includes flags
+            args = ['mbtempest',
+                    '--type', '5',
+                    '--load', 'mali_scrip.nc',
+                    '--load', 'mpaso_scrip.nc',
+                    '--intx', 'moab_intx_mali_mpaso.h5m',
+                    '--weights',
+                    '--method', 'fv',
+                    '--method', 'fv',
+                    '--file', mapping_file_name] + mbtempest_args[method]
+
+            if method == 'bilinear':
+                # unhappy in parallel for now
+                check_call(args, logger)
+            else:
+
+                run_command(args=args, cpus_per_task=self.cpus_per_task,
+                            ntasks=self.ntasks,
+                            openmp_threads=self.openmp_threads,
+                            config=config, logger=logger)
+
+            in_filename = f'mali_topography_{method}.nc'
+            out_filename = f'mali_topography_ncremap_{method}.nc'
+            write_netcdf(ds_in[method], in_filename)
+
+            # remapping with the -P mpas flag leads to undesired
+            # renormalization
+            args = ['ncremap',
+                    '-m', mapping_file_name,
+                    '--vrb=1',
+                    in_filename,
+                    out_filename]
+            check_call(args, logger)
+
+            ds_remapped = xr.open_dataset(out_filename)
+            for var_name in ds_remapped:
+                var = ds_remapped[var_name]
+                if 'Frac' in var:
+                    # copy the fractional variable, making sure it doesn't
+                    # exceed 1
+                    var = np.minimum(var, 1.)
+                ds_out[var_name] = var
+
+        write_netcdf(ds_out, 'mali_topography_remapped.nc')
+
+    def _combine_topo(self):
+        os.rename('topography_remapped.nc',
+                  'bedmachine_topography_remapped.nc')
+        ds_mali = xr.open_dataset('mali_topography_remapped.nc')
+        ds_mali = ds_mali.reset_coords(['lat', 'lon'], drop=True)
+        ds_bedmachine = xr.open_dataset('bedmachine_topography_remapped.nc')
+        ds_bedmachine = ds_bedmachine.reset_coords(['lat', 'lon'], drop=True)
+
+        ds_out = xr.Dataset(ds_bedmachine)
+        # for now, just use the land-ice pressure, draft and thickness from
+        # MALI
+        for var in ['landIcePressureObserved', 'landIceDraftObserved',
+                    'landIceThkObserved']:
+            ds_out[var] = ds_mali[var]
+
+        # for now, blend topography at calving fronts, but we may want a
+        # smoother blend in the future
+        alpha = ds_mali.landIceFracBilinear
+        ds_out['bed_elevation'] = (alpha * ds_mali.bed_elevation +
+                                   (1.0 - alpha) * ds_bedmachine.bed_elevation)
+
+        for var in ['maliFracBilinear', 'maliFracConserve']:
+            mali_field = ds_mali[var]
+            mali_field = xr.where(mali_field.notnull(), mali_field, 0.)
+            ds_out[var] = mali_field
+
+        ds_out['ssh'] = ds_out.landIceDraftObserved
+
+        write_netcdf(ds_out, 'topography_remapped.nc')

--- a/compass/ocean/tests/global_ocean/mesh/remap_mali_topography/__init__.py
+++ b/compass/ocean/tests/global_ocean/mesh/remap_mali_topography/__init__.py
@@ -109,28 +109,17 @@ class RemapMaliTopography(RemapTopography):
         thickness = ds_mali.thickness
 
         ice_density = config.getfloat('remap_topography', 'ice_density')
-
-        mali_ice_density = ds_mali.attrs['config_ice_density']
-        mali_ocean_density = ds_mali.attrs['config_ocean_density']
-        sea_level = ds_mali.attrs['config_sea_level']
+        ocean_density = config.getfloat('remap_topography', 'ocean_density')
+        sea_level = config.getfloat('remap_topography', 'sea_level')
 
         g = constants['SHR_CONST_G']
-        ocean_density = constants['SHR_CONST_RHOSW']
-
-        if ice_density != mali_ice_density:
-            raise ValueError('Ice density from the config option in '
-                             '[remap_topography] does not match the value '
-                             'from MALI config_ice_density')
-        if ocean_density != mali_ocean_density:
-            logger.warn('\nWARNING: Ocean density from SHR_CONST_RHOSW does '
-                        'not match the value from MALI config_ocean_density\n')
 
         draft = - (ice_density / ocean_density) * thickness
 
         ice_mask = ds_mali.thickness > 0
         floating_mask = np.logical_and(
             ice_mask,
-            ice_density / mali_ocean_density * thickness <= sea_level - bed)
+            ice_density / ocean_density * thickness <= sea_level - bed)
         grounded_mask = np.logical_and(ice_mask, np.logical_not(floating_mask))
         ocean_mask = np.logical_and(np.logical_not(grounded_mask),
                                     bed < sea_level)

--- a/compass/ocean/tests/global_ocean/mesh/remap_mali_topography/__init__.py
+++ b/compass/ocean/tests/global_ocean/mesh/remap_mali_topography/__init__.py
@@ -77,6 +77,11 @@ class RemapMaliTopography(RemapTopography):
             target=mali_filename,
             database='mali_topo')
 
+        if not self.config.has_option('remap_topography', 'ocean_density'):
+            raise ValueError(
+                'You must be using a mesh that defines [remap_topography]/'
+                'ocean_density in the config file')
+
     def run(self):
         """
         Run this step of the test case

--- a/compass/ocean/tests/global_ocean/mesh/remap_mali_topography/__init__.py
+++ b/compass/ocean/tests/global_ocean/mesh/remap_mali_topography/__init__.py
@@ -253,8 +253,9 @@ class RemapMaliTopography(RemapTopography):
             (1.0 - alpha) * ds_bedmachine.bed_elevation)
 
         alpha = ds_out.maliFrac
+        # NOTE: MALI's ocean fraction is already scaled by the MALI fraction
         ds_out['oceanFracObserved'] = (
-            alpha * ds_mali.oceanFrac +
+            ds_mali.oceanFrac +
             (1.0 - alpha) * ds_bedmachine.oceanFracObserved)
 
         ds_out['ssh'] = ds_out.landIceDraftObserved

--- a/compass/ocean/tests/global_ocean/mesh/remap_mali_topography/ais_2to10km.cfg
+++ b/compass/ocean/tests/global_ocean/mesh/remap_mali_topography/ais_2to10km.cfg
@@ -1,0 +1,5 @@
+# config options related to remapping MALI topography to an MPAS-Ocean mesh
+[remap_mali_topography]
+
+# The name of the MALI topogrpahy file
+mali_filename = ais_2to10km_20231222_modifiedBathymetry-drop20m-smooth6x_bulldozedTroughs-75-400m_BEDMAP2-ASE-mjh.nc

--- a/compass/ocean/tests/global_ocean/mesh/remap_mali_topography/ais_2to10km.cfg
+++ b/compass/ocean/tests/global_ocean/mesh/remap_mali_topography/ais_2to10km.cfg
@@ -1,3 +1,13 @@
+# config options related to remapping topography to an MPAS-Ocean mesh
+[remap_topography]
+
+# the density of ocean water (kg/m^3), equivalent to config_ocean_density in MALI
+ocean_density = 1028.0
+
+# the elevation of sea level, equivalent to config_sea_level in MALI
+sea_level = 0.0
+
+
 # config options related to remapping MALI topography to an MPAS-Ocean mesh
 [remap_mali_topography]
 

--- a/compass/ocean/tests/global_ocean/mesh/remap_mali_topography/ais_2to10km.cfg
+++ b/compass/ocean/tests/global_ocean/mesh/remap_mali_topography/ais_2to10km.cfg
@@ -1,6 +1,9 @@
 # config options related to remapping topography to an MPAS-Ocean mesh
 [remap_topography]
 
+# the density of land ice from MALI (kg/m^3)
+ice_density = 910.0
+
 # the density of ocean water (kg/m^3), equivalent to config_ocean_density in MALI
 ocean_density = 1028.0
 

--- a/compass/ocean/tests/global_ocean/mesh/remap_mali_topography/ais_4to20km.cfg
+++ b/compass/ocean/tests/global_ocean/mesh/remap_mali_topography/ais_4to20km.cfg
@@ -12,4 +12,4 @@ sea_level = 0.0
 [remap_mali_topography]
 
 # The name of the MALI topogrpahy file
-mali_filename = AIS_4to20km_20230105_relaxed_10yrs.nc
+mali_filename = ais_4to20km.20240708.nc

--- a/compass/ocean/tests/global_ocean/mesh/remap_mali_topography/ais_4to20km.cfg
+++ b/compass/ocean/tests/global_ocean/mesh/remap_mali_topography/ais_4to20km.cfg
@@ -1,3 +1,13 @@
+# config options related to remapping topography to an MPAS-Ocean mesh
+[remap_topography]
+
+# the density of ocean water (kg/m^3), equivalent to config_ocean_density in MALI
+ocean_density = 1028.0
+
+# the elevation of sea level, equivalent to config_sea_level in MALI
+sea_level = 0.0
+
+
 # config options related to remapping MALI topography to an MPAS-Ocean mesh
 [remap_mali_topography]
 

--- a/compass/ocean/tests/global_ocean/mesh/remap_mali_topography/ais_4to20km.cfg
+++ b/compass/ocean/tests/global_ocean/mesh/remap_mali_topography/ais_4to20km.cfg
@@ -1,0 +1,5 @@
+# config options related to remapping MALI topography to an MPAS-Ocean mesh
+[remap_mali_topography]
+
+# The name of the MALI topogrpahy file
+mali_filename = AIS_4to20km_20230105_relaxed_10yrs.nc

--- a/compass/ocean/tests/global_ocean/mesh/remap_mali_topography/ais_4to20km.cfg
+++ b/compass/ocean/tests/global_ocean/mesh/remap_mali_topography/ais_4to20km.cfg
@@ -12,4 +12,4 @@ sea_level = 0.0
 [remap_mali_topography]
 
 # The name of the MALI topogrpahy file
-mali_filename = ais_4to20km.20240708.nc
+mali_filename = AIS_4to20km_20241118_relaxation_0TGmelt_10yr.20241224.nc

--- a/compass/ocean/tests/global_ocean/mesh/remap_mali_topography/ais_4to20km.cfg
+++ b/compass/ocean/tests/global_ocean/mesh/remap_mali_topography/ais_4to20km.cfg
@@ -1,6 +1,9 @@
 # config options related to remapping topography to an MPAS-Ocean mesh
 [remap_topography]
 
+# the density of land ice from MALI (kg/m^3)
+ice_density = 910.0
+
 # the density of ocean water (kg/m^3), equivalent to config_ocean_density in MALI
 ocean_density = 1028.0
 

--- a/compass/ocean/tests/global_ocean/mesh/so12to30/so12to30.cfg
+++ b/compass/ocean/tests/global_ocean/mesh/so12to30/so12to30.cfg
@@ -65,7 +65,7 @@ min_res = 12
 # the maximum (coarsest) resolution in the mesh, can be the same as min_res
 max_res = 30
 # The URL of the pull request documenting the creation of the mesh
-pull_request = https://github.com/MPAS-Dev/compass/pull/807
+pull_request = https://github.com/MPAS-Dev/compass/pull/829
 
 
 # config options related to initial condition and diagnostics support files

--- a/compass/ocean/tests/global_ocean/mesh/so12to30/so12to30.cfg
+++ b/compass/ocean/tests/global_ocean/mesh/so12to30/so12to30.cfg
@@ -59,7 +59,7 @@ mesh_description = MPAS Southern Ocean regionally refined mesh for E3SM version
 e3sm_version = 3
 # The revision number of the mesh, which should be incremented each time the
 # mesh is revised
-mesh_revision = 3
+mesh_revision = 4
 # the minimum (finest) resolution in the mesh
 min_res = 12
 # the maximum (coarsest) resolution in the mesh, can be the same as min_res

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -53,10 +53,15 @@ master_doc = 'index'
 
 # General information about the project.
 project = u'compass'
-copyright = u'Copyright (c) 2013-2021,  Los Alamos National Security, LLC (LANS) (Ocean: LA-CC-13-047;' \
-            u'Land Ice: LA-CC-13-117) and the University Corporation for Atmospheric Research (UCAR).'
-author = u'Xylar Asay-Davis, Matt Hoffman, Doug Jacobsen, Mark Petersen, ' \
-         u'Philip Wolfram, Luke Van Roekel, Tong Zhang'
+copyright = u'Copyright (c) 2013-2024, Triad National Security, LLC ' \
+            u'(Ocean: LA-CC-13-047; Land Ice: LA-CC-13-117) and the ' \
+            u'University Corporation for Atmospheric Research (UCAR).'
+author = u'Xylar Asay-Davis, Alice Barthel, Carolyn Begeman, Pete Bosler, ' \
+         u'Riley Brady, Steven Brus, Sara Calandrini, Zhendong Cao, ' \
+         u'Giacomo Capodaglio, Max Carlson, Althea Denlinger, ' \
+         u'Yaris Eidenbenz, Darren Engwirda, Holly Han, Jeremy Lilly, ' \
+         u'Mauro Perego, Mark Petersen, Cameron Smith, Yohei Takano, ' \
+         u'Irena Vankova, Luke Van Roekel, Philip Wolfram, Tong Zhang'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the

--- a/docs/developers_guide/ocean/api.rst
+++ b/docs/developers_guide/ocean/api.rst
@@ -284,6 +284,10 @@ test cases and steps
    mesh.Mesh.configure
    mesh.Mesh.run
 
+   mesh.remap_mali_topography.RemapMaliTopography
+   mesh.remap_mali_topography.RemapMaliTopography.setup
+   mesh.remap_mali_topography.RemapMaliTopography.run
+
    mesh.ec30to60.EC30to60BaseMesh
    mesh.ec30to60.EC30to60BaseMesh.build_cell_width_lat_lon
 

--- a/docs/developers_guide/ocean/test_groups/global_ocean.rst
+++ b/docs/developers_guide/ocean/test_groups/global_ocean.rst
@@ -874,6 +874,41 @@ The vertical grid is an ``index_tanh_dz`` profile (see
 :ref:`dev_ocean_framework_vertical`) with 64 vertical levels ranging in
 thickness from 10 to 250 m.
 
+.. _dev_ocean_global_ocean_sowisc12to30_mali_topo:
+
+SOwISC12to30 with MALI topography
++++++++++++++++++++++++++++++++++
+
+Versions of the ``SOwISC12to30`` test cases exist with topography that comes
+from the MALI model instead of from GEBCO and BedMachine Antarctica.
+
+For now, the only supported MALI initial condition is a 4-20 km resoution
+mesh with the following config options:
+
+.. code-block:: cfg
+
+    # config options related to remapping topography to an MPAS-Ocean mesh
+    [remap_topography]
+
+    # the density of ocean water (kg/m^3), equivalent to config_ocean_density in MALI
+    ocean_density = 1028.0
+
+    # the elevation of sea level, equivalent to config_sea_level in MALI
+    sea_level = 0.0
+
+
+    # config options related to remapping MALI topography to an MPAS-Ocean mesh
+    [remap_mali_topography]
+
+    # The name of the MALI topogrpahy file
+    mali_filename = ais_4to20km.20240708.nc
+
+
+The topography is remapped in a step defined in the
+:py:class:`compass.ocean.tests.global_ocean.mesh.remap_mali_topography.RemapMaliTopography`
+class, which descends from
+:py:class:`compass.ocean.mesh.remap_topography.RemapTopography`.
+
 .. _dev_ocean_global_ocean_wc14:
 
 WC14 and WCwISC14

--- a/docs/users_guide/ocean/test_groups/global_ocean.rst
+++ b/docs/users_guide/ocean/test_groups/global_ocean.rst
@@ -476,6 +476,10 @@ The mesh has 12-km resolution around Antarctica and 30-km resolution elsewhere.
 The mesh includes the :ref:`global_ocean_ice_shelf_cavities` around Antarctica
 in the ocean domain.
 
+A version of the SOwISC12to30 mesh also exist with topography that comes
+from a 4-20 km MALI initial condition instead of from GEBCO and BedMachine
+Antarctica.
+
 .. image:: images/sowisc12to60.png
    :width: 500 px
    :align: center
@@ -537,7 +541,7 @@ As a user, your main way of altering forward runs is by changing namelist
 options directly in ``namelist.ocean`` or modifying streams in
 ``streams.ocean``.  However, there are a few parameters related to forward runs
 you can change in the config file for a test case.  Since some test cases like
-:ref:`global_ocean_restart_test` and :ref`global_ocean_dynamic_adjustment` have
+:ref:`global_ocean_restart_test` and :ref:`global_ocean_dynamic_adjustment` have
 more than one forward run, it is convenient to change options like
 ``forward_ntasks`` once in the config file, knowing that this will change the
 target number of cores of all forward model runs in the test case.  The same


### PR DESCRIPTION
Long name: SOwISC12to30kmL80E3SMv3r4

This version of the Southern Ocean Regionally Refined Mesh (SORRM) has resolution that is:
* 12 km resolution around Antarctica
* 30 km elsewhere
 
It is intended to be similar to the Icos30 mesh except in the Southern Ocean and around Antarctica.

This mesh differs from r3 in https://github.com/MPAS-Dev/compass/pull/807 in that:

* MALI topography as well as masks for land ice, floating ice and ocean get combined with BedMachine Antarctica/GEBCO.

<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [x] User's Guide has been updated
* [x] Developer's Guide has been updated
* [x] API documentation in the Developer's Guide (`api.rst`) has any new or modified class, method and/or functions listed
* [x] Documentation has been [built locally](https://mpas-dev.github.io/compass/latest/developers_guide/building_docs.html) and changes look as expected
* [x] The `E3SM-Project` submodule has been updated with relevant E3SM changes
* [x] Document (in a comment titled `Testing` in this PR) any testing that was used to verify the changes

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->
