### PR TITLE
Switch CI from miniconda to micromamba

### DIFF
--- a/.github/workflows/build_workflow.yml
+++ b/.github/workflows/build_workflow.yml
@@ -74,15 +74,17 @@ jobs:
 
       - if: ${{ steps.skip_check.outputs.should_skip != 'true' }}
         name: Set up Conda Environment
-        uses: conda-incubator/setup-miniconda@v3
+        uses: mamba-org/setup-micromamba@v2
         with:
-          activate-environment: "compass_ci"
-          miniforge-version: latest
-          channels: conda-forge,e3sm/label/compass
-          channel-priority: strict
-          use-mamba: false
-          auto-update-conda: true
-          python-version: ${{ matrix.python-version }}
+          environment-name: compass_test
+          init-shell: bash
+          condarc: |
+            channel_priority: strict
+            channels:
+                - conda-forge
+                - e3sm/label/compass
+          create-args: >-
+            python=${{ matrix.python-version }}
 
       - if: ${{ steps.skip_check.outputs.should_skip != 'true' }}
         name: Install compass

--- a/.github/workflows/docs_workflow.yml
+++ b/.github/workflows/docs_workflow.yml
@@ -27,15 +27,17 @@ jobs:
 
       - if: ${{ steps.skip_check.outputs.should_skip != 'true' }}
         name: Set up Conda Environment
-        uses: conda-incubator/setup-miniconda@v3
+        uses: mamba-org/setup-micromamba@v2
         with:
-          activate-environment: "compass_ci"
-          miniforge-version: latest
-          channels: conda-forge,e3sm/label/compass
-          channel-priority: strict
-          use-mamba: false
-          auto-update-conda: true
-          python-version: ${{ env.PYTHON_VERSION }}
+          environment-name: compass_test
+          init-shell: bash
+          condarc: |
+            channel_priority: strict
+            channels:
+                - conda-forge
+                - e3sm/label/compass
+          create-args: >-
+            python=${{ env.PYTHON_VERSION }}
 
       - if: ${{ steps.skip_check.outputs.should_skip != 'true' }}
         name: Install compass

--- a/conda/shared.py
+++ b/conda/shared.py
@@ -95,19 +95,19 @@ def get_conda_base(conda_base, config, shared=False, warn=False):
     if shared:
         conda_base = config.get('paths', 'compass_envs')
     elif conda_base is None:
-        if 'CONDA_EXE' in os.environ:
-            # if this is a test, assume we're the same base as the
-            # environment currently active
-            conda_exe = os.environ['CONDA_EXE']
-            conda_base = os.path.abspath(
-                os.path.join(conda_exe, '..', '..'))
+        try:
+            conda_base = subprocess.check_output(
+                ['conda', 'info', '--base'], text=True
+            ).strip()
             if warn:
                 print(f'\nWarning: --conda path not supplied.  Using conda '
                       f'installed at:\n'
                       f'   {conda_base}\n')
-        else:
-            raise ValueError('No conda base provided with --conda and '
-                             'none could be inferred.')
+        except subprocess.CalledProcessError as e:
+            raise ValueError(
+                'No conda base provided with --conda and '
+                'none could be inferred.'
+            ) from e
     # handle "~" in the path
     conda_base = os.path.abspath(os.path.expanduser(conda_base))
     return conda_base


### PR DESCRIPTION
<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->
This PR switches CI to use the `setup-micromamba` GitHub action instead of the `setup-miniconda` GitHub action, in an effort to fix CI crashes caused by the latest `miniconda` version. 

To do this, I needed to make a change to `conda.shared`, so that it did not reference the `CONDA_EXE` variable. Apparently miniconda sets this environment var, but micromamba does not. 
<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [ ] Documentation has been [built locally](https://mpas-dev.github.io/compass/latest/developers_guide/building_docs.html) and changes look as expected
* [x] Document (in a comment titled `Testing` in this PR) any testing that was used to verify the changes

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->
