### PR TITLE
Make a deep copy of `PatchCollection`s in ISOMIP+ test cases

### DIFF
--- a/compass/ocean/tests/isomip_plus/viz/plot.py
+++ b/compass/ocean/tests/isomip_plus/viz/plot.py
@@ -794,10 +794,10 @@ class MoviePlotter(object):
             return
 
         if oceanDomain:
-            localPatches = copy.copy(self.oceanPatches)
+            localPatches = copy.deepcopy(self.oceanPatches)
             localPatches.set_array(field[self.oceanMask])
         else:
-            localPatches = copy.copy(self.cavityPatches)
+            localPatches = copy.deepcopy(self.cavityPatches)
             localPatches.set_array(field[self.cavityMask])
 
         if cmap is not None:


### PR DESCRIPTION
The shallow copy previously used (`copy.copy()`) was allowing modifications of attributes to persist across different plots, with unintended consequences.

<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->

<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [x] Document (in a comment titled `Testing` in this PR) any testing that was used to verify the changes

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->
Fixes #877 
