### PR TITLE
Correct region name to ISMIP6 Greenland Regions

### DIFF
--- a/compass/ocean/tests/global_ocean/files_for_e3sm/diagnostic_masks.py
+++ b/compass/ocean/tests/global_ocean/files_for_e3sm/diagnostic_masks.py
@@ -82,7 +82,7 @@ def make_diagnostics_files(logger, mesh_short_name, with_ice_shelf_cavities,
 
     gf = GeometricFeatures()
     region_groups = ['Antarctic Regions', 'Arctic Ocean Regions',
-                     'Arctic Sea Ice Regions', 'Greenland Regions',
+                     'Arctic Sea Ice Regions', 'ISMIP6 Greenland Regions',
                      'Ocean Basins', 'Ocean Subbasins', 'ISMIP6 Regions']
 
     if with_ice_shelf_cavities:


### PR DESCRIPTION
Region group name in files_for_e3sm diagnostic masks did not match geometric features. After correcting, this works for `IcoswISC240`.