### PR TITLE
Update geometry data set to BedMachineAntarctica v4

### DIFF
--- a/compass/landice/mesh.py
+++ b/compass/landice/mesh.py
@@ -1648,13 +1648,17 @@ def interp_gridded2mali(self, source_file, mali_scrip, parallel_executable,
 
     # Generate remapping weights
     logger.info('generating gridded dataset -> MPAS weights')
-    args = [parallel_executable, '-n', nProcs, 'ESMF_RegridWeightGen',
-            '--source', masked_source_scrip,
-            '--destination', mali_scrip,
-            '--weight', weights_filename,
-            '--method', 'conserve',
-            "--netcdf4",
-            "--dst_regional", "--src_regional", '--ignore_unmapped']
+    args = parallel_executable.split() + [
+        '-n', nProcs,
+        'ESMF_RegridWeightGen',
+        '--source', masked_source_scrip,
+        '--destination', mali_scrip,
+        '--weight', weights_filename,
+        '--method', 'conserve',
+        "--netcdf4",
+        "--dst_regional",
+        "--src_regional",
+        '--ignore_unmapped']
     check_call(args, logger=logger)
 
     # Perform actual interpolation using the weights

--- a/compass/landice/tests/antarctica/mesh_gen/mesh_gen_bmv2.cfg
+++ b/compass/landice/tests/antarctica/mesh_gen/mesh_gen_bmv2.cfg
@@ -56,7 +56,7 @@ data_path = /global/cfs/cdirs/fanssie/standard_datasets/AIS_datasets
 
 # filename of the BedMachine thickness and bedTopography dataset
 # (default value is for Perlmutter)
-bedmachine_filename = NSIDC-0756_BedMachineAntarctica_19700101-20191001_V04.1_edits_floodFill_extrap.nc
+bedmachine_filename = BedMachineAntarctica_2020-07-15_v02_edits_floodFill_extrap_fillVostok.nc
 
 # filename of the MEASURES ice velocity dataset
 # (default value is for Perlmutter)

--- a/docs/users_guide/landice/test_groups/antarctica.rst
+++ b/docs/users_guide/landice/test_groups/antarctica.rst
@@ -78,7 +78,7 @@ the mesh generation options are adjusted through the config file.
 
     # filename of the BedMachine thickness and bedTopography dataset
     # (default value is for Perlmutter)
-    bedmachine_filename = BedMachineAntarctica_2020-07-15_v02_edits_floodFill_extrap_fillVostok.nc
+    bedmachine_filename = NSIDC-0756_BedMachineAntarctica_19700101-20191001_V04.1_edits_floodFill_extrap.nc
 
     # filename of the MEASURES ice velocity dataset
     # (default value is for Perlmutter)


### PR DESCRIPTION
Update default geometry data set to BedMachineAntarctica v4. Retain v2 data set in separate cfg file.

<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->

<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [x] User's Guide has been updated
* [x] Document (in a comment titled `Testing` in this PR) any testing that was used to verify the changes

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->
