### PR TITLE
Split string to interpret "srun --label" correctly

### DIFF
--- a/compass/landice/mesh.py
+++ b/compass/landice/mesh.py
@@ -1648,13 +1648,17 @@ def interp_gridded2mali(self, source_file, mali_scrip, parallel_executable,
 
     # Generate remapping weights
     logger.info('generating gridded dataset -> MPAS weights')
-    args = [parallel_executable, '-n', nProcs, 'ESMF_RegridWeightGen',
-            '--source', masked_source_scrip,
-            '--destination', mali_scrip,
-            '--weight', weights_filename,
-            '--method', 'conserve',
-            "--netcdf4",
-            "--dst_regional", "--src_regional", '--ignore_unmapped']
+    args = parallel_executable.split() + [
+        '-n', nProcs,
+        'ESMF_RegridWeightGen',
+        '--source', masked_source_scrip,
+        '--destination', mali_scrip,
+        '--weight', weights_filename,
+        '--method', 'conserve',
+        "--netcdf4",
+        "--dst_regional",
+        "--src_regional",
+        '--ignore_unmapped']
     check_call(args, logger=logger)
 
     # Perform actual interpolation using the weights


### PR DESCRIPTION
Split string "srun --label" so that it is interpretted correctly when passed to check_call.

<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->

<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [x] Document (in a comment titled `Testing` in this PR) any testing that was used to verify the changes


<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->
