### PR TITLE
CI updates and cleanup

### DIFF
--- a/.github/workflows/build_workflow.yml
+++ b/.github/workflows/build_workflow.yml
@@ -12,6 +12,7 @@ on:
 env:
   CANCEL_OTHERS: false
   PATHS_IGNORE: '["**/README.md", "**/docs/**"]'
+  PYTHON_VERSION: "3.13"
 
 jobs:
   pre-commit-hooks:
@@ -30,15 +31,17 @@ jobs:
         uses: actions/checkout@v4
 
       - if: ${{ steps.skip_check.outputs.should_skip != 'true' }}
-        name: Set up Python 3.10
+        name: Set up Python ${{ env.PYTHON_VERSION }}
         uses: actions/setup-python@v5
         with:
-          python-version: "3.10"
+          python-version: ${{ env.PYTHON_VERSION }}
+
       - if: ${{ steps.skip_check.outputs.should_skip != 'true' }}
         id: file_changes
-        uses: trilom/file-changes-action@v1.2.4
+        uses: trilom/file-changes-action@1.2.4
         with:
           output: ' '
+
       - if: ${{ steps.skip_check.outputs.should_skip != 'true' }}
         # Run all pre-commit hooks on all the files.
         # Getting only staged files can be tricky in case a new PR is opened
@@ -70,18 +73,6 @@ jobs:
         uses: actions/checkout@v4
 
       - if: ${{ steps.skip_check.outputs.should_skip != 'true' }}
-        name: Cache Conda
-        uses: actions/cache@v4
-        env:
-          # Increase this value to reset cache if conda-dev-spec.template has not changed in the workflow
-          CACHE_NUMBER: 0
-        with:
-          path: ~/conda_pkgs_dir_py${{ matrix.python-version }}
-          key:
-            ${{ runner.os }}-${{ matrix.python-version }}-conda-${{ env.CACHE_NUMBER }}-${{
-            hashFiles('conda/configure_compass_env.py,conda/*,conda/compass_env/*') }}
-
-      - if: ${{ steps.skip_check.outputs.should_skip != 'true' }}
         name: Set up Conda Environment
         uses: conda-incubator/setup-miniconda@v3
         with:
@@ -90,7 +81,7 @@ jobs:
           channels: conda-forge,e3sm/label/compass
           channel-priority: strict
           use-mamba: false
-          auto-update-conda: false
+          auto-update-conda: true
           python-version: ${{ matrix.python-version }}
 
       - if: ${{ steps.skip_check.outputs.should_skip != 'true' }}

--- a/.github/workflows/docs_workflow.yml
+++ b/.github/workflows/docs_workflow.yml
@@ -7,6 +7,9 @@ on:
   release:
     types: [published]
 
+env:
+  PYTHON_VERSION: "3.13"
+
 jobs:
   publish-docs:
     runs-on: ubuntu-latest
@@ -22,16 +25,6 @@ jobs:
           persist-credentials: false
           fetch-depth: 0
 
-      - name: Cache Conda
-        uses: actions/cache@v4
-        env:
-          # Increase this value to reset cache if deploy/conda-dev-spec.template has not changed in the workflow
-          CACHE_NUMBER: 0
-        with:
-          path: ~/conda_pkgs_dir
-          key: ${{ runner.os }}-conda-${{ env.CACHE_NUMBER }}-${{
-            hashFiles('conda/configure_compass_env.py,conda/*,conda/compass_env/*') }}
-
       - if: ${{ steps.skip_check.outputs.should_skip != 'true' }}
         name: Set up Conda Environment
         uses: conda-incubator/setup-miniconda@v3
@@ -41,8 +34,8 @@ jobs:
           channels: conda-forge,e3sm/label/compass
           channel-priority: strict
           use-mamba: false
-          auto-update-conda: false
-          python-version: ${{ matrix.python-version }}
+          auto-update-conda: true
+          python-version: ${{ env.PYTHON_VERSION }}
 
       - if: ${{ steps.skip_check.outputs.should_skip != 'true' }}
         name: Install compass
@@ -51,7 +44,7 @@ jobs:
           ./conda/configure_compass_env.py \
             --env_only \
             --env_name compass_test \
-            --python=${{ matrix.python-version }} \
+            --python=${{ env.PYTHON_VERSION }} \
             --verbose
           source load_compass_test.sh
 

--- a/.github/workflows/pre_commit_update_workflow.yml
+++ b/.github/workflows/pre_commit_update_workflow.yml
@@ -12,6 +12,7 @@ on:
 
 env:
   UP_TO_DATE: false
+  PYTHON_VERSION: "3.13"
 
 jobs:
   auto-update:
@@ -22,7 +23,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.10"
+          python-version: ${{ env.PYTHON_VERSION }}
 
       - name: Install pre-commit
         run: pip install pre-commit


### PR DESCRIPTION
<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->
This PR adds a few CI updates we've implemented in other repos recently:

1. I updated the default python version in various places to 3.13, and changed this version from a magic number to a variable in a few places (for consistency). 
2. I enabled `auto-update-conda` which we had disabled previously thinking it was causing trouble, but it wasn't.
3. I removed the caching step for creating a conda environment - it doesn't appear to be saving any time and we don't consider it worth keeping.

<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [x] Documentation has been [built locally](https://mpas-dev.github.io/compass/latest/developers_guide/building_docs.html) and changes look as expected
* [x] Document (in a comment titled `Testing` in this PR) any testing that was used to verify the changes

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->
