### PR TITLE
Added `cubed_sphere` target grid test to `utility/combine_topo`

### DIFF
--- a/compass/ocean/tests/utility/__init__.py
+++ b/compass/ocean/tests/utility/__init__.py
@@ -19,7 +19,7 @@ class Utility(TestGroup):
         """
         super().__init__(mpas_core=mpas_core, name='utility')
 
-        self.add_test_case(CombineTopo(test_group=self))
+        self.add_test_case(CombineTopo(test_group=self, target_grid='lat_lon'))
         self.add_test_case(CullRestarts(test_group=self))
         self.add_test_case(ExtrapWoa(test_group=self))
         self.add_test_case(CreateSalinRestoring(test_group=self))

--- a/compass/ocean/tests/utility/__init__.py
+++ b/compass/ocean/tests/utility/__init__.py
@@ -19,7 +19,10 @@ class Utility(TestGroup):
         """
         super().__init__(mpas_core=mpas_core, name='utility')
 
-        self.add_test_case(CombineTopo(test_group=self, target_grid='lat_lon'))
+        for target_grid in ['lat_lon', 'cubed_sphere']:
+            self.add_test_case(
+                CombineTopo(test_group=self, target_grid=target_grid),
+            )
         self.add_test_case(CullRestarts(test_group=self))
         self.add_test_case(ExtrapWoa(test_group=self))
         self.add_test_case(CreateSalinRestoring(test_group=self))

--- a/compass/ocean/tests/utility/combine_topo/__init__.py
+++ b/compass/ocean/tests/utility/combine_topo/__init__.py
@@ -463,7 +463,7 @@ class Combine(Step):
         lon_tiles = section.getint('lon_tiles')
 
         # Make tiles directory
-        os.mkdir('tiles')
+        os.makedirs('tiles', exist_ok=True)
 
         # Initialize combined xarray.Dataset
         gebco_remapped = xr.Dataset()

--- a/compass/ocean/tests/utility/combine_topo/__init__.py
+++ b/compass/ocean/tests/utility/combine_topo/__init__.py
@@ -28,7 +28,8 @@ class CombineTopo(TestCase):
         ----------
         test_group : compass.ocean.tests.utility.Utility
             The test group that this test case belongs to
-        target_grid : `str`, either "lat_lon" or "cubed_sphere"
+        target_grid : str
+            either "lat_lon" or "cubed_sphere"
         """
 
         subdir = os.path.join('combine_topo', target_grid)
@@ -47,9 +48,12 @@ class Combine(Step):
 
     Attributes
     ----------
-    target_grid : `str`, either "lat_lon" or "cubed_sphere"
-    resolution : `float` degrees, or `int` NExxx
-    resolution_name: `str`, either x.xxxx_degrees or NExxx
+    target_grid : str
+        either "lat_lon" or "cubed_sphere"
+    resolution : float
+        degrees (float) or face subdivisions (int)
+    resolution_name: str
+        either x.xxxx_degrees or NExxx
     """
 
     def __init__(self, test_case, target_grid):
@@ -60,7 +64,8 @@ class Combine(Step):
         ----------
         test_case : compass.ocean.tests.utility.combine_topo.CombineTopo
             The test case this step belongs to
-        target_grid : `str`, either "lat_lon" or "cubed_sphere"
+        target_grid : str
+            either "lat_lon" or "cubed_sphere"
         """
         super().__init__(
             test_case, name='combine', ntasks=None, min_tasks=None,
@@ -251,8 +256,10 @@ class Combine(Step):
 
         Parameters
         ----------
-        lon_tile : `int`, tile number along lon dim
-        lat_tile : `int`, tile number along lat dim
+        lon_tile : int
+            tile number along lon dim
+        lat_tile : int
+            tile number along lat dim
         """
         logger = self.logger
 
@@ -378,8 +385,10 @@ class Combine(Step):
 
         Parameters
         ----------
