### PR TITLE
Add a step for smoothing topograpy

### DIFF
--- a/compass/ocean/mesh/remap_topography.cfg
+++ b/compass/ocean/mesh/remap_topography.cfg
@@ -14,7 +14,7 @@ description = Bathymetry is from GEBCO 2023, combined with BedMachine
               Antarctica v3 around Antarctica.
 
 # the target and minimum number of MPI tasks to use in remapping
-ntasks = 1280
+ntasks = 640
 min_tasks = 256
 
 # remapping method {'bilinear', 'neareststod', 'conserve'}
@@ -30,7 +30,7 @@ ice_density = 910.0
 
 # smoothing parameters
 # no smoothing (required for esmf):
-#     expandDist = 0   [m]
-#     expandFactor = 1 [cell fraction]
-expandDist = 0
-expandFactor = 1
+#     expand_distance = 0   [m]
+#     expand_factor = 1 [cell fraction]
+expand_distance = 0
+expand_factor = 1

--- a/compass/ocean/mesh/remap_topography.py
+++ b/compass/ocean/mesh/remap_topography.py
@@ -8,6 +8,7 @@ from mpas_tools.io import write_netcdf
 from mpas_tools.logging import check_call
 from pyremap import MpasCellMeshDescriptor
 
+from compass.io import symlink
 from compass.parallel import run_command
 from compass.step import Step
 
@@ -24,11 +25,17 @@ class RemapTopography(Step):
 
     mesh_name : str
         The name of the MPAS mesh to include in the mapping file
+
+    smoothing : bool, optional
+        Whether smoothing will be applied as part of the remapping
+
+    unsmoothed_topo : compass.ocean.mesh.remap_topography.RemapTopography
+        A step with unsmoothed topography
     """
 
     def __init__(
         self, test_case, base_mesh_step, name='remap_topography', subdir=None,
-        mesh_name='MPAS_mesh',
+        mesh_name='MPAS_mesh', smoothing=False, unsmoothed_topo=None
     ):
         """
         Create a new step
@@ -49,11 +56,19 @@ class RemapTopography(Step):
 
         mesh_name : str, optional
             The name of the MPAS mesh to include in the mapping file
-        """
+
+        smoothing : bool, optional
+            Whether smoothing will be applied as part of the remapping
+
+        unsmoothed_topo : compass.ocean.mesh.remap_topography.RemapTopography, optional
+            A step with unsmoothed topography
+        """  # noqa: E501
         super().__init__(test_case, name=name, subdir=subdir,
                          ntasks=None, min_tasks=None)
         self.base_mesh_step = base_mesh_step
         self.mesh_name = mesh_name
+        self.smoothing = smoothing
+        self.unsmoothed_topo = unsmoothed_topo
 
         self.add_output_file(filename='topography_remapped.nc')
 
@@ -108,6 +123,11 @@ class RemapTopography(Step):
         """
         Run this step of the test case
         """
+        super().run()
+        if self._symlink_unsmoothed():
+            # we symlinked to the unsmoothed topography and we're done!
+            return
+
         config = self.config
         weight_generator = config.get('remap_topography', 'weight_generator')
 
@@ -124,6 +144,33 @@ class RemapTopography(Step):
         self._remap_to_target()
         self._modify_remapped_bathymetry()
 
+    def _symlink_unsmoothed(self):
+        """
+        If we are smoothing but no smoothing was actually requested, symlink
+        to the unsmoothed topography
+        """
+        if not self.smoothing or self.unsmoothed_topo is None:
+            # there's no unsmoothed topogrpahy yet
+            return False
+
+        config = self.config
+        section = config['remap_topography']
+        expand_distance = section.getfloat('expand_distance')
+        expand_factor = section.getfloat('expand_factor')
+
+        if expand_distance != 0. or expand_factor != 1.:
+            # we're doing some smoothing!
+            return False
+
+        # we already have unsmoothed topography and we're not doing
+        # smoothing so we can just symlink the unsmoothed results
+        out_filename = 'topography_remapped.nc'
+        unsmoothed_path = self.unsmoothed_topo.work_dir
+        target = os.path.join(unsmoothed_path, out_filename)
+        symlink(target, out_filename)
+
+        return True
+
     def _create_target_scrip_file(self):
         """
         Create target SCRIP file from MPAS mesh file.
@@ -131,10 +178,14 @@ class RemapTopography(Step):
         logger = self.logger
         logger.info('Create source SCRIP file')
 
-        config = self.config
-        section = config['remap_topography']
-        expandDist = section.getfloat('expandDist')
-        expandFactor = section.getfloat('expandFactor')
+        if self.smoothing:
+            config = self.config
+            section = config['remap_topography']
+            expand_distance = section.getfloat('expand_distance')
+            expand_factor = section.getfloat('expand_factor')
+        else:
+            expand_distance = 0.
+            expand_factor = 1.
 
         descriptor = MpasCellMeshDescriptor(
             fileName='base_mesh.nc',
@@ -142,8 +193,8 @@ class RemapTopography(Step):
         )
         descriptor.to_scrip(
             'target.scrip.nc',
-            expandDist=expandDist,
-            expandFactor=expandFactor,
+            expandDist=expand_distance,
+            expandFactor=expand_factor,
         )
 
         logger.info('  Done.')

--- a/compass/ocean/tests/global_ocean/mesh/__init__.py
+++ b/compass/ocean/tests/global_ocean/mesh/__init__.py
@@ -117,15 +117,27 @@ class Mesh(TestCase):
 
         self.add_step(base_mesh_step)
 
-        remap_step = RemapTopography(test_case=self,
-                                     base_mesh_step=base_mesh_step,
-                                     mesh_name=mesh_name)
-        self.add_step(remap_step)
+        unsmoothed_topo = RemapTopography(test_case=self,
+                                          base_mesh_step=base_mesh_step,
+                                          name='remap_topo_unsmoothed',
+                                          mesh_name=mesh_name,
+                                          smoothing=False)
+
+        self.add_step(unsmoothed_topo)
+
+        smoothed_topo = RemapTopography(test_case=self,
+                                        base_mesh_step=base_mesh_step,
+                                        name='remap_topo_smoothed',
+                                        mesh_name=mesh_name,
+                                        smoothing=True,
+                                        unsmoothed_topo=unsmoothed_topo)
+
+        self.add_step(smoothed_topo)
 
         self.add_step(CullMeshStep(
             test_case=self, base_mesh_step=base_mesh_step,
             with_ice_shelf_cavities=self.with_ice_shelf_cavities,
-            remap_topography=remap_step))
+            unsmoothed_topo=unsmoothed_topo, smoothed_topo=smoothed_topo))
 
     def configure(self, config=None):
         """
