### PR TITLE
Several fixes to global ocean meshes with MALI topography 

### DIFF
--- a/compass/ocean/tests/global_ocean/mesh/remap_mali_topography/__init__.py
+++ b/compass/ocean/tests/global_ocean/mesh/remap_mali_topography/__init__.py
@@ -319,6 +319,14 @@ class RemapMaliTopography(RemapTopography):
             ds_mali.oceanFrac +
             (1.0 - alpha) * ds_bedmachine.oceanFracObserved)
 
+        # limit land ice floatation fraction to ocean fraction -- because of
+        # machine-precision noise in the combined ocean fraciton,
+        # land ice floating fraction can exceed ocean fraction by ~1e-15
+        ds_out['landIceFloatingFracObserved'] = np.minimum(
+            ds_out['landIceFloatingFracObserved'],
+            ds_out['oceanFracObserved']
+        )
+
         ds_out['ssh'] = ds_out.landIceDraftObserved
 
         write_netcdf(ds_out, 'topography_remapped.nc')


### PR DESCRIPTION
<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->

This merge:
* Fixes MALI ice draft calculation for grounded ice. The ice draft is determined by flotation in floating regions but is equal to the bed elevation in grounded regions. We also include `sea_level` (currently zero) in the calculation of the ice draft.
* Fixes renormalization of MALI topography. It is first masked to below sea level, then remapped, then renormalized by the ocean fraction (area below sea level).
* Uses the correct target scrip file for topo remapping. We need to use the appropriate unsmoothed or smoothed scrip file, whereas we were previously creating a new MPAS-Ocean scrip file that was always without smoothing.

<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [x] Document (in a comment titled `Testing` in this PR) any testing that was used to verify the changes

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->
