### PR TITLE
Constrain numpy < 2.0

### DIFF
--- a/compass/version.py
+++ b/compass/version.py
@@ -1,1 +1,1 @@
-__version__ = '1.4.0-alpha.2'
+__version__ = '1.4.0-alpha.3'

--- a/conda/compass_env/spec-file.template
+++ b/conda/compass_env/spec-file.template
@@ -25,7 +25,7 @@ moab=*={{ mpi_prefix }}_tempest_*
 mpas_tools=0.33.0
 nco
 netcdf4=*=nompi_*
-numpy
+numpy <2.0
 {% if supports_otps %}
 otps=2021.10
 {% endif %}


### PR DESCRIPTION
<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->

For now, we need to constrain `numpy < 2.0`.  Hopefully, we can update MPAS-Tools and compass to work with numpy >=2.0 in the near future.

<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [x] Document (in a comment titled `Testing` in this PR) any testing that was used to verify the changes

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->
