### PR TITLE
Fix files for E3SM following reorg of init

### DIFF
--- a/compass/ocean/tests/global_ocean/files_for_e3sm/__init__.py
+++ b/compass/ocean/tests/global_ocean/files_for_e3sm/__init__.py
@@ -162,12 +162,8 @@ class FilesForE3SM(TestCase):
                        base_mesh_filename)
 
         if init is not None:
-            if mesh.with_ice_shelf_cavities:
-                initial_state_filename = \
-                    f'{init.path}/ssh_adjustment/adjusted_init.nc'
-            else:
-                initial_state_filename = \
-                    f'{init.path}/initial_state/initial_state.nc'
+            initial_state_filename = \
+                f'{init.path}/initial_state/initial_state.nc'
             initial_state_filename = os.path.join(self.base_work_dir,
                                                   initial_state_filename)
             config.set('files_for_e3sm', 'ocean_initial_state_filename',

--- a/compass/ocean/tests/global_ocean/files_for_e3sm/remap_ice_shelf_melt.py
+++ b/compass/ocean/tests/global_ocean/files_for_e3sm/remap_ice_shelf_melt.py
@@ -30,33 +30,39 @@ class RemapIceShelfMelt(FilesForE3SMStep):
 
         init : compass.ocean.tests.global_ocean.init.Init
             The test case that produces the initial condition for this run
-        """  # noqa: E501
+        """
         super().__init__(test_case, name='remap_ice_shelf_melt', ntasks=512,
                          min_tasks=1)
         self.init = init
-        filename = 'prescribed_ismf_paolo2023.nc'
-        if init is None:
-            self.add_input_file(
-                filename='Paolo_2023_ANT_G1920V01_IceShelfMelt.nc',
-                target='Paolo_2023_ANT_G1920V01_IceShelfMelt.nc',
-                database='initial_condition_database',
-                url='https://its-live-data.s3.amazonaws.com/height_change/Antarctica/Floating/ANT_G1920V01_IceShelfMelt.nc')    # noqa: E501
-        elif 'remap_ice_shelf_melt' in self.init.steps:
-            melt_path = \
-                self.init.steps['remap_ice_shelf_melt'].path
-
-            self.add_input_file(
-                filename=filename,
-                work_dir_target=f'{melt_path}/{filename}')
 
     def setup(self):
         """
         setup input files based on config options
         """
         super().setup()
+        if not self.with_ice_shelf_cavities:
+            return
+
         filename = 'prescribed_ismf_paolo2023.nc'
-        if self.with_ice_shelf_cavities:
+
+        if self.init is None:
+            self.add_input_file(
+                filename='Paolo_2023_ANT_G1920V01_IceShelfMelt.nc',
+                target='Paolo_2023_ANT_G1920V01_IceShelfMelt.nc',
+                database='initial_condition_database',
+                url='https://its-live-data.s3.amazonaws.com/height_change/Antarctica/Floating/ANT_G1920V01_IceShelfMelt.nc')    # noqa: E501
             self.add_output_file(filename=filename)
+        else:
+            if 'remap_ice_shelf_melt' not in self.init.steps:
+                raise ValueError('Something seems to be misconfigured. No '
+                                 'remap_ice_shelf_melt step found in init '
+                                 'test case.')
+            melt_path = \
+                self.init.steps['remap_ice_shelf_melt'].path
+
+            self.add_input_file(
+                filename=filename,
+                work_dir_target=f'{melt_path}/{filename}')
 
     def run(self):
         """


### PR DESCRIPTION
Following https://github.com/MPAS-Dev/compass/pull/813, the initial state is the same whether ice shelf cavities are present or not.  It is the result of the `init/initial_state` step.

The `remap_ice_shelf_melt` step in `files_for_e3sm` needs to find the output in the corresponding `remap_ice_shelf_melt` in the `init` test case during `setup()` because that step no longer exists at construction.

<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->

<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [x] Document (in a comment titled `Testing` in this PR) any testing that was used to verify the changes

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->
