### PR TITLE
Only add metadata to forward runs when useful

### DIFF
--- a/compass/ocean/tests/global_ocean/analysis_test/__init__.py
+++ b/compass/ocean/tests/global_ocean/analysis_test/__init__.py
@@ -45,7 +45,7 @@ class AnalysisTest(ForwardTestCase):
 
         step = ForwardStep(test_case=self, mesh=mesh, init=init,
                            time_integrator=time_integrator, ntasks=4,
-                           openmp_threads=1)
+                           openmp_threads=1, add_metadata=False)
 
         self.variables = {
             'output.nc':

--- a/compass/ocean/tests/global_ocean/daily_output_test/__init__.py
+++ b/compass/ocean/tests/global_ocean/daily_output_test/__init__.py
@@ -36,7 +36,7 @@ class DailyOutputTest(ForwardTestCase):
 
         step = ForwardStep(test_case=self, mesh=mesh, init=init,
                            time_integrator=time_integrator, ntasks=4,
-                           openmp_threads=1)
+                           openmp_threads=1, add_metadata=False)
 
         module = self.__module__
         step.add_output_file(filename='output.nc')

--- a/compass/ocean/tests/global_ocean/decomp_test/__init__.py
+++ b/compass/ocean/tests/global_ocean/decomp_test/__init__.py
@@ -36,7 +36,8 @@ class DecompTest(ForwardTestCase):
             name = '{}proc'.format(procs)
             step = ForwardStep(test_case=self, mesh=mesh, init=init,
                                time_integrator=time_integrator, name=name,
-                               subdir=name, ntasks=procs, openmp_threads=1)
+                               subdir=name, ntasks=procs, openmp_threads=1,
+                               add_metadata=False)
             step.add_output_file(filename='output.nc')
             self.add_step(step)
 

--- a/compass/ocean/tests/global_ocean/dynamic_adjustment/__init__.py
+++ b/compass/ocean/tests/global_ocean/dynamic_adjustment/__init__.py
@@ -174,7 +174,8 @@ class DynamicAdjustment(ForwardTestCase):
                            time_integrator=time_integrator, name=step_name,
                            subdir=step_name,
                            land_ice_flux_mode=land_ice_flux_mode,
-                           get_dt_from_min_res=get_dt_from_min_res)
+                           get_dt_from_min_res=get_dt_from_min_res,
+                           add_metadata=True)
 
         namelist_options = dict(shared_options)
         if previous_restart_filename is None:

--- a/compass/ocean/tests/global_ocean/files_for_e3sm/write_coeffs_reconstruct/__init__.py
+++ b/compass/ocean/tests/global_ocean/files_for_e3sm/write_coeffs_reconstruct/__init__.py
@@ -31,7 +31,7 @@ class WriteCoeffsReconstruct(ForwardStep, FilesForE3SMStep):
         """
         super().__init__(test_case=test_case, mesh=mesh, init=init,
                          time_integrator='split_explicit_ab2',
-                         name='write_coeffs_reconstruct')
+                         name='write_coeffs_reconstruct', add_metadata=False)
 
         package = 'compass.ocean.tests.global_ocean.files_for_e3sm.' \
                   'write_coeffs_reconstruct'

--- a/compass/ocean/tests/global_ocean/monthly_output_test/__init__.py
+++ b/compass/ocean/tests/global_ocean/monthly_output_test/__init__.py
@@ -35,7 +35,7 @@ class MonthlyOutputTest(ForwardTestCase):
 
         step = ForwardStep(test_case=self, mesh=mesh, init=init,
                            time_integrator=time_integrator, ntasks=4,
-                           openmp_threads=1)
+                           openmp_threads=1, add_metadata=False)
 
         module = self.__module__
         step.add_output_file(filename='output.nc')

--- a/compass/ocean/tests/global_ocean/performance_test/__init__.py
+++ b/compass/ocean/tests/global_ocean/performance_test/__init__.py
@@ -44,14 +44,16 @@ class PerformanceTest(ForwardTestCase):
                 step = ForwardStep(test_case=self, mesh=mesh, init=init,
                                    time_integrator=time_integrator,
                                    name=step_name,
-                                   land_ice_flux_mode=flux_mode)
+                                   land_ice_flux_mode=flux_mode,
+                                   add_metadata=False)
                 step.add_streams_file(this_module, 'streams.wisc')
                 step.add_output_file(filename='land_ice_fluxes.nc')
                 step.add_output_file(filename='output.nc')
                 self.add_step(step)
         else:
             step = ForwardStep(test_case=self, mesh=mesh, init=init,
-                               time_integrator=time_integrator)
+                               time_integrator=time_integrator,
+                               add_metadata=False)
 
             step.add_output_file(filename='output.nc')
             self.add_step(step)

--- a/compass/ocean/tests/global_ocean/restart_test/__init__.py
+++ b/compass/ocean/tests/global_ocean/restart_test/__init__.py
@@ -45,7 +45,7 @@ class RestartTest(ForwardTestCase):
             step = ForwardStep(test_case=self, mesh=mesh, init=init,
                                time_integrator=time_integrator, name=name,
                                subdir=name, ntasks=4, openmp_threads=1,
-                               get_dt_from_min_res=False)
+                               get_dt_from_min_res=False, add_metadata=False)
 
             suffix = '{}.{}'.format(time_integrator.lower(), part)
             step.add_namelist_file(module, 'namelist.{}'.format(suffix))

--- a/compass/ocean/tests/global_ocean/threads_test/__init__.py
+++ b/compass/ocean/tests/global_ocean/threads_test/__init__.py
@@ -37,7 +37,8 @@ class ThreadsTest(ForwardTestCase):
             step = ForwardStep(test_case=self, mesh=mesh, init=init,
                                time_integrator=time_integrator, name=name,
                                subdir=name, ntasks=4,
-                               openmp_threads=openmp_threads)
+                               openmp_threads=openmp_threads,
+                               add_metadata=False)
             step.add_output_file(filename='output.nc')
             self.add_step(step)
 


### PR DESCRIPTION
A lot of time is being taken to add metadata to output files during regression testing, even though that metadata will not be used by anyone and is not very useful.

We only want to be adding metadata to mesh files, initial conditions, outputs from dynamic adjustment and files staged for use as initial conditions in E3SM.

<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->

<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [ ] Document (in a comment titled `Testing` in this PR) any testing that was used to verify the changes

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->
