### PR TITLE
Fix steps for remapping MALI topography to an MPAS-Ocean base mesh

### DIFF
--- a/compass/ocean/tests/global_ocean/mesh/__init__.py
+++ b/compass/ocean/tests/global_ocean/mesh/__init__.py
@@ -182,9 +182,9 @@ class Mesh(TestCase):
             smoothed_topo = RemapMaliTopography(
                 test_case=self,
                 base_mesh_step=base_mesh_step,
-                name='remap_topo_unsmoothed',
+                name='remap_topo_smoothed',
                 mesh_name=mesh_name,
-                smoothing=False,
+                smoothing=True,
                 unsmoothed_topo=unsmoothed_topo,
                 mali_ais_topo=mali_ais_topo,
                 ocean_includes_grounded=False)

--- a/compass/ocean/tests/global_ocean/mesh/remap_mali_topography/__init__.py
+++ b/compass/ocean/tests/global_ocean/mesh/remap_mali_topography/__init__.py
@@ -7,6 +7,7 @@ from mpas_tools.io import write_netcdf
 from mpas_tools.logging import check_call
 from pyremap import MpasCellMeshDescriptor
 
+from compass.io import symlink
 from compass.ocean.mesh.remap_topography import RemapTopography
 from compass.parallel import run_command
 
@@ -110,8 +111,16 @@ class RemapMaliTopography(RemapTopography):
         Run this step of the test case
         """
         super().run()
-        self._remap_mali_topo()
-        self._combine_topo()
+        if self.symlinked_to_unsmoothed:
+            # we already have unsmoothed topography and we're not doing
+            # smoothing so we can just symlink the unsmoothed results
+            out_filename = 'mali_topography_remapped.nc'
+            unsmoothed_path = self.unsmoothed_topo.work_dir
+            target = os.path.join(unsmoothed_path, out_filename)
+            symlink(target, out_filename)
+        else:
+            self._remap_mali_topo()
+            self._combine_topo()
 
     def _remap_mali_topo(self):
         in_mesh_name = self.mali_ais_topo


### PR DESCRIPTION
<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->
This pull request introduces changes to improve the handling of symlinking for unsmoothed topography in the `compass` ocean modeling framework. The key updates include adding a new attribute to track symlink status, modifying the logic for determining when to symlink, and updating related test cases to reflect these changes.

### Enhancements to symlinking logic in `RemapTopography`:

* Added a new attribute `symlinked_to_unsmoothed` to the `RemapTopography` class to track whether symlinking to unsmoothed topography is performed. (`compass/ocean/mesh/remap_topography.py`) [[1]](diffhunk://#diff-c1f0744d83f56af79d59a66197a0889974a619b64c10cd6895e84cfe6bc20576R34-R37) [[2]](diffhunk://#diff-c1f0744d83f56af79d59a66197a0889974a619b64c10cd6895e84cfe6bc20576R76)
* Refactored the `_symlink_unsmoothed` method to set the `symlinked_to_unsmoothed` attribute and removed redundant return values. (`compass/ocean/mesh/remap_topography.py`) [[1]](diffhunk://#diff-c1f0744d83f56af79d59a66197a0889974a619b64c10cd6895e84cfe6bc20576R158-R161) [[2]](diffhunk://#diff-c1f0744d83f56af79d59a66197a0889974a619b64c10cd6895e84cfe6bc20576L163-L173)
* Updated the `run` method in `RemapTopography` to check the `symlinked_to_unsmoothed` attribute and exit early if symlinking is completed. (`compass/ocean/mesh/remap_topography.py`)

### Updates related to `RemapMaliTopography`:

* Corrected the initialization of the `RemapMaliTopography` step in the global ocean mesh test to use smoothing. (`compass/ocean/tests/global_ocean/mesh/__init__.py`)
* Enhanced the `run` method in the `RemapMaliTopography` step to handle symlinking for unsmoothed topography when applicable. (`compass/ocean/tests/global_ocean/mesh/remap_mali_topography/__init__.py`)

<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [x] Document (in a comment titled `Testing` in this PR) any testing that was used to verify the changes

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->
