### PR TITLE
github action for running a coarse gis meshgen test

### DIFF
--- a/.github/workflows/gis_coarse_meshgen.yml
+++ b/.github/workflows/gis_coarse_meshgen.yml
@@ -23,16 +23,16 @@ jobs:
 
           # create the compass environment
           ./conda/configure_compass_env.py --conda $root/mambaForge --mpi mpich
-          
+
           # enable the compass environment
           source load_dev_compass_1.7.0-alpha.1_mpich.sh
-          
+
           popd
 
           # download the input GIS coarse mesh
           wget https://rpi.app.box.com/public/static/qytr3c49h1xbucxz594df327qatiu8ds.tgz
           tar xf qytr3c49h1xbucxz594df327qatiu8ds.tgz
-          
+
           # create the config file describing the system
           cat << EOF > system.cfg
           # This file contains some common config options you might want to set
@@ -56,11 +56,11 @@ jobs:
           measures_filename = greenland_vel_mosaic500_extrap_stride8.nc
           bedmachine_filename = BedMachineGreenland-v5_edits_floodFill_extrap_stride25.nc
           EOF
-          
+
           # setup the greenland mesh generation test case
           testDir=$root/gis_mesh_gen
           compass setup -w $testDir -t landice/greenland/mesh_gen -f system.cfg
-          
+
           # run the test case
           cd $testDir
           compass run

--- a/.github/workflows/gis_coarse_meshgen.yml
+++ b/.github/workflows/gis_coarse_meshgen.yml
@@ -1,10 +1,11 @@
 name: CI/CD Build Workflow
 
 on:
-  push:
-    branches: [main]
   pull_request:
     branches: [main]
+    paths:
+    - compass/landice/mesh.py
+    - compass/landice/tests/greenland/mesh.py
 
 jobs:
   setup_and_run_job:

--- a/.github/workflows/gis_coarse_meshgen.yml
+++ b/.github/workflows/gis_coarse_meshgen.yml
@@ -11,23 +11,16 @@ jobs:
     name: setup_and_run_job
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+          path: compass
       - name: setup_and_run_step
         run: |
           # create top level working directory
-          mkdir compassDev
-          cd $_
           root=$PWD
-          
-          # clone the modified compass repo
-          git clone https://github.com/MPAS-Dev/compass.git
           pushd compass
 
-          # use https for submodules - runner cannot use git protocol
-          sed -i 's!git@github.com:!https://github.com/!g' .gitmodules
-
-          # clone submodules
-          git submodule update --init
-          
           # create the compass environment
           ./conda/configure_compass_env.py --conda $root/mambaForge --mpi mpich
           

--- a/.github/workflows/gis_coarse_meshgen.yml
+++ b/.github/workflows/gis_coarse_meshgen.yml
@@ -1,0 +1,74 @@
+name: CI/CD Build Workflow
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  setup_and_run_job:
+    name: setup_and_run_job
+    runs-on: ubuntu-latest
+    steps:
+      - name: setup_and_run_step
+        run: |
+          # create top level working directory
+          mkdir compassDev
+          cd $_
+          root=$PWD
+          
+          # clone the modified compass repo
+          git clone https://github.com/MPAS-Dev/compass.git
+          pushd compass
+
+          # use https for submodules - runner cannot use git protocol
+          sed -i 's!git@github.com:!https://github.com/!g' .gitmodules
+
+          # clone submodules
+          git submodule update --init
+          
+          # create the compass environment
+          ./conda/configure_compass_env.py --conda $root/mambaForge --mpi mpich
+          
+          # enable the compass environment
+          source load_dev_compass_1.7.0-alpha.1_mpich.sh
+          
+          popd
+
+          # download the input GIS coarse mesh
+          wget https://rpi.app.box.com/public/static/qytr3c49h1xbucxz594df327qatiu8ds.tgz
+          tar xf qytr3c49h1xbucxz594df327qatiu8ds.tgz
+          
+          # create the config file describing the system
+          cat << EOF > system.cfg
+          # This file contains some common config options you might want to set
+          # The paths section describes paths to databases and shared compass environments
+          [paths]
+          database_root =
+          # The parallel section describes options related to running tests in parallel
+          [parallel]
+          # parallel system of execution: slurm or single_node
+          system = single_node
+          # whether to use mpirun or srun to run the model
+          parallel_executable = mpirun
+          # cores per node on the machine, detected automatically by default
+          cores_per_node = 4
+          [mesh]
+          #run quicker - gis takes 20mins on 128 perlmutter cores
+          min_spac = 10.e3
+          [greenland]
+          nprocs = 4
+          data_path = $root/gis4kmSubSampled_01302025
+          measures_filename = greenland_vel_mosaic500_extrap_stride8.nc
+          bedmachine_filename = BedMachineGreenland-v5_edits_floodFill_extrap_stride25.nc
+          EOF
+          
+          # setup the greenland mesh generation test case
+          testDir=$root/gis_mesh_gen
+          compass setup -w $testDir -t landice/greenland/mesh_gen -f system.cfg
+          
+          # run the test case
+          cd $testDir
+          compass run
+


### PR DESCRIPTION
This PR adds a github action workflow for running a coarse GIS meshgen case on a 'free' github hosted runner.  The run takes about 11 minutes.  It is only triggered when a PR, in any of its commits, changes either of the following files:

https://github.com/SCOREC/compass/blob/368a4a5b0d22344b53c08dbd2c8fbebf6b738032/.github/workflows/gis_coarse_meshgen.yml#L7-L8

```
    - compass/landice/mesh.py
    - compass/landice/tests/greenland/mesh.py
```

Testing was done here by pushing changes to `compass/landice/tests/mesh.py`.  Those changes were reverted, but the action log is available here: https://github.com/MPAS-Dev/compass/actions/runs/14233471393/job/39888454918

As noted below in the checklist, this test is currently downloading the GIS input data from a public RPI box directory.  Is there a better place to host these files?

Checklist
* [X] Document any testing that was used to verify the changes
* [ ] Find a better home for the GIS input data.