-        in_filename : `str`, source file name
-        out_filename : `str`, weights file name
+        in_filename : str
+            source file name
+        out_filename : str
+            weights file name
         """
         config = self.config
         method = config.get('combine_topo', 'method')
@@ -409,11 +418,14 @@ class Combine(Step):
 
         Parameters
         ----------
-        in_filename : `str`, source file name
-        mapping_filename : `str`, weights file name
-        out_filename : `str`, remapped file name
-        default_dims : `bool`, default `True`,
-            if `False` specify non-default source dims y,x
+        in_filename : str
+            source file name
+        mapping_filename : str
+            weights file name
+        out_filename : str
+            remapped file name
+        default_dims : bool
+            default True, if False specify non-default source dims y,x
         """
         # Build command args
         args = [

--- a/compass/ocean/tests/utility/combine_topo/__init__.py
+++ b/compass/ocean/tests/utility/combine_topo/__init__.py
@@ -652,7 +652,8 @@ class Combine(Step):
             combined[field] = combined[field].where(valid, fill_val)
 
         # Save combined bathy to NetCDF
-        _write_netcdf_with_fill_values(combined, self.outputs[1])
+        _write_netcdf_with_fill_values(combined, self.outputs[1],
+                                       format='NETCDF3_64BIT_DATA')
 
         logger.info('  Done.')
 
@@ -670,7 +671,7 @@ class Combine(Step):
         logger.info('  Done.')
 
 
-def _write_netcdf_with_fill_values(ds, filename):
+def _write_netcdf_with_fill_values(ds, filename, format='NETCDF4'):
     """ Write an xarray Dataset with NetCDF4 fill values where needed """
     fill_values = netCDF4.default_fillvals
     encoding = {}
@@ -687,4 +688,4 @@ def _write_netcdf_with_fill_values(ds, filename):
                     break
         else:
             encoding[var_name] = {"_FillValue": None}
-    ds.to_netcdf(filename, encoding=encoding)
+    ds.to_netcdf(filename, encoding=encoding, format=format)

--- a/compass/ocean/tests/utility/combine_topo/__init__.py
+++ b/compass/ocean/tests/utility/combine_topo/__init__.py
@@ -584,6 +584,10 @@ class Combine(Step):
         section = config['combine_topo']
         renorm_thresh = section.getfloat('renorm_thresh')
 
+        out_filename = self.outputs[1]
+        stem = pathlib.Path(out_filename).stem
+        netcdf4_filename = f'{stem}.netcdf4.nc'
+
         # Parse config
         config = self.config
         section = config['combine_topo']
@@ -652,8 +656,16 @@ class Combine(Step):
             combined[field] = combined[field].where(valid, fill_val)
 
         # Save combined bathy to NetCDF
-        _write_netcdf_with_fill_values(combined, self.outputs[1],
-                                       format='NETCDF3_64BIT_DATA')
+        _write_netcdf_with_fill_values(combined, netcdf4_filename)
+
+        # writing directly in NETCDF3_64BIT_DATA proved prohibitively slow
+        # so we will use ncks to convert
+        args = [
+            'ncks', '-O', '-5',
+            netcdf4_filename,
+            out_filename,
+        ]
+        check_call(args, logger)
 
         logger.info('  Done.')
 

--- a/compass/ocean/tests/utility/combine_topo/combine_topo.cfg
+++ b/compass/ocean/tests/utility/combine_topo/combine_topo.cfg
@@ -7,7 +7,7 @@ global_filename = GEBCO_2023.nc
 
 # target resolution (degrees or NExxx)
 resolution_latlon = 0.0125
-resolution_cubedsphere = 9000
+resolution_cubedsphere = 3000
 method = bilinear
 
 # threshold for masks below which interpolated variables are not renormalized
@@ -15,7 +15,7 @@ renorm_thresh = 1e-3
 
 # the target and minimum number of MPI tasks to use in remapping
 ntasks = 1280
-min_tasks = 512
+min_tasks = 1024
 
 # latitudes between which the topography datasets get blended
 latmin = -62.

--- a/compass/ocean/tests/utility/combine_topo/combine_topo.cfg
+++ b/compass/ocean/tests/utility/combine_topo/combine_topo.cfg
@@ -5,10 +5,12 @@
 antarctic_filename = BedMachineAntarctica-v3.nc
 global_filename = GEBCO_2023.nc
 
-resolution = 0.5
+# target resolution (degrees or NExxx)
+resolution_latlon = 0.0125
+resolution_cubedsphere = 9000
 method = bilinear
 
-# the threshold for masks below which interpolated variables are not renormalized
+# threshold for masks below which interpolated variables are not renormalized
 renorm_thresh = 1e-3
 
 # the target and minimum number of MPI tasks to use in remapping

--- a/compass/ocean/tests/utility/combine_topo/combine_topo.cfg
+++ b/compass/ocean/tests/utility/combine_topo/combine_topo.cfg
@@ -15,7 +15,7 @@ renorm_thresh = 1e-3
 
 # the target and minimum number of MPI tasks to use in remapping
 ntasks = 1280
-min_tasks = 1024
+min_tasks = 512
 
 # latitudes between which the topography datasets get blended
 latmin = -62.

--- a/compass/ocean/tests/utility/combine_topo/combine_topo.cfg
+++ b/compass/ocean/tests/utility/combine_topo/combine_topo.cfg
@@ -5,13 +5,20 @@
 antarctic_filename = BedMachineAntarctica-v3.nc
 global_filename = GEBCO_2023.nc
 
-# the name of the output topography file, to be copied to the bathymetry database
-cobined_filename = BedMachineAntarctica_v3_and_GEBCO_2023_0.0125_degree_20240828.nc
+resolution = 0.5
+method = bilinear
+
+# the threshold for masks below which interpolated variables are not renormalized
+renorm_thresh = 1e-3
 
 # the target and minimum number of MPI tasks to use in remapping
-ntasks = 512
-min_tasks = 128
+ntasks = 1280
+min_tasks = 512
 
 # latitudes between which the topography datasets get blended
 latmin = -62.
 latmax = -60.
+
+# the number of tiles in lat and lon for GEBCO remapping
+lat_tiles = 3
+lon_tiles = 6

--- a/docs/developers_guide/ocean/test_groups/utility.rst
+++ b/docs/developers_guide/ocean/test_groups/utility.rst
@@ -19,10 +19,15 @@ dataset.
 combine
 ~~~~~~~
 The class :py:class:`compass.ocean.tests.utility.combine_topo.Combine`
-defines a step for combining the datasets above.  The GEBCO data is downsampled
-to a 1/80 degree latitude-longitude grid to make later remapping to MPAS meshes
-more manageable.  The BedMachine data is remapped to this same mesh and the
-two datasets are blended between 60 and 62 degrees south latitude.
+defines a step for combining the datasets above. The GEBCO and BedMachine data
+are remapped to a common global grid to make later remapping to MPAS meshes
+more manageable, and the two datasets are blended between 60 and 62 degrees
+south latitude. The GEBCO global dataset is divided into regional tiles prior
+to remapping to improve performance. Two common global target grid options are
+provided: a 1/80 degree latitude-longitude grid and an ne3000 cubed sphere
+grid. These target grid options are selectable via the ``target_grid`` argument
+in the :py:class:`compass.ocean.tests.utility.combine_topo.CombineTopo` test
+case class.
 
 cull_restarts
 -------------

--- a/docs/users_guide/ocean/test_groups/utility.rst
+++ b/docs/users_guide/ocean/test_groups/utility.rst
@@ -8,13 +8,22 @@ may create datasets for other test groups to use.  It is partly designed to
 provide provenance for data processing that may be more complex than a single,
 short script.
 
-combine_topo
-------------
-The ``ocean/utility/combine_topo`` test case is used to combine the
+combine_topo/lat_lon
+--------------------
+The ``ocean/utility/combine_topo/lat_lon`` test case is used to combine the
 `BedMachine Antarctica v3 <https://nsidc.org/data/nsidc-0756/versions/3>`_
 dataset with the `GEBCO 2023 <https://www.gebco.net/data_and_products/gridded_bathymetry_data/>`_
 dataset.  The result is on a 1/80 degree latitude-longitude grid.  This utility
-is intended for provenance.  It is intended to doucment the process for
+is intended for provenance.  It is intended to document the process for
+producing the topography dataset used for E3SM ocean meshes.
+
+combine_topo/cubed_sphere
+-------------------------
+The ``ocean/utility/combine_topo/cubed_sphere`` test case is used to combine the
+`BedMachine Antarctica v3 <https://nsidc.org/data/nsidc-0756/versions/3>`_
+dataset with the `GEBCO 2023 <https://www.gebco.net/data_and_products/gridded_bathymetry_data/>`_
+dataset.  The result is on an ne3000 cubed sphere grid.  This utility
+is intended for provenance.  It is intended to document the process for
 producing the topography dataset used for E3SM ocean meshes.
 
 cull_restarts


### PR DESCRIPTION
<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->
The `ocean/utility/combine_topo` test has been split into two separate tests: one for a `lat_lon` target grid and one for a `cubed_sphere` target grid. The `cubed_sphere` test allows the migration to `mbtempest` for remapping bathymetry to MPAS grids by removing the pole singularities. The workflow for the existing `lat_lon` target grid has also been updated to use remapping tools more consistently between the GEBCO and BedMachineAntarctica data sets, and between the `lat_lon` and `cubed_sphere` target mesh workflows. Specifically, the GEBCO dataset is separated into tiles prior to remapping, `ESMF_RegridWeightGen` is used for building weights files, and `ncremap` is used for the final remapping step.

<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [x] User's Guide has been updated
* [x] Developer's Guide has been updated
* [x] Documentation has been [built locally](https://mpas-dev.github.io/compass/latest/developers_guide/building_docs.html) and changes look as expected
* [x] Document (in a comment titled `Testing` in this PR) any testing that was used to verify the changes

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->

<!--
Testing:
The `combine_topo/lat_lon` test was run to completion at `resolution_latlon = 0.0125` and the `combine_topo/cubed_sphere` test was run to completion at `resolution_cubedsphere = 3000`. Output files were verified in Python. Both tests used 10 nodes on Chrysalis and a 4h walltime.
-->