### PR TITLE
Remove `mode` attribute from immutable streams in Humboldt cases

### DIFF
--- a/compass/landice/tests/humboldt/streams.landice.hydro.template
+++ b/compass/landice/tests/humboldt/streams.landice.hydro.template
@@ -15,7 +15,6 @@
 
 <immutable_stream name="ismip6-gis"
                   type="input"
-                  mode="forward;analysis"
                   filename_template="{{ HUMBOLDT_FORCING_FILE }}"
                   input_interval="0001-00-00_00:00:00"
                   reference_time="2000-07-01_00:00:00"

--- a/compass/landice/tests/humboldt/streams.landice.template
+++ b/compass/landice/tests/humboldt/streams.landice.template
@@ -15,7 +15,6 @@
 
 <immutable_stream name="ismip6-gis"
                   type="input"
-                  mode="forward;analysis"
                   filename_template="{{ HUMBOLDT_FORCING_FILE }}"
                   input_interval="0001-00-00_00:00:00"
                   reference_time="2000-07-01_00:00:00"


### PR DESCRIPTION
Remove incorrect `mode` attribute from immutable streams in Humboldt cases, which now causes an error due to the changes in https://github.com/E3SM-Project/E3SM/pull/8125.

<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->

<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [x] Document (in a comment titled `Testing` in this PR) any testing that was used to verify the changes


<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->
