### PR TITLE
Chicoma debug

### DIFF
--- a/compass/job/__init__.py
+++ b/compass/job/__init__.py
@@ -82,6 +82,11 @@ def write_job_script(config, machine, target_cores, min_cores, work_dir,
         else:
             constraint = ''
 
+    if config.has_option('job', 'reservation'):
+        reservation = config.get('job', 'reservation')
+    else:
+        reservation = ''
+
     job_name = config.get('job', 'job_name')
     if job_name == '<<<default>>>':
         if suite == '':
@@ -96,7 +101,8 @@ def write_job_script(config, machine, target_cores, min_cores, work_dir,
     text = template.render(job_name=job_name, account=account,
                            nodes=f'{nodes}', wall_time=wall_time, qos=qos,
                            partition=partition, constraint=constraint,
-                           suite=suite, pre_run_commands=pre_run_commands,
+                           reservation=reservation, suite=suite,
+                           pre_run_commands=pre_run_commands,
                            post_run_commands=post_run_commands)
     text = _clean_up_whitespace(text)
     if suite == '':

--- a/compass/job/job_script.template
+++ b/compass/job/job_script.template
@@ -10,6 +10,9 @@
 {% if qos != '' -%}
 #SBATCH  --qos={{ qos }}
 {%- endif %}
+{% if reservation != '' -%}
+#SBATCH  --reservation={{ reservation }}
+{%- endif %}
 {% if partition != '' -%}
 #SBATCH  --partition={{ partition }}
 {%- endif %}

--- a/compass/machines/chicoma-cpu.cfg
+++ b/compass/machines/chicoma-cpu.cfg
@@ -51,5 +51,8 @@ threads_per_core = 1
 # The job partition to use
 partition = standard
 
+# The job reservation to use (needed for debug jobs)
+reservation =
+
 # The job quality of service (QOS) to use
 qos = standard

--- a/docs/developers_guide/machines/chicoma.rst
+++ b/docs/developers_guide/machines/chicoma.rst
@@ -19,3 +19,22 @@ Then, you can build the MPAS model with
 .. code-block:: bash
 
     make [DEBUG=true] gnu-cray
+
+debug jobs
+~~~~~~~~~~
+
+In order to run jobs in the debug queue, you will need to use: 
+
+.. code-block:: cfg
+
+    # Config options related to creating a job script
+    [job]
+
+    # The job partition to use
+    partition = debug
+
+    # The job reservation to use (needed for debug jobs)
+    reservation = debug
+
+    # The job quality of service (QOS) to use
+    qos =

--- a/docs/users_guide/machines/chicoma.rst
+++ b/docs/users_guide/machines/chicoma.rst
@@ -138,9 +138,12 @@ when setting up test cases or a test suite:
     # The job partition to use
     partition = standard
 
+    # The job reservation to use (needed for debug jobs)
+    reservation =
+
     # The job quality of service (QOS) to use
     qos = standard
-
+    
 
 Additionally, some relevant config options come from the
 `mache <https://github.com/E3SM-Project/mache/>`_ package:


### PR DESCRIPTION
This PR adds a `reservation` option to the `job` section of the config files, which is needed to run jobs in the `debug` queue on `chicoma`. 

While setting `qos=debug` used to work on `chicoma`, something switched in the last couple months and both `reservation` and `partition` need to set to `debug` for things to work. See the `chicoma` docs for reference: 
https://hpc.lanl.gov/policies/job-scheduling-policies.html#JobSchedulingPolicies-Chicoma
(Note: the entry in the table is for a interactive `debug` job, but the need to set both `reservation` and `partition` applies to batch jobs aswell). 

__Checklist__
* [x] User's Guide has been updated
* [x] Developer's Guide has been updated
* [x] Documentation has been [built locally](https://mpas-dev.github.io/compass/latest/developers_guide/building_docs.html) and changes look as expected
* [x] Document (in a comment titled `Testing` in this PR) any testing that was used to verify the changes

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->
