### PR TITLE
Add smoothing to remapping of SSS restoring

### DIFF
--- a/compass/ocean/tests/global_ocean/global_ocean.cfg
+++ b/compass/ocean/tests/global_ocean/global_ocean.cfg
@@ -208,3 +208,13 @@ with_ice_shelf_cavities = autodetect
 
 # whether to write out sea-ice partition info for plotting in paraview
 plot_seaice_partitions = False
+
+# Config options related to smoothing of sea-surface salinity during remapping.
+# The smoothing distance increases linearly from zero at sss_smoothing_min_lat
+# to its maximum value at the north pole.
+#
+# the minimum latitude (degrees) for smoothing
+sss_smoothing_min_lat = 70
+
+# the maximum smoothing distance (meters)
+sss_smoothing_max_dist = 1000e3

--- a/compass/ocean/tests/utility/create_salin_restoring/__init__.py
+++ b/compass/ocean/tests/utility/create_salin_restoring/__init__.py
@@ -1,9 +1,6 @@
-from compass.ocean.tests.utility.create_salin_restoring.extrap_salin import (
-    ExtrapSalin,
-)
-from compass.ocean.tests.utility.create_salin_restoring.salinity_restoring import (  # noqa: E501
-    Salinity,
-)
+from compass.ocean.tests.utility.create_salin_restoring.combine import Combine
+from compass.ocean.tests.utility.create_salin_restoring.extrap import Extrap
+from compass.ocean.tests.utility.create_salin_restoring.remap import Remap
 from compass.testcase import TestCase
 
 
@@ -25,5 +22,6 @@ class CreateSalinRestoring(TestCase):
         """
         super().__init__(test_group=test_group, name='create_salin_restoring')
 
-        self.add_step(Salinity(test_case=self))
-        self.add_step(ExtrapSalin(test_case=self))
+        self.add_step(Combine(test_case=self))
+        self.add_step(Extrap(test_case=self))
+        self.add_step(Remap(test_case=self))

--- a/compass/ocean/tests/utility/create_salin_restoring/combine.py
+++ b/compass/ocean/tests/utility/create_salin_restoring/combine.py
@@ -5,7 +5,7 @@ from mpas_tools.io import write_netcdf
 from compass.step import Step
 
 
-class Salinity(Step):
+class Combine(Step):
     """
     A step for combining January through December sea surface salinity
     data into a single file for salinity restoring in G-cases.
@@ -14,15 +14,14 @@ class Salinity(Step):
 
     def __init__(self, test_case):
         """
-        Create a new step
+        Create the step
 
         Parameters
         ----------
-        test_case : compass.ocean.tests.utility.create_salin_restoring.
-        CreateSalinRestoring
-        The test case this step belongs to
-        """
-        super().__init__(test_case, name='salinity_restoring', ntasks=1,
+        test_case : compass.ocean.tests.utility.create_salin_restoring.CreateSalinRestoring
+            The test case this step belongs to
+        """  # noqa: E501
+        super().__init__(test_case, name='combine', ntasks=1,
                          min_tasks=1)
         self.add_output_file(filename='woa_surface_salinity_monthly.nc')
 

--- a/compass/ocean/tests/utility/create_salin_restoring/create_salin_restoring.cfg
+++ b/compass/ocean/tests/utility/create_salin_restoring/create_salin_restoring.cfg
@@ -1,0 +1,13 @@
+# config options related creating salinity restoring
+[salinity_restoring]
+
+# target resolution (NExxx)
+resolution = 300
+method = bilinear
+
+# threshold for masks below which interpolated variables are not renormalized
+renorm_thresh = 1e-3
+
+# the target and minimum number of MPI tasks to use in remapping
+ntasks = 1280
+min_tasks = 256

--- a/compass/ocean/tests/utility/create_salin_restoring/extrap.py
+++ b/compass/ocean/tests/utility/create_salin_restoring/extrap.py
@@ -7,7 +7,7 @@ from scipy.signal import convolve2d
 from compass.step import Step
 
 
-class ExtrapSalin(Step):
+class Extrap(Step):
     """
     Extrapolate WOA 2023 monthly sea surface salinity data into missing ocean
     regions, including ice cavities and coasts
@@ -20,21 +20,19 @@ class ExtrapSalin(Step):
     """
     def __init__(self, test_case):
         """
-        Create a new test case
+        Create the step
 
         Parameters
         ----------
-        test_case : compass.ocean.tests.utility.create_salin_restoring.
-        CreateSalinRestoring
+        test_case : compass.ocean.tests.utility.create_salin_restoring.CreateSalinRestoring
             The test case this step belongs to
-
-        """
+        """  # noqa: E501
         super().__init__(test_case=test_case, name='extrap', cpus_per_task=64,
                          min_cpus_per_task=1, openmp_threads=1)
 
         self.add_input_file(
             filename='woa_surface_salinity_monthly.nc',
-            target='../salinity_restoring/woa_surface_salinity_monthly.nc')
+            target='../combine/woa_surface_salinity_monthly.nc')
 
         self.woa_filename = None
 
