### PR TITLE
github action for running a coarse gis meshgen test: update tarball link

### DIFF
--- a/.github/workflows/gis_coarse_meshgen.yml
+++ b/.github/workflows/gis_coarse_meshgen.yml
@@ -35,8 +35,9 @@ jobs:
           popd
 
           # download the input GIS coarse mesh
-          tarball=7rhrks110k80tuwrn2t9puzmgy39o3en.tgz
-          wget https://rpi.box.com/shared/static/${tarball}
+          tarball=gis4kmSubSampled_01302025.tgz
+          url=https://web.lcrc.anl.gov/public/e3sm/mpas_standalonedata/mpas-albany-landice/
+          wget ${url}/${tarball}
           tar xf ${tarball}
 
           # create the config file describing the system


### PR DESCRIPTION
This PR is a follow up to https://github.com/MPAS-Dev/compass/pull/899 that updates the link for downloading the tarball with the subsampled test GIS mesh.