### PR TITLE
Add `--mpi=pmi2` flag to `srun` on Chrysalis 

### DIFF
--- a/compass/machines/chrysalis.cfg
+++ b/compass/machines/chrysalis.cfg
@@ -11,6 +11,13 @@ database_root = /lcrc/group/e3sm/public_html/mpas_standalonedata
 compass_envs = /lcrc/soft/climate/compass/chrysalis/base
 
 
+# The parallel section describes options related to running jobs in parallel
+[parallel]
+
+# whether to use mpirun or srun to run a task
+parallel_executable = srun --mpi=pmi2
+
+
 # Options related to deploying a compass conda environment on supported
 # machines
 [deploy]

--- a/compass/version.py
+++ b/compass/version.py
@@ -1,1 +1,1 @@
-__version__ = '1.7.0-alpha.3'
+__version__ = '1.7.0-alpha.4'

--- a/conda/compass_env/spec-file.template
+++ b/conda/compass_env/spec-file.template
@@ -32,7 +32,7 @@ otps=2021.10
 progressbar2
 pyamg >=4.2.2
 pyproj
-pyremap>=2.0.0,<3.0.0
+pyremap>=2.1.0,<3.0.0
 requests
 ruamel.yaml
 # having pip check problems with this version

--- a/docs/users_guide/machines/chrysalis.rst
+++ b/docs/users_guide/machines/chrysalis.rst
@@ -24,6 +24,13 @@ test suite:
     compass_envs = /lcrc/soft/climate/compass/chrysalis/base
 
 
+    # The parallel section describes options related to running jobs in parallel
+    [parallel]
+
+    # whether to use mpirun or srun to run a task
+    parallel_executable = srun --mpi=pmi2
+
+
     # Options related to deploying a compass conda environment on supported
     # machines
     [deploy]


### PR DESCRIPTION
<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->
This is expected to prevent errors seen in certain configurations.

This merge also updates pyremap to v2.1.0, which allows support for a parallel executable with flags.

The dependency update requires bumping the alpha version of compass: 1.7.0-alpha.4

<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [ ] User's Guide has been updated
* [ ] Document (in a comment titled `Testing` in this PR) any testing that was used to verify the changes

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->