@@ -42,6 +40,7 @@ class ExtrapSalin(Step):
         """
         Determine the output filename
         """
+        super().setup()
 
         now = datetime.now()
 
@@ -56,6 +55,8 @@ class ExtrapSalin(Step):
         Extrapolate WOA 2023 model temperature and salinity into ice-shelf
         cavities.
         """
+        super().run()
+
         # extrapolate horizontally using the ocean mask
         _extrap(self.woa_filename)
 

--- a/compass/ocean/tests/utility/create_salin_restoring/remap.py
+++ b/compass/ocean/tests/utility/create_salin_restoring/remap.py
@@ -1,0 +1,254 @@
+import os
+import pathlib
+from datetime import datetime
+from glob import glob
+
+from mpas_tools.logging import check_call
+
+from compass.parallel import run_command
+from compass.step import Step
+
+
+class Remap(Step):
+    """
+    A step for remapping sea-surface salinity to a cubed-sphere grid
+
+    Attributes
+    ----------
+    resolution : int
+        face subdivisions
+
+    datestring : str
+        The datestamp to append to filenames
+    """
+
+    def __init__(self, test_case):
+        """
+        Create the step
+
+        Parameters
+        ----------
+        test_case : compass.ocean.tests.utility.create_salin_restoring.CreateSalinRestoring
+            The test case this step belongs to
+        """  # noqa: E501
+        super().__init__(
+            test_case, name='remap', ntasks=None, min_tasks=None,
+        )
+        self.resolution = None
+        self.datestring = None
+
+    def setup(self):
+        """
+        Set up the step in the work directory, including downloading any
+        dependencies.
+        """
+        super().setup()
+
+        config = self.config
+        section = config['salinity_restoring']
+
+        now = datetime.now()
+
+        datestring = now.strftime("%Y%m%d")
+        self.datestring = datestring
+
+        in_filename = f'woa23_decav_0.25_sss_monthly_extrap.{datestring}.nc'
+        target = f'../extrap/{in_filename}'
+        self.add_input_file(filename=in_filename, target=target)
+
+        self._set_res_and_outputs(update=False)
+
+        # Get ntasks and min_tasks
+        self.ntasks = section.getint('ntasks')
+        self.min_tasks = section.getint('min_tasks')
+
+    def constrain_resources(self, available_resources):
+        """
+        Constrain ``cpus_per_task`` and ``ntasks`` based on the number of
+        cores available to this step
+
+        Parameters
+        ----------
+        available_resources : dict
+            The total number of cores available to the step
+        """
+        config = self.config
+        section = config['salinity_restoring']
+        self.ntasks = section.getint('ntasks')
+        self.min_tasks = section.getint('min_tasks')
+        super().constrain_resources(available_resources)
+
+    def run(self):
+        """
+        Run this step of the test case
+        """
+        self._set_res_and_outputs(update=True)
+        self._create_target_scrip_file()
+        self._remap()
+        self._cleanup()
+
+    def _set_res_and_outputs(self, update):
+        """
+        Set or update the resolution and output filenames based on config
+        options
+        """
+        config = self.config
+        section = config['salinity_restoring']
+        resolution = section.getint('resolution')
+        if update and resolution == self.resolution:
+            return
+
+        self.resolution = resolution
+        datestring = self.datestring
+
+        # Start over with empty outputs
+        self.outputs = []
+
+        scrip_filename = f'ne{resolution}_{datestring}.scrip.nc'
+        self.add_output_file(scrip_filename)
+
+        out_filename = \
+            f'woa23_decav_ne{resolution}_sss_monthly_extrap.{datestring}.nc'
+        self.add_output_file(out_filename)
+
+        if update:
+            # We need to set absolute paths
+            step_dir = self.work_dir
+            self.outputs = [os.path.abspath(os.path.join(step_dir, filename))
+                            for filename in self.outputs]
+
+    def _create_target_scrip_file(self):
+        """
+        Create SCRIP file for either the x.xxxx degree (lat-lon) mesh or the
+        NExxx (cubed-sphere) mesh, depending on the value of `self.target_grid`
+        References:
+          https://acme-climate.atlassian.net/wiki/spaces/DOC/pages/872579110/
+          Running+E3SM+on+New+Atmosphere+Grids
+        """
+        logger = self.logger
+        logger.info(f'Create SCRIP file for ne{self.resolution} mesh')
+
+        out_filename = self.outputs[0]
+        stem = pathlib.Path(out_filename).stem
+        netcdf4_filename = f'{stem}.netcdf4.nc'
+
+        # Create EXODUS file
+        args = [
+            'GenerateCSMesh', '--alt', '--res', f'{self.resolution}',
+            '--file', f'ne{self.resolution}.g',
+        ]
+        check_call(args, logger)
+
+        # Create SCRIP file
+        args = [
+            'ConvertMeshToSCRIP', '--in', f'ne{self.resolution}.g',
+            '--out', netcdf4_filename,
+        ]
+        check_call(args, logger)
+
+        # writing out directly to NETCDF3_64BIT_DATA is either very slow or
+        # unsupported, so use ncks
+        args = [
+            'ncks', '-O', '-5',
+            netcdf4_filename,
+            out_filename,
+        ]
+        check_call(args, logger)
+
+        logger.info('  Done.')
+
+    def _remap(self):
+        """
+        Remap salinity restoring
+        """
+        logger = self.logger
+        logger.info('Remapping salinity restoring to cubed-sphere grid')
+
+        # Parse config
+        config = self.config
+        section = config['salinity_restoring']
+        method = section.get('method')
+
+        in_filename = self.inputs[0]
+        out_filename = self.outputs[1]
+
+        mapping_filename = f'map_0.25_deg_to_ne{self.resolution}_{method}.nc'
+
+        self._create_weights(in_filename, mapping_filename)
+        self._remap_to_target(
+            in_filename, mapping_filename, out_filename,
+        )
+
+        logger.info('  Done.')
+
+    def _create_weights(self, in_filename, out_filename):
+        """
+        Create weights file for remapping to cubed-sphere grid
+
+        Parameters
+        ----------
+        in_filename : str
+            source file name
+
+        out_filename : str
+            weights file name
+        """
+        config = self.config
+        method = config.get('salinity_restoring', 'method')
+
+        # Generate weights file
+        args = [
+            'ESMF_RegridWeightGen',
+            '--source', in_filename,
+            '--destination', self.outputs[0],
+            '--weight', out_filename,
+            '--method', method,
+            '--netcdf4',
+            '--src_regional',
+            '--ignore_unmapped',
+        ]
+        run_command(
+            args, self.cpus_per_task, self.ntasks,
+            self.openmp_threads, config, self.logger,
+        )
+
+    def _remap_to_target(self, in_filename, mapping_filename, out_filename):
+        """
+        Remap to `self.target_grid`. Filenames are passed as parameters so
+        that the function can be applied to GEBCO and BedMachine.
+
+        Parameters
+        ----------
+        in_filename : str
+            source file name
+
+        mapping_filename : str
+            weights file name
+
+        out_filename : str
+            remapped file name
+        """
+        # Build command args
+        args = [
+            'ncremap',
+            '-m', mapping_filename,
+            '--vrb=1',
+            in_filename,
+            out_filename
+        ]
+
+        # Remap to target grid
+        check_call(args, self.logger)
+
+    def _cleanup(self):
+        """
+        Clean up work directory
+        """
+        logger = self.logger
+        logger.info('Cleaning up work directory')
+
+        # Remove PETxxx.RegridWeightGen.Log files
+        for f in glob('*.RegridWeightGen.Log'):
+            os.remove(f)
+
+        logger.info('  Done.')

--- a/docs/developers_guide/ocean/api.rst
+++ b/docs/developers_guide/ocean/api.rst
@@ -971,6 +971,11 @@ utility
    combine_topo.Combine.setup
    combine_topo.Combine.run
 
+   create_salin_restoring.CreateSalinRestoring
+   create_salin_restoring.Combine
+   create_salin_restoring.Extrap
+   create_salin_restoring.Remap
+
    cull_restarts.CullRestarts
    cull_restarts.Cull
    cull_restarts.Cull.run

--- a/docs/developers_guide/ocean/test_groups/global_ocean.rst
+++ b/docs/developers_guide/ocean/test_groups/global_ocean.rst
@@ -1406,8 +1406,10 @@ The test case is made up of 10 steps:
     ice-shelf melt flux) compsets.
 
 :py:class:`compass.ocean.tests.global_ocean.files_for_e3sm.remap_sea_surface_salinity_restoring.RemapSeaSurfaceSalinityRestoring`
-    is used to remap sea-surface salinity from the World Ocean Atlas (2023) to the MPAS mesh.  
-    This dataset is used in E3SM for compsets with data atmospheric/land forcing.
+    is used to remap sea-surface salinity from the World Ocean Atlas (2023) to
+    the MPAS mesh. The step includes smoothing near the north pole to remove
+    artifacts in the original dataset in the Arctic. This dataset is used in
+    E3SM for compsets with data atmospheric/land forcing.
 
 :py:class:`compass.ocean.tests.global_ocean.files_for_e3sm.remap_iceberg_climatology.RemapIcebergClimatology`
     is used to remap freshwater fluxes from an iceberg climatology from

--- a/docs/developers_guide/ocean/test_groups/utility.rst
+++ b/docs/developers_guide/ocean/test_groups/utility.rst
@@ -123,26 +123,34 @@ The resulting file is ready to be placed in compass' initial condition database
 create_salin_restoring
 ----------------------
 The class :py:class:`compass.ocean.tests.utility.create_salin_restoring.CreateSalinRestoring`
-defines a test case for creating a monthly average sea surface salinity dataset based on the 
+defines a test case for creating a monthly average sea surface salinity dataset based on the
 `WOA 2023 <https://www.ncei.noaa.gov/products/world-ocean-atlas>`_ data.  It also extrapolates
 the twelve months of data into ice-shelf cavities and across continents.
 
-salinity_restoring
-------------------
+combine
+~~~~~~~
 
-The class :py:class:`compass.ocean.tests.utility.create_salin_restoring.Salinity`
+The class :py:class:`compass.ocean.tests.utility.create_salin_restoring.Combine`
 defines a step to download and combine January through December sea surface salinity into a single
-file that serves as the base dataset for salinity restoring in forced ocean sea-ice cases (FOSI).  
+file that serves as the base dataset for salinity restoring in forced ocean sea-ice cases (FOSI).
 The surface level of WOA 2023 data is utilized.
 
 The reference date for each month of data is assumed to be the 15th of each month.  In a simulation,
-this implies that for a model start time of January 1, the salinity is restored to the average of 
+this implies that for a model start time of January 1, the salinity is restored to the average of
 the December and January sea surface salinities.
 
-extrap_salin
-------------
+extrap
+~~~~~~
 
-The class :py:class:`compass.ocean.tests.utility.create_salin_restoring.ExtrapSalin`
-defines a step to extrapolate the combined January through December sea surface salinities 
+The class :py:class:`compass.ocean.tests.utility.create_salin_restoring.Extrap`
+defines a step to extrapolate the combined January through December sea surface salinities
 into missing ocean regions such as ice-shelf cavities and across continents.  Since this is only
 extrapolation of surface values, masks are not utilized.
+
+remap
+~~~~~
+
+The class :py:class:`compass.ocean.tests.utility.create_salin_restoring.Remap`
+defines a step to remap the extrapolated data to a cubed-sphere grid at ne300
+(~10 km) resolution. The cubed-sphere grid is much more favorable to remapping
+to MPAS meshes, particularly at the poles and with significant smoothing.

--- a/docs/users_guide/ocean/test_groups/utility.rst
+++ b/docs/users_guide/ocean/test_groups/utility.rst
@@ -44,8 +44,10 @@ documentation here.
 
 create_salin_restoring
 ----------------------
-The ``ocean/utility/create_salin_restoring`` test case is used to download monthly 
-average `WOA 2023 <https://www.ncei.noaa.gov/products/world-ocean-atlas>`_ data, 
-extracts the surface layer and extrapolates into ice-shelf cavities and across
-continents.  It is provided mainly for developers to update the salinity restoring
-data and is not intended for users, so we do not provide full documentation here.
+The ``ocean/utility/create_salin_restoring`` test case is used to download
+monthly average `WOA 2023 <https://www.ncei.noaa.gov/products/world-ocean-atlas>`_
+data, extracts the surface layer and extrapolates into ice-shelf cavities and
+across continents.  The fields are then remapped to a cubed-sphere grid at
+~10 km (ne300) resolution for easier remapping to MPAS meshes.  This testcase
+is provided mainly for developers to update the salinity restoring data and is
+not intended for users, so we do not provide full documentation here.


### PR DESCRIPTION
This requires a major reorganization of the step to be more like `remap_topography` after its recent reorganization.

Remapping is performed with `mbtempest`.  The public function `remap_sss()` has been removed.  (It was not mentioned in the docs.)

This merge also adds a remapping step to the utility that generates the SSS field from WOA23.  The data is remapped to a cubed-sphere grid at ne300 (~10 km) resolution.  Remapping from the cubed sphere to MPAS meshes will be *much* more performant than remapping from the WOA original lat-lon grid, particularly when there is smoothing near the poles as we do here.

The smoothing goes linearly from zero at 70 N to 1000 km at 90 N.

<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->

<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [x] User's Guide has been updated
* [x] Developer's Guide has been updated
* [x] Documentation has been [built locally](https://mpas-dev.github.io/compass/latest/developers_guide/building_docs.html) and changes look as expected
* [x] Document (in a comment titled `Testing` in this PR) any testing that was used to verify the changes

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->
