### PR TITLE
Update to 1.6.0 alpha.1

### DIFF
--- a/compass/machines/pm-gpu.cfg
+++ b/compass/machines/pm-gpu.cfg
@@ -31,6 +31,10 @@ spack = /global/cfs/cdirs/e3sm/software/compass/pm-gpu/spack
 # pnetcdf as E3SM (spack modules are used otherwise)
 use_e3sm_hdf5_netcdf = True
 
+# spack variants for Albany and Trilinos
+albany_variants = +mpas~py+unit_tests+cuda+uvm+sfad sfadsize=12
+trilinos_variants = +cuda+uvm+ampere80+zen3
+
 # The parallel section describes options related to running jobs in parallel.
 # Most options in this section come from mache so here we just add or override
 # some defaults

--- a/compass/version.py
+++ b/compass/version.py
@@ -1,1 +1,1 @@
-__version__ = '1.5.0-alpha.1'
+__version__ = '1.6.0-alpha.1'

--- a/conda/bootstrap.py
+++ b/conda/bootstrap.py
@@ -470,6 +470,8 @@ def build_spack_env(config, update_spack, machine, compiler, mpi,  # noqa: C901
                     tmpdir, logger):
 
     albany = config.get('deploy', 'albany')
+    albany_variants = config.get('deploy', 'albany_variants')
+    trilinos_variants = config.get('deploy', 'trilinos_variants')
     cmake = config.get('deploy', 'cmake')
     esmf = config.get('deploy', 'esmf')
     lapack = config.get('deploy', 'lapack')
@@ -478,9 +480,6 @@ def build_spack_env(config, update_spack, machine, compiler, mpi,  # noqa: C901
     petsc = config.get('deploy', 'petsc')
     scorpio = config.get('deploy', 'scorpio')
     parallelio = config.get('deploy', 'parallelio')
-
-    # for now, we'll assume Cuda is needed anytime GPUs are present
-    with_cuda = config.has_option('parallel', 'gpus_per_node')
 
     if config.has_option('deploy', 'spack_mirror'):
         spack_mirror = config.get('deploy', 'spack_mirror')
@@ -543,14 +542,8 @@ def build_spack_env(config, update_spack, machine, compiler, mpi,  # noqa: C901
             f'@{parallelio}+pnetcdf~timing"')
 
     if albany != 'None':
-        if with_cuda:
-            albany_cuda = '+cuda+uvm+sfad sfadsize=12'
-            trilinos_cuda = '+cuda+uvm'
-        else:
-            albany_cuda = ''
-            trilinos_cuda = ''
-        specs.append(f'"trilinos-for-albany@{albany}{trilinos_cuda}"')
-        specs.append(f'"albany@{albany}+mpas~py+unit_tests{albany_cuda}"')
+        specs.append(f'"trilinos-for-albany@{albany}{trilinos_variants}"')
+        specs.append(f'"albany@{albany}{albany_variants}"')
 
     yaml_template = f'{spack_template_path}/{machine}_{compiler}_{mpi}.yaml'
     if not os.path.exists(yaml_template):

--- a/conda/compass_env/spec-file.template
+++ b/conda/compass_env/spec-file.template
@@ -22,7 +22,7 @@ matplotlib-base >=3.9.1
 metis
 moab >=5.5.1
 moab=*={{ mpi_prefix }}_tempest_*
-mpas_tools=0.34.1
+mpas_tools=0.35.0
 nco
 netcdf4=*=nompi_*
 numpy >=2.0,<3.0

--- a/conda/compass_env/spec-file.template
+++ b/conda/compass_env/spec-file.template
@@ -16,7 +16,7 @@ ipython
 jupyter
 lxml
 {% if include_mache %}
-mache=1.25.0
+mache=1.26.0
 {% endif %}
 matplotlib-base >=3.9.1
 metis

--- a/conda/configure_compass_env.py
+++ b/conda/configure_compass_env.py
@@ -102,7 +102,7 @@ def main():
     if local_mache:
         mache = ''
     else:
-        mache = '"mache=1.25.0"'
+        mache = '"mache=1.26.0"'
 
     setup_install_env(env_name, activate_base, args.use_local, logger,
                       args.recreate, conda_base, mache)

--- a/conda/default.cfg
+++ b/conda/default.cfg
@@ -21,6 +21,9 @@ mpi = nompi
 
 # the version of various packages to include if using spack
 albany = compass-2024-03-13
+# spack variants for Albany and Trilinos
+albany_variants = +mpas~py+unit_tests
+trilinos_variants =
 # cmake newer than 3.23.0 needed for Trilinos
 cmake = 3.23.0:
 esmf = 8.6.1


### PR DESCRIPTION
<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->

### Updates:
- mache to v1.26.0 -- updates chicoma-cpu
- mpas_tools to v0.35.0

<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [x] Document (in a comment titled `Testing` in this PR) any testing that was used to verify the changes

## Testing

MPAS-Ocean with `pr`:
- [x] Chicoma
  - [x] gnu and mpich
- [x] Chrysalis
  - [x] intel and openmpi
  - [x] gnu and openmpi
- [x] Perlmutter 
  - [x] gnu and mpich

MALI with `full_integration`:
- [x] Chicoma
  - [x] gnu and mpich
- [x] Chrysalis 
  - [x] gnu and openmpi
- [x] Perlmutter
  - [x] gnu and mpich
  - [x] gnugpu and mpich - same restart failures and slow execution as seen in https://github.com/MPAS-Dev/compass/pull/857, but we know this isn't configured right yet

## Deployed

MPAS-Ocean with `pr`:
- [x] Anvil
  - [x] intel and impi
  - [x] intel and openmpi
  - [x] gnu and openmpi
- [x] Chicoma
  - [x] gnu and mpich
- [x] Chrysalis
  - [x] intel and openmpi
  - [x] gnu and openmpi
- [ ] Compy - skipping for now as I can't log on.
  - [ ] intel and impi
- [x] Perlmutter 
  - [x] gnu and mpich (@altheaden)

MALI with `full_integration`:
- [x] Chicoma
  - [x] gnu and mpich
- [x] Chrysalis 
  - [x] gnu and openmpi - 4 failures as reported in https://github.com/MPAS-Dev/compass/issues/871
- [x] Perlmutter
  - [x] gnu and mpich (@altheaden)
  - [x] gnugpu and mpich - same failures as above