### PR TITLE
Fix bug setting cell spacing outside cull distance

### DIFF
--- a/compass/landice/mesh.py
+++ b/compass/landice/mesh.py
@@ -372,7 +372,7 @@ def set_cell_width(self, section_name, thk, bed=None, vx=None, vy=None,
     # that distance.
     if dist_to_edge is not None:
         mask = np.logical_and(
-            thk == 0.0, dist_to_edge > (3. * cull_distance))
+            thk == 0.0, dist_to_edge > np.abs(3. * cull_distance))
         logger.info('Setting cell_width in outer regions to max_spac '
                     f'for {mask.sum()} cells')
         cell_width[mask] = max_spac


### PR DESCRIPTION
Add a necessary absolute value when setting large cell spacing outside of cull distance. Otherwise, this causes problems when using a negative cull distance to indicate culling to a geojson file. 

<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->

<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [ ] User's Guide has been updated
* [ ] Developer's Guide has been updated
* [ ] API documentation in the Developer's Guide (`api.rst`) has any new or modified class, method and/or functions listed
* [ ] Documentation has been [built locally](https://mpas-dev.github.io/compass/latest/developers_guide/building_docs.html) and changes look as expected
* [ ] The `E3SM-Project` submodule has been updated with relevant E3SM changes
* [ ] The `MALI-Dev` submodule has been updated with relevant MALI changes
* [ ] Document (in a comment titled `Testing` in this PR) any testing that was used to verify the changes
* [ ] New tests have been added to a test suite

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->