@@ -137,14 +149,13 @@ class Mesh(TestCase):
         if config is None:
             config = self.config
         config.add_from_package('compass.mesh', 'mesh.cfg', exception=True)
-        if 'remap_topography' in self.steps:
-            config.add_from_package('compass.ocean.mesh',
-                                    'remap_topography.cfg', exception=True)
+        config.add_from_package('compass.ocean.mesh',
+                                'remap_topography.cfg', exception=True)
 
-            if not self.high_res_topography:
-                config.add_from_package('compass.ocean.mesh',
-                                        'low_res_topography.cfg',
-                                        exception=True)
+        if not self.high_res_topography:
+            config.add_from_package('compass.ocean.mesh',
+                                    'low_res_topography.cfg',
+                                    exception=True)
 
         if self.mesh_name.startswith('Kuroshio'):
             # add the config options for all kuroshio meshes
@@ -176,11 +187,7 @@ class Mesh(TestCase):
                        'Antarctica')
 
         # a description of the bathymetry
-        if 'remap_topography' in self.steps:
-            description = config.get('remap_topography', 'description')
-        else:
-            description = 'Bathymetry is from GEBCO 2023, combined with ' \
-                          'BedMachine Antarctica v3 around Antarctica.'
+        description = config.get('remap_topography', 'description')
 
         config.set('global_ocean', 'bathy_description', description)
 

--- a/docs/users_guide/ocean/framework/mesh.rst
+++ b/docs/users_guide/ocean/framework/mesh.rst
@@ -52,10 +52,10 @@ controlled by the following config options:
 
     # smoothing parameters
     # no smoothing (required for esmf):
-    #     expandDist = 0   [m]
-    #     expandFactor = 1 [cell fraction]
-    expandDist = 0
-    expandFactor = 1
+    #     expand_distance = 0   [m]
+    #     expand_factor = 1 [cell fraction]
+    expand_distance = 0
+    expand_factor = 1
 
 The topography and source SCRIP filenames should be something from the ocean
 `bathymetry database <https://web.lcrc.anl.gov/public/e3sm/mpas_standalonedata/mpas-ocean/bathymetry_database/>`_.


### PR DESCRIPTION
We remap the topography once without smoothing and then once with smoothing.  The unsmoothed topography is used to determine the land mask, thus allowing many meshes with different levels of smoothing to have the same mapping files in E3SM.

For the time being, only two simple types of smoothing are supported: a smoothing over a fixed distance or by expanding cells by a fixed fraction.  (The two types of smoothing can also be used at the same time.)

In the future, maps with non-uniform smoothing could be added for finer control.

A check use used to bypass the second smoothing pass if, in fact, no smoothing is requested (the default behavior).

<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->

<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [ ] User's Guide has been updated
* [ ] Developer's Guide has been updated
* [ ] API documentation in the Developer's Guide (`api.rst`) has any new or modified class, method and/or functions listed
* [ ] Documentation has been [built locally](https://mpas-dev.github.io/compass/latest/developers_guide/building_docs.html) and changes look as expected
* [ ] The `E3SM-Project` submodule has been updated with relevant E3SM changes
* [ ] The `MALI-Dev` submodule has been updated with relevant MALI changes
* [ ] Document (in a comment titled `Testing` in this PR) any testing that was used to verify the changes
* [ ] New tests have been added to a test suite

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->
