### PR TITLE
Mask only topography above sea level when remapping BedMachine topo 

### DIFF
--- a/compass/ocean/tests/utility/combine_topo/combine_topo.cfg
+++ b/compass/ocean/tests/utility/combine_topo/combine_topo.cfg
@@ -6,7 +6,7 @@ antarctic_filename = BedMachineAntarctica-v3.nc
 global_filename = GEBCO_2023.nc
 
 # the name of the output topography file, to be copied to the bathymetry database
-cobined_filename = BedMachineAntarctica_v3_and_GEBCO_2023_0.0125_degree_20240323.nc
+cobined_filename = BedMachineAntarctica_v3_and_GEBCO_2023_0.0125_degree_20240610.nc
 
 # the target and minimum number of MPI tasks to use in remapping
 ntasks = 512
@@ -15,7 +15,3 @@ min_tasks = 128
 # latitudes between which the topography datasets get blended
 latmin = -62.
 latmax = -60.
-
-# the threshold for masks below which interpolated variables are not
-# renormalized
-renorm_thresh = 1e-3

--- a/compass/ocean/tests/utility/combine_topo/combine_topo.cfg
+++ b/compass/ocean/tests/utility/combine_topo/combine_topo.cfg
@@ -6,7 +6,7 @@ antarctic_filename = BedMachineAntarctica-v3.nc
 global_filename = GEBCO_2023.nc
 
 # the name of the output topography file, to be copied to the bathymetry database
-cobined_filename = BedMachineAntarctica_v3_and_GEBCO_2023_0.0125_degree_20240610.nc
+cobined_filename = BedMachineAntarctica_v3_and_GEBCO_2023_0.0125_degree_20240611.nc
 
 # the target and minimum number of MPI tasks to use in remapping
 ntasks = 512


### PR DESCRIPTION
<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->
This merge updates the utility that creates the merged BedMachine and GEBCO topography dataset to include bathymetry and ice topography under grounded ice as long as that ice below sea level.  This is done to make the topography used in simulations without MALI coupling more similar to simulations where the topography will come from MALI in the near future.  Since grounding lines will move, we do not wish to mask the topography to only the floating domain.

However, including topography above sea level is problematic.  It can result in both bathymetry and ice-draft values that are above sea level even in cells where a significant fraction of the cell is below sea level (e.g. when bathymetry is shallow in the portion of the cell that is below sea level but steep in the portion that is above sea level).

Similarly, we will want to have MALI pass only the portion of the topography that is below sea level, along with a fraction of each cell that is below sea level.

<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [x] Document (in a comment titled `Testing` in this PR) any testing that was used to verify the changes

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->
