### PR TITLE
support running landice/greenland/mesh_gen test case on workstations

### DIFF
--- a/compass/landice/tests/antarctica/mesh.py
+++ b/compass/landice/tests/antarctica/mesh.py
@@ -138,7 +138,7 @@ class Mesh(Step):
 
         # Now perform bespoke interpolation of geometry and velocity data
         # from their respective sources
-        interp_gridded2mali(self, bedmachine_dataset, dst_scrip_file, 
+        interp_gridded2mali(self, bedmachine_dataset, dst_scrip_file,
                             parallel_executable, nProcs,
                             self.mesh_filename, src_proj, variables="all")
 

--- a/compass/landice/tests/antarctica/mesh.py
+++ b/compass/landice/tests/antarctica/mesh.py
@@ -63,6 +63,7 @@ class Mesh(Step):
 
         section_ais = config['antarctica']
 
+        parallel_executable = config.get('parallel', 'parallel_executable')
         nProcs = section_ais.get('nProcs')
         src_proj = section_ais.get("src_proj")
         data_path = section_ais.get('data_path')

--- a/compass/landice/tests/antarctica/mesh.py
+++ b/compass/landice/tests/antarctica/mesh.py
@@ -138,14 +138,16 @@ class Mesh(Step):
 
         # Now perform bespoke interpolation of geometry and velocity data
         # from their respective sources
-        interp_gridded2mali(self, bedmachine_dataset, dst_scrip_file, nProcs,
+        interp_gridded2mali(self, bedmachine_dataset, dst_scrip_file, 
+                            parallel_executable, nProcs,
                             self.mesh_filename, src_proj, variables="all")
 
         # only interpolate a subset of MEaSUREs variables onto the MALI mesh
         measures_vars = ['observedSurfaceVelocityX',
                          'observedSurfaceVelocityY',
                          'observedSurfaceVelocityUncertainty']
-        interp_gridded2mali(self, measures_dataset, dst_scrip_file, nProcs,
+        interp_gridded2mali(self, measures_dataset, dst_scrip_file,
+                            parallel_executable, nProcs,
                             self.mesh_filename, src_proj,
                             variables=measures_vars)
 

--- a/compass/landice/tests/greenland/mesh.py
+++ b/compass/landice/tests/greenland/mesh.py
@@ -65,6 +65,7 @@ class Mesh(Step):
 
         section_gis = config['greenland']
 
+        parallel_executable = config.get('parallel', 'parallel_executable')
         nProcs = section_gis.get('nProcs')
         src_proj = section_gis.get("src_proj")
         data_path = section_gis.get('data_path')
@@ -100,14 +101,16 @@ class Mesh(Step):
 
         # Now perform bespoke interpolation of geometry and velocity data
         # from their respective sources
-        interp_gridded2mali(self, bedmachine_dataset, dst_scrip_file, nProcs,
+        interp_gridded2mali(self, bedmachine_dataset, dst_scrip_file,
+                            parallel_executable, nProcs,
                             self.mesh_filename, src_proj, variables="all")
 
         # only interpolate a subset of MEaSUREs variables onto the MALI mesh
         measures_vars = ['observedSurfaceVelocityX',
                          'observedSurfaceVelocityY',
                          'observedSurfaceVelocityUncertainty']
-        interp_gridded2mali(self, measures_dataset, dst_scrip_file, nProcs,
+        interp_gridded2mali(self, measures_dataset, dst_scrip_file,
+                            parallel_executable, nProcs,
                             self.mesh_filename, src_proj,
                             variables=measures_vars)
 


### PR DESCRIPTION
<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->

This PR passes the `parallel_executable` to a few functions that were hardcoded to use `srun`.  With the right input files, this allows testing on workstations with limited memory and cores.

Testing was done with subsampled GIS inputs (to 4km, thanks to @matthewhoffman) for the `landice/greenland/mesh_gen` test.

<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [X] User's Guide has been updated - no change needed
* [X] Developer's Guide has been updated - no change needed
* [x] API documentation in the Developer's Guide (`api.rst`) has any new or modified class, method and/or functions listed  - no changes needed - the doc string for `interp_gridded2mali` was updated in `compass/landice/mesh.py`
* [X] Documentation has been [built locally](https://mpas-dev.github.io/compass/latest/developers_guide/building_docs.html) and changes look as expected - the new `parallel_executable` arg is rendered in the html
* [X] **not applicable** The `E3SM-Project` submodule has been updated with relevant E3SM changes
* [X] **not applicable** The `MALI-Dev` submodule has been updated with relevant MALI changes
* [X] Document (in a comment titled `Testing` in this PR) any testing that was used to verify the changes
* [X] **not applicable?** New tests have been added to a test suite